### PR TITLE
ROOT6

### DIFF
--- a/decayAmplitude/ampIntegralMatrix.cc
+++ b/decayAmplitude/ampIntegralMatrix.cc
@@ -725,6 +725,14 @@ ampIntegralMatrix::openRootAmpFiles(vector<TTree*>&             ampTrees,
 
 		++waveIndex;
 	}
+	// If some waves were skipped above, the arrays are too large, and the
+	// integrate() method thinks there are more waves than there actually
+	// are. Calling resize() with a value smaller than the current size
+	// does not trigger a reallocation, so all pointers stay valid.
+	_waveNames.resize(waveIndex);
+	_waveDescriptions.resize(waveIndex);
+	ampTrees.resize(waveIndex-waveIndexOffset);
+	ampTreeLeafs.resize(waveIndex-waveIndexOffset);
 	return nmbAmps;
 }
 

--- a/decayAmplitude/ampIntegralMatrix.cc
+++ b/decayAmplitude/ampIntegralMatrix.cc
@@ -622,9 +622,11 @@ ampIntegralMatrix::openRootAmpFiles(vector<TTree*>&             ampTrees,
 	ampTrees.clear    ();
 	ampTreeLeafs.clear();
 	unsigned long nmbAmps = 0;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 	unsigned int             waveIndex = waveIndexOffset;
 	vector<TTree*>           trees;
 	vector<waveDescription*> waveDescs;

--- a/decayAmplitude/calcAmplitudes.cc
+++ b/decayAmplitude/calcAmplitudes.cc
@@ -98,9 +98,11 @@ main(int    argc,
 	printGitHash     ();
 	cout << endl;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	// parse command line options
 	const string   progName                 = argv[0];

--- a/decayAmplitude/calcIntegrals.cc
+++ b/decayAmplitude/calcIntegrals.cc
@@ -79,10 +79,6 @@ main(int    argc,
 	printGitHash     ();
 	cout << endl;
 
-	// force loading predefined std::complex dictionary
-	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
-	//gROOT->ProcessLine("#include <complex>");
-
 	// parse command line options
 	const string progName        = argv[0];
 	string       outFileName     = "./norm.int";

--- a/decayAmplitude/test/testAmplitudeTree.cc
+++ b/decayAmplitude/test/testAmplitudeTree.cc
@@ -58,9 +58,11 @@ main(int argc, char** argv)
 	const unsigned int nmbIncohSubAmps = 3;
 	gRandom->SetSeed(123456789);
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	if (1) {
 		TFile*               outFile      = TFile::Open("testAmplitudeTree.root", "RECREATE");

--- a/decayAmplitude/test/testIntegral.cc
+++ b/decayAmplitude/test/testIntegral.cc
@@ -119,8 +119,10 @@ main(int    argc,
 		ampIntegralMatrix integral2(integral);
 		integral2.writeAscii("testIntegral2.int");
 		// root I/O
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 		// force loading predefined std::complex dictionary
 		gROOT->ProcessLine("#include <complex>");
+#endif
 		{
 			TFile* outFile = TFile::Open("testIntegral.root", "RECREATE");
 			printInfo << "writing integral to 'testIntegral.root'" << endl;

--- a/generators/weightEvents.cc
+++ b/generators/weightEvents.cc
@@ -208,9 +208,11 @@ main(int    argc,
 	printGitHash     ();
 	cout << endl;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	// parse command line options
 	const string   progName                 = argv[0];

--- a/partialWaveFit/pwafit.cc
+++ b/partialWaveFit/pwafit.cc
@@ -161,9 +161,11 @@ main(int    argc,
 	printGitHash     ();
 	cout << endl;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	// ---------------------------------------------------------------------------
 	// internal parameters

--- a/resonanceFit/pwaMassFit.cc
+++ b/resonanceFit/pwaMassFit.cc
@@ -93,9 +93,11 @@ main(int    argc,
 	rpwa::printGitHash     ();
 	std::cout << std::endl;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// force loading predefined std::complex dictionary
 	// see http://root.cern.ch/phpBB3/viewtopic.php?f=5&t=9618&p=50164
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	// --------------------------------------------------------------------------
 	// internal parameters

--- a/storageFormats/convertEventFile.cc
+++ b/storageFormats/convertEventFile.cc
@@ -60,11 +60,13 @@ int main(int argc, char** argv)
 	string userString = outputFileName;
 	bool debug = false;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// if the following line is missing, there are error messages of the sort
 	// "Warning in <TClass::TClass>: no dictionary for class TVector3 is available",
 	// no idea why. Probably there is a correct way of ensuring that the dictionaries
 	// are loaded, but I do not know it (yet). KB
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	extern char* optarg;
 	int c;

--- a/storageFormats/mergeDatafiles.cc
+++ b/storageFormats/mergeDatafiles.cc
@@ -41,11 +41,13 @@ int main(int argc, char** argv)
 	const string progName = argv[0];
 	bool force = false;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// if the following line is missing, there are error messages of the sort
 	// "Warning in <TClass::TClass>: no dictionary for class TVector3 is available",
 	// no idea why. Probably there is a correct way of ensuring that the dictionaries
 	// are loaded, but I do not know it (yet). KB
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 //	extern char* optarg;
 	int c;

--- a/storageFormats/printMetadata.cc
+++ b/storageFormats/printMetadata.cc
@@ -44,11 +44,13 @@ int main(int argc, char** argv)
 	string inputFileName  = "input.root";
 	bool recalculateHash = false;
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
 	// if the following line is missing, there are error messages of the sort
 	// "Warning in <TClass::TClass>: no dictionary for class TVector3 is available",
 	// no idea why. Probably there is a correct way of ensuring that the dictionaries
 	// are loaded, but I do not know it (yet). KB
 	gROOT->ProcessLine("#include <complex>");
+#endif
 
 	extern char* optarg;
 	int c;


### PR DESCRIPTION
The ROOT6 master now supports std::complex, and in principle it works.

This patch removes gROOT->ProcessLine("#include <complex>") for ROOT6 where it is no longer required, and fixes one bug found while testing.