### PR TITLE
src: Fix a bug in pwaLikelihood's readDecayAmplitudes.

### DIFF
--- a/src/pwaLikelihood.cc
+++ b/src/pwaLikelihood.cc
@@ -1160,9 +1160,11 @@ pwaLikelihood<complexT>::readDecayAmplitudes(const string& ampDirName,
 				  amps.push_back(amp);
 				}
 			}
-			if (firstWave)
+			if (firstWave) {
 				nmbEvents = _nmbEvents = amps.size();
-			else {
+				_decayAmps.resize(extents[_nmbEvents][2][_nmbWavesReflMax]);
+				firstWave = false;
+			} else {
 				nmbEvents = amps.size();
 				if (nmbEvents != _nmbEvents)
 					printWarn << "size mismatch in amplitude files: this file contains " << nmbEvents
@@ -1172,7 +1174,6 @@ pwaLikelihood<complexT>::readDecayAmplitudes(const string& ampDirName,
 
 			// copy decay amplitudes into array that is indexed [event index][reflectivity][wave index]
 			// this index scheme ensures a more linear memory access pattern in the likelihood function
-			_decayAmps.resize(extents[_nmbEvents][2][_nmbWavesReflMax]);
 			for (unsigned int iEvt = 0; iEvt < _nmbEvents; ++iEvt)
 				_decayAmps[iEvt][iRefl][iWave] = amps[iEvt];
 			if (_debug)


### PR DESCRIPTION
Fix a bug in pwaLikelihood::readDecayAmplitude, where the array containing the
decay amplitudes was resized every time a new amplitude file was read in, while
slowed down the initial loading of amplitudes by some order of magnitudes.
While doing that, also finally fix the bug that the firstWave boolean was never
set to false so the consistency in terms of number of events in the amplitude
files was never properly checked as was intended.