### PR TITLE
Fortran compiler flags

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -52,11 +52,14 @@ enable_language(Fortran)
 
 
 # add compiler options
-#set(CMAKE_Fortran_FLAGS "-O2 -m32 -fno-automatic -ffixed-line-length-none -finit-local-zero")
-#set(CMAKE_Fortran_FLAGS "-O2 -m32 -fno-automatic -ffixed-line-length-none")
-set(CMAKE_Fortran_FLAGS "-O2 -fno-automatic -ffixed-line-length-none")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-automatic -ffixed-line-length-none")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELEASE} -g")
 message(STATUS "Using Fortran compiler '${CMAKE_Fortran_COMPILER}'")
 message(STATUS "Using Fortran compiler flags '${CMAKE_Fortran_FLAGS}'")
+message(STATUS "Using additional Fortran compiler flags '${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE}}' "
+	"for build type ${CMAKE_BUILD_TYPE}.")
 
 
 # source files that are compiled into library


### PR DESCRIPTION
Change the Fortran compiler flags so that they still can be changed from
the Cmake command-line. Add special flags for Release and Debug builds,
increase the optimization level for release builds (to the Cmake default
for 'gfortran' and to the same level C++ code is compiled with).

In addition one might think about adding `-Wall`, `-Werror`, and `-fimplicit-none` (then at least implicit variables would need to be specified in each function) to the Fortran flags. The last two options will certainly break the build.
