### PR TITLE
src: Fix the evidence calculation for some cases.

### DIFF
--- a/src/fitResult.cc
+++ b/src/fitResult.cc
@@ -215,11 +215,28 @@ fitResult::evidenceComponents() const
 
 	// REMOVE CONSTRAINT TO NUMBER OF EVENTS!
 	const double l   = -logLikelihood();// - intensity(".*");
-	const double det = thrCovMatrix.Determinant();
+	double logDet = thrCovMatrix.Determinant();
 	const double d   = (double)thrCovMatrix.GetNcols();
 
+	if(std::isinf(logDet)) {
+		printWarn << "found infinite determinant of covariance matrix, trying to calculate log(det) directly..." << endl;
+		logDet = 0.;
+		TVectorT<double> eigenvalues;
+		thrCovMatrix.EigenVectors(eigenvalues);
+		for(int i = 0; i < eigenvalues.GetNrows(); ++i) {
+			logDet += TMath::Log(eigenvalues[i]);
+		}
+		if(std::isinf(logDet) or std::isnan(logDet)) {
+			printWarn << "calculation failed, log(det) = " << logDet << "." << endl;
+		} else {
+			printSucc << "calculation succeeded, log(det) = " << logDet << "." << endl;
+		}
+	} else {
+		logDet = TMath::Log(logDet);
+	}
+
 	// parameter-volume after observing data
-	const double lvad = 0.5 * (d * 1.837877066 + TMath::Log(det));
+	const double lvad = 0.5 * (d * 1.837877066 + logDet);
 
 	// parameter volume prior to observing the data
 	// n-Sphere:


### PR DESCRIPTION
Fix the evidence calculation for the case of large covariance matrices (i.e.
several hundred parameters). Because of numerical limitations, the determinant
of the covariance matrix could become infinite, ruining the evidence
calculation. Fix this by calculating the eigenvalues of the covariance matrix
and adding up the logarithms of them which could still yield a sensible number.