### PR TITLE
amplitude: Add const width Breit-Wigner.

### DIFF
--- a/amplitude/waveDescription.cc
+++ b/amplitude/waveDescription.cc
@@ -658,6 +658,8 @@ waveDescription::mapMassDependenceType(const string& massDepType)
 	if (   (massDepType == "BreitWigner")
 	    or (massDepType == ""))  // default mass dependence
 		massDep = createRelativisticBreitWigner();
+	else if (massDepType == "constWidthBreitWigner")
+		massDep = createConstWidthBreitWigner();
 	else if (massDepType == "flat")
 		massDep = createFlatMassDependence();
 	else if (massDepType == "flatRange")


### PR DESCRIPTION
Add the const-width Breit-Wigner function to the waveDescription, so that it
can actually be used in the keyfiles.