### PR TITLE
Fix issues around normalization matrices

### DIFF
--- a/partialWaveFit/addIntegralsToFitResult.cc
+++ b/partialWaveFit/addIntegralsToFitResult.cc
@@ -41,6 +41,7 @@
 #include "ampIntegralMatrix.h"
 #include "fileUtils.hpp"
 #include "fitResult.h"
+#include "partialWaveFitHelper.h"
 #include "reportingUtilsEnvironment.h"
 
 using namespace std;
@@ -238,8 +239,13 @@ main(int    argc,
 						printErr << "encountered flat wave prematurely. Aborting..." << endl;
 						return 1;
 					}
-					normIntegral.set(waveIndex_i, waveIndex_j, providedNormIntegral.element(waveName_i, waveName_j));
-					accIntegral.set(waveIndex_i, waveIndex_j, providedAccIntegral.element(waveName_i, waveName_j));
+					if (partialWaveFitHelper::getReflectivity(waveName_i) == partialWaveFitHelper::getReflectivity(waveName_j)) {
+						normIntegral.set(waveIndex_i, waveIndex_j, providedNormIntegral.element(waveName_i, waveName_j));
+						accIntegral.set (waveIndex_i, waveIndex_j, providedAccIntegral.element (waveName_i, waveName_j));
+					} else {
+						normIntegral.set(waveIndex_i, waveIndex_j, 0);
+						accIntegral.set (waveIndex_i, waveIndex_j, 0);
+					}
 				}
 			}
 			for(unsigned int i = 0; i < phaseSpaceIntegral.size() - 1; ++i) {

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -45,6 +45,7 @@
 #include "TRandom3.h"
 
 #include "fitResult.h"
+#include "partialWaveFitHelper.h"
 
 
 using namespace std;
@@ -281,6 +282,13 @@ complex<double>
 fitResult::spinDensityMatrixElem(const unsigned int waveIndexA,
                                  const unsigned int waveIndexB) const
 {
+	// spin density matrix element is 0 if the two waves have different
+	// reflectivities
+	if (partialWaveFitHelper::getReflectivity(_waveNames[waveIndexA])
+	    != partialWaveFitHelper::getReflectivity(_waveNames[waveIndexB])) {
+		return 0;
+	}
+
 	// get pairs of amplitude indices with the same rank for waves A and B
 	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
 		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);
@@ -363,6 +371,14 @@ TMatrixT<double>
 fitResult::spinDensityMatrixElemCov(const unsigned int waveIndexA,
                                     const unsigned int waveIndexB) const
 {
+	// spin density matrix element is 0 if the two waves have different
+	// reflectivities
+	if (partialWaveFitHelper::getReflectivity(_waveNames[waveIndexA])
+	    != partialWaveFitHelper::getReflectivity(_waveNames[waveIndexB])) {
+		TMatrixT<double> spinDensCov(2, 2);
+		return spinDensCov;
+	}
+
 	// get pairs of amplitude indices with the same rank for waves A and B
 	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
 		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -155,6 +155,19 @@ fitResult::evidence() const
 std::vector<double>
 fitResult::evidenceComponents() const
 {
+	// make sure evidence can be calculated, i.e.:
+	// - covariance matrix exists
+	// - accepted normalisation integral exists
+	if (fitParCovMatrix().GetNcols() == 0 || fitParCovMatrix().GetNrows() == 0
+	    || acceptedNormIntegralMatrix().nCols() == 0 || acceptedNormIntegralMatrix().nRows() == 0) {
+		std::vector<double> retval;
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		return retval;
+	}
+
 	// find the thresholded production amplitudes, assume those are the
 	// ones with imaginary and real part equal to zero
 	set<unsigned int> thrProdAmpIndices;

--- a/partialWaveFit/partialWaveFitHelper.cc
+++ b/partialWaveFit/partialWaveFitHelper.cc
@@ -52,3 +52,37 @@ rpwa::partialWaveFitHelper::extractWaveList(const rpwa::fitResult& result,
 		}
 	}
 }
+
+
+// depends on naming convention for waves!!!
+// VR_IGJPCMEIso....
+int
+rpwa::partialWaveFitHelper::getReflectivity(const std::string& name)
+{
+	size_t waveNamePos = 0;  // position at which the wave name starts
+	// check whether name is a production amplitude (parameter) or a wave name
+	if (name[0] == 'V') {
+		waveNamePos = name.find("_");
+		if (waveNamePos == std::string::npos) {
+			printErr << "cannot parse parameter/wave name '" << name << "'. "
+			         << "appears to be parameter name, but does not contain '_'. Aborting..." << std::endl;
+			throw;
+		}
+		waveNamePos += 1;
+	}
+
+	int refl = 0;
+	if (name.substr(waveNamePos) != "flat") {
+		if (name[waveNamePos + 6] == '-')
+			refl= -1;
+		else if (name[waveNamePos + 6] == '+')
+			refl= +1;
+		else {
+			printErr << "cannot parse parameter/wave name '" << name << "'. "
+			         << "cannot not determine reflectivity. Aborting..." << std::endl;
+			throw;
+		}
+	}
+
+	return refl;
+}

--- a/partialWaveFit/partialWaveFitHelper.h
+++ b/partialWaveFit/partialWaveFitHelper.h
@@ -40,6 +40,8 @@ namespace rpwa {
 
 		void extractWaveList(const rpwa::fitResult& fitResult, std::ostream& waveList);
 
+		int getReflectivity(const std::string& name);
+
 
 	}  // namespace partialWaveFitHelper
 

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -54,6 +54,7 @@
 #endif
 #include "amplitudeTreeLeaf.h"
 #include "pwaLikelihood.h"
+#include "partialWaveFitHelper.h"
 
 
 // #define USE_FDF
@@ -994,7 +995,7 @@ pwaLikelihood<complexT>::readWaveList(const string& waveListFileName)
 			if (_debug)
 				printDebug << "reading line " << setw(3) << lineNmb + 1 << ": " << waveName<< ", "
 				           << "threshold = " << setw(4) << threshold << " MeV/c^2" << endl;
-			if (getReflectivity(waveName) > 0) {
+			if (partialWaveFitHelper::getReflectivity(waveName) > 0) {
 				++_nmbWavesRefl[1];  // positive reflectivity
 				waveNames     [1].push_back(waveName);
 				waveThresholds[1].push_back(threshold);
@@ -1447,44 +1448,6 @@ pwaLikelihood<complexT>::clear()
 	_decayAmps.resize(extents[0][0][0]);
 }
 
-
-// depends on naming convention for waves!!!
-// VR_IGJPCMEIso....
-template<typename complexT>
-int
-pwaLikelihood<complexT>::getReflectivity(const string& name)
-{
-	size_t waveNamePos = 0;  // position at which the wave name starts
-	// check whether name is a production amplitude (parameter) or a wave name
-	if (name[0] == 'V') {
-		waveNamePos = name.find("_");
-		if (waveNamePos == string::npos) {
-			printErr << "cannot parse parameter/wave name '" << name << "'. "
-			         << "appears to be parameter name, but does not contain '_'. Aborting..." << endl;
-			throw;
-		}
-		waveNamePos += 1;
-	}
-
-	int refl = 0;
-	if (name.substr(waveNamePos) != "flat") {
-		if (name[waveNamePos + 6] == '-')
-			refl= -1;
-		else if (name[waveNamePos + 6] == '+')
-			refl= +1;
-		else {
-			printErr << "cannot parse parameter/wave name '" << name << "'. "
-			         << "cannot not determine reflectivity. Aborting..." << endl;
-			throw;
-		}
-	}
-
-	if (_debug)
-		printDebug << "extracted reflectivity = " << refl << " from parameter/wave name "
-		           << "'" << name << "' (char position " << waveNamePos + 6 << ")" << endl;
-
-	return refl;
-}
 
 // copy values from array that corresponds to the function parameters
 // to structure that corresponds to the complex production amplitudes

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -1114,12 +1114,11 @@ pwaLikelihood<complexT>::reorderIntegralMatrix(const ampIntegralMatrix& integral
 	reorderedMatrix.resize(extents[2][_nmbWavesReflMax][2][_nmbWavesReflMax]);
 	for (unsigned int iRefl = 0; iRefl < 2; ++iRefl)
 		for (unsigned int iWave = 0; iWave < _nmbWavesRefl[iRefl]; ++iWave)
-			for (unsigned int jRefl = 0; jRefl < 2; ++jRefl)
-				for (unsigned int jWave = 0; jWave < _nmbWavesRefl[jRefl]; ++jWave) {
-					const complex<double> val = integral.element(_waveNames[iRefl][iWave],
-					                                             _waveNames[jRefl][jWave]);
-					reorderedMatrix[iRefl][iWave][jRefl][jWave] = complexT(val.real(), val.imag());
-				}
+			for (unsigned int jWave = 0; jWave < _nmbWavesRefl[iRefl]; ++jWave) {
+				const complex<double> val = integral.element(_waveNames[iRefl][iWave],
+				                                             _waveNames[iRefl][jWave]);
+				reorderedMatrix[iRefl][iWave][iRefl][jWave] = complexT(val.real(), val.imag());
+			}
 }
 
 
@@ -1382,15 +1381,15 @@ pwaLikelihood<complexT>::getIntegralMatrices(complexMatrix&  normMatrix,
 	}
 	// set unused entries to 0
 	for (unsigned int i = 0; i < normMatrix.nCols(); ++i) {
-		normMatrix.set(_nmbWaves, i, complexT(0., 0.));
-		normMatrix.set(i, _nmbWaves, complexT(0., 0.));
-		accMatrix.set(_nmbWaves, i, complexT(0., 0.));
-		accMatrix.set(i, _nmbWaves, complexT(0., 0.));
+		normMatrix.set(_nmbWaves, i, 0);
+		normMatrix.set(i, _nmbWaves, 0);
+		accMatrix.set (_nmbWaves, i, 0);
+		accMatrix.set (i, _nmbWaves, 0);
 	}
 	// add flat
-	normMatrix.set(_nmbWaves, _nmbWaves, complexT(1,0));
-	accMatrix.set (_nmbWaves, _nmbWaves, complexT(_totAcc,0));
-	phaseSpaceIntegral[_nmbWaves] = 1;
+	normMatrix.set(_nmbWaves, _nmbWaves, 1.);
+	accMatrix.set (_nmbWaves, _nmbWaves, _totAcc);
+	phaseSpaceIntegral[_nmbWaves] = 1.;
 }
 
 

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -1452,28 +1452,39 @@ pwaLikelihood<complexT>::clear()
 // VR_IGJPCMEIso....
 template<typename complexT>
 int
-pwaLikelihood<complexT>::getReflectivity(const TString& waveName)
+pwaLikelihood<complexT>::getReflectivity(const string& name)
 {
-	int refl = 0;
-	unsigned int reflIndex = 6;  // position of reflectivity in wave
-	// check whether it is parameter or wave name
-	if (waveName[0] == 'V')
-		reflIndex = 9;
-	if (waveName[reflIndex] == '-')
-		refl= -1;
-	else if (waveName[reflIndex] == '+')
-		refl= +1;
-	else {
-		printErr << "cannot parse parameter/wave name '" << waveName << "'. "
-		         << "cannot not determine reflectivity. Aborting..." << endl;
-		throw;
+	size_t waveNamePos = 0;  // position at which the wave name starts
+	// check whether name is a production amplitude (parameter) or a wave name
+	if (name[0] == 'V') {
+		waveNamePos = name.find("_");
+		if (waveNamePos == string::npos) {
+			printErr << "cannot parse parameter/wave name '" << name << "'. "
+			         << "appears to be parameter name, but does not contain '_'. Aborting..." << endl;
+			throw;
+		}
+		waveNamePos += 1;
 	}
+
+	int refl = 0;
+	if (name.substr(waveNamePos) != "flat") {
+		if (name[waveNamePos + 6] == '-')
+			refl= -1;
+		else if (name[waveNamePos + 6] == '+')
+			refl= +1;
+		else {
+			printErr << "cannot parse parameter/wave name '" << name << "'. "
+			         << "cannot not determine reflectivity. Aborting..." << endl;
+			throw;
+		}
+	}
+
 	if (_debug)
-		printDebug << "extracted reflectivity = " << refl << " from parameter name "
-		           << "'" << waveName << "' (char position " << reflIndex << ")" << endl;
+		printDebug << "extracted reflectivity = " << refl << " from parameter/wave name "
+		           << "'" << name << "' (char position " << waveNamePos + 6 << ")" << endl;
+
 	return refl;
 }
-
 
 // copy values from array that corresponds to the function parameters
 // to structure that corresponds to the complex production amplitudes

--- a/partialWaveFit/pwaLikelihood.h
+++ b/partialWaveFit/pwaLikelihood.h
@@ -206,7 +206,7 @@ namespace rpwa {
 
 
 		void clear();
-		static int getReflectivity(const TString& waveName);
+		static int getReflectivity(const std::string& waveName);
 
 		void reorderIntegralMatrix(const rpwa::ampIntegralMatrix& integral,
 		                           normMatrixArrayType&           reorderedMatrix) const;

--- a/partialWaveFit/pwaLikelihood.h
+++ b/partialWaveFit/pwaLikelihood.h
@@ -206,7 +206,6 @@ namespace rpwa {
 
 
 		void clear();
-		static int getReflectivity(const std::string& waveName);
 
 		void reorderIntegralMatrix(const rpwa::ampIntegralMatrix& integral,
 		                           normMatrixArrayType&           reorderedMatrix) const;


### PR DESCRIPTION
Fix issues #25 and #31.

Set the spin-density matrix elements to 0 for different reflectivities.
Set the entries in both norm matrices to 0 for different reflectivities mimicking the behaviour in the likelihood.

Properly split accepted norm matrix when calculating the evidence for fits with thresholds and ranks.