### PR TITLE
src: Fix start values in pwafit.

### DIFF
--- a/src/pwafit.cc
+++ b/src/pwafit.cc
@@ -452,16 +452,21 @@ main(int    argc,
 				// get parameter value from fitResult
 				assert(startFitResult);
 				startVal = startFitResult->fitParameter(parName.c_str());
-			} else
-				startVal = (useFixedStartValues) ? defaultStartValue
-					: random.Uniform(defaultStartValue, sqrtNmbEvts);
+			} else {
+				startVal = (useFixedStartValues) ? defaultStartValue : random.Uniform(defaultStartValue, sqrtNmbEvts);
+				if(random.Rndm() > 0.5) {
+					startVal *= -1.;
+				}
+			}
 			// check if parameter needs to be fixed because of threshold
 			if ((L.parThreshold(parIndex) == 0) or (L.parThreshold(parIndex) < massBinCenter)) {
 				if (startVal == 0) {
 					cout << "    read start value 0 for parameter " << parName << ". "
 					     << "using default start value." << endl;
-					startVal = (useFixedStartValues) ? defaultStartValue
-						: random.Uniform(defaultStartValue, sqrtNmbEvts);
+					startVal = (useFixedStartValues) ? defaultStartValue : random.Uniform(defaultStartValue, sqrtNmbEvts);
+					if(random.Rndm() > 0.5) {
+						startVal *= -1;
+					}
 				}
 				cout << "    setting parameter [" << setw(3) << i << "] "
 				     << setw(maxParNameLength) << parName << " = " << maxPrecisionAlign(startVal) << endl;


### PR DESCRIPTION
For some reason, the start values in pwafit for the minimizer were always
positive. Fix this by multiplying the seed value with -1. 50% of the time.