### PR TITLE
Various fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,14 @@ if(DEBUG_OUTPUT)
 endif()
 
 
+# test whether thread_local is understood
+check_cxx_source_compiles("#include <iostream>
+int main() { thread_local int a = 1; std::cout << a << std::endl; }" COMPILER_PROVIDES_THREAD_LOCAL)
+if(COMPILER_PROVIDES_THREAD_LOCAL)
+       add_definitions(-DCOMPILER_PROVIDES_THREAD_LOCAL)
+endif()
+
+
 # redirect output files
 message(STATUS "")
 message(STATUS ">>> Setting up output paths.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ if(NOT NLopt_FOUND)
 	message(STATUS "Cannot find NLopt installation. No NLopt components will be generated.")
 else()
 	set(USE_NLOPT ON)
+	add_definitions(-DUSE_NLOPT)
 endif()
 add_feature_info(NLopt USE_NLOPT "NLopt is a library for nonlinear optimization.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,8 @@ endif()
 # at the same time the library is required. the third find_package
 # line is needed in case the components are not found, because
 # Boost_FOUND is set to FALSE.
-find_package(Boost 1.50.0 REQUIRED)
-find_package(Boost 1.50.0 QUIET COMPONENTS ${_BOOST_COMPONENTS})
+find_package(Boost 1.56.0 REQUIRED)
+find_package(Boost 1.56.0 QUIET COMPONENTS ${_BOOST_COMPONENTS})
 foreach(_BOOST_COMPONENT ${_BOOST_COMPONENTS})
 	string(TOUPPER ${_BOOST_COMPONENT} _BOOST_COMPONENT)
 	if(Boost_${_BOOST_COMPONENT}_FOUND)
@@ -199,7 +199,7 @@ foreach(_BOOST_COMPONENT ${_BOOST_COMPONENTS})
 endforeach()
 unset(_BOOST_COMPONENT)
 unset(_BOOST_COMPONENTS)
-find_package(Boost 1.50.0 REQUIRED)
+find_package(Boost 1.56.0 REQUIRED)
 set_package_properties(Boost
 	PROPERTIES
 	DESCRIPTION "C++ Template Library"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,15 +148,6 @@ if(DEBUG_OUTPUT)
 endif()
 
 
-# detect some compiler/STL features
-# test whether std::complex provides real and imag accessors
-check_cxx_source_compiles("#include <complex>
-int main() { std::complex<double> a; a.real() = 0; }" COMPILER_PROVIDES_STD_COMPLEX_ACCESSORS)
-if(COMPILER_PROVIDES_STD_COMPLEX_ACCESSORS)
-	add_definitions(-DCOMPILER_PROVIDES_STD_COMPLEX_ACCESSORS)
-endif()
-
-
 # redirect output files
 message(STATUS "")
 message(STATUS ">>> Setting up output paths.")

--- a/README.md
+++ b/README.md
@@ -64,33 +64,43 @@ The minimum required CMake version is 2.8.8. In case your system offers only out
 
 ### Boost ###
 
-Part of the code relies on the Boost C++ template library which is available at <http://www.boost.org>. Version 1.50.0 or higher is required; it is recommended to use the latest Boots release. Boost is to a large extend a header-only library so that usually nothing has to be build (noteworthy exception are the Python bindings; see below). Just install the respective Boost packages for your platform or, in case you do not have administrator privileges, extract the source archive to a location of your choice.
+Part of the code relies on the Boost C++ template library which is available at <http://www.boost.org>. Version 1.56.0 or higher is required; it is recommended to use the latest Boots release. Boost is to a large extend a header-only library so that usually nothing has to be build (noteworthy exception are the Python bindings; see below). Just install the respective Boost packages for your platform or, in case you do not have administrator privileges, extract the source archive to a location of your choice.
 
-A more convenient way than downloading and extracting the tarball of a certain Boost version is to clone the Boost git repository by running
+The most convenient way to install Boost is to download and extract the tarball of the desired Boost version. However one can also clone the Boost git repository by running
 
-    > git clone https://github.com/ned14/boost-trunk.git
+    > git clone --recursive https://github.com/boostorg/boost.git
 
 The list of available versions (tags) is printed by
 
+    > cd boost
     > git tag
 
-Checkout the wanted release version via
+As the Boost git repository is split into multiple modules checking out one particular tag is a bit cumbersome. After identifying the tag the checkout has to be performed for the main directory and each submodule. This can be done by (be sure to be in the main Boost directory)
 
-    > cd boost-trunk
-    > git checkout release/Boost_1_50_0
-
-This way one can easily switch to any existing Boost version and also updates are much more convenient:
-
-    > git checkout master
-    > git fetch
-    > git fetch --tags
-    > git checkout release/Boost_1_51_0
+    > cd boost
+    > git checkout boost-1.58.0
+    > git submodule foreach 'git checkout --force boost-1.58.0 || true'
 
 If you use one of the (optional) features like Python or MPI be sure to recompile the respective Boost libraries after having switched to a different Boost version.
 
 In order to find out the current Boost version (a.k.a. branch tag) run
 
     > git describe --tags
+
+And accordingly for the submodules run
+
+    > git submodule foreach 'git describe --tags'
+
+You should note though that the tags shown by this command might differ from the one expected in cases where no changes between the tag shown and the one expected were made.
+
+A full update of the Boost git repository can be performed by running
+
+    > cd boost
+    > git checkout master
+    > git pull
+    > git submodule update --recursive --init
+    > git submodule update --recursive
+    > git submodule foreach --recursive "git checkout master; git pull"
 
 
 ### ROOT ###

--- a/cmakeModules/FindROOT.cmake
+++ b/cmakeModules/FindROOT.cmake
@@ -448,6 +448,13 @@ function(root_generate_dictionary DICT_FILE)
 			message(STATUS "root_generate_dictionary will execute "
 				"'${RLIBMAP_EXECUTABLE} -o ${_MAP_FILE} -l ${_LIB_NAME} -c ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_LINKDEF}'")
 		endif()
+
+		# ignore compiler warnings concerning ignored qualifiers when
+		# compiling the ROOT dictionaries (this is required for
+		# 'Apple LLVM version 6.1.0')
+		set_source_files_properties(${DICT_FILE}
+		                            PROPERTIES
+		                            COMPILE_FLAGS "-Wno-ignored-qualifiers")
 	else()
 		string(REGEX REPLACE "^(.*)\\.(.*)$" "\\1_rdict.pcm" _DICT_PCM "${_MAP_FILE}")
 		set(OUTPUT_FILES ${DICT_FILE} ${_DICT_PCM} ${_MAP_FILE})

--- a/compileBoostLibraries.sh
+++ b/compileBoostLibraries.sh
@@ -21,23 +21,26 @@ else
 fi
 
 
-JAM_CONFIG_FILE="${BOOST_ROOT_DIR}/tools/build/v2/user-config.jam"
-if [[ ! -e ${JAM_CONFIG_FILE} ]]
+JAM_CONFIG_FILE_SOURCE="${BOOST_ROOT_DIR}/tools/build/example/user-config.jam"
+JAM_CONFIG_FILE_TARGET="${BOOST_ROOT_DIR}/tools/build/src/user-config.jam"
+if [[ ! -e ${JAM_CONFIG_FILE_SOURCE} ]]
 then
-		echo "!!! error: '${JAM_CONFIG_FILE}' does not exist"
+		echo "!!! error: '${JAM_CONFIG_FILE_SOURCE}' does not exist"
 		exit 1
 fi
-LINE='using mpi ;'
-if ! grep --quiet --line-regexp "${LINE}" ${JAM_CONFIG_FILE}
+if [[ ! -e ${JAM_CONFIG_FILE_TARGET} ]]
 then
-		echo "${LINE}" >> ${JAM_CONFIG_FILE}
+		cp ${JAM_CONFIG_FILE_SOURCE} ${JAM_CONFIG_FILE_TARGET}
+fi
+LINE='using mpi ;'
+if ! grep --quiet --line-regexp "${LINE}" ${JAM_CONFIG_FILE_TARGET}
+then
+		echo "${LINE}" >> ${JAM_CONFIG_FILE_TARGET}
 fi
 
-
 echo "    view result in ${LOG_FILE}"
-#./bootstrap.sh --with-libraries=mpi,python --with-python=python3 --prefix=. &> ${LOG_FILE}
 ./bootstrap.sh --with-libraries=mpi,python,timer --prefix=. &> ${LOG_FILE}
-./bjam -a >> ${LOG_FILE} 2>&1
+./b2 -a >> ${LOG_FILE} 2>&1
 
 
 exit 0

--- a/decayAmplitude/waveDescription.h
+++ b/decayAmplitude/waveDescription.h
@@ -44,16 +44,15 @@
 #include "TObject.h"
 
 #ifndef __CINT__
-#include "libconfig.h++"
-
 #include "isobarDecayTopology.h"
 #include "isobarAmplitude.h"
-#else
+#endif
+
+
 namespace libconfig {
 	class Config;
 	class Setting;
 }
-#endif
 
 
 namespace rpwa {

--- a/nlopt/pwaNloptFit.cc
+++ b/nlopt/pwaNloptFit.cc
@@ -58,6 +58,7 @@
 #include "conversionUtils.hpp"
 #include "pwaLikelihood.h"
 #include "fitResult.h"
+#include "partialWaveFitHelper.h"
 #include "amplitudeTreeLeaf.h"
 
 
@@ -355,7 +356,8 @@ main(int    argc,
 		fitParCovMatrix.ResizeTo(nmbPar, nmbPar);
 		fitParCovMatrix = L.CovarianceMatrix(hessian);
 		TVectorT<double> eigenvalues;
-		hessian.EigenVectors(eigenvalues);
+		TMatrixT<double> eigenvectors;
+		rpwa::partialWaveFitHelper::getEigenvectors(L, hessian, eigenvectors, eigenvalues);
 		if (not quiet) {
 			printInfo << "analytical Hessian eigenvalues:" << endl;
 		}

--- a/partialWaveFit/5piMassDep.conf
+++ b/partialWaveFit/5piMassDep.conf
@@ -571,11 +571,28 @@ model :
     } );
   finalStateMassDependence :
   {
-    formula = "sqrt([1] * (x-[0])^5*(1.+(x-[0])*[2])*exp(-[3]* (x-[0])^2))";
-    val = [ 0.698, 308.7e-6, 4.859, 0.001742 ];
-    lower = [ 0.698, 308.7e-6, 4.859, -1.0 ];
-    upper = [ 0.698, 308.7e-6, 4.859, 1.0 ];
-    error = [ 0.0, 0.0, 0.0, 0.000025 ];
-    fix = [ true, true, true, false ];
+    formula = "sqrt([1]*(x-[0])^5*(1.+(x-[0])*[2])*exp(-[3]*(x-[0])^2))";
+    p0 :
+    {
+      val = 0.698;
+      fix = true;
+    };
+    p1 :
+    {
+      val = 308.7e-6;
+      fix = true;
+    };
+    p2 :
+    {
+      val = 4.859;
+      fix = true;
+    };
+    p3 :
+    {
+      val = 0.001742;
+      lower = 1.0;
+      upper = 1.0;
+      fix = false;
+    };
   };
 };

--- a/partialWaveFit/calcCovMatrixForFitResult.cc
+++ b/partialWaveFit/calcCovMatrixForFitResult.cc
@@ -259,26 +259,10 @@ main(int    argc,
 
 	// analytically calculate Hessian
 	const TMatrixT<double> hessian = L.Hessian(pars.data());
-	// create reduced hessian without fixed parameters
-	TMatrixT<double> reducedHessian(nmbPar - L.nmbParsFixed(), nmbPar - L.nmbParsFixed());
-	{
-		unsigned int iReduced = 0;
-		for(unsigned int i = 0; i < nmbPar; ++i) {
-			unsigned int jReduced = 0;
-			if (not L.parFixed(i)) {
-				for(unsigned int j = 0; j < nmbPar; ++j) {
-					if (not L.parFixed(j)) {
-						reducedHessian[iReduced][jReduced] = hessian[i][j];
-						jReduced++;
-					}
-				}
-				iReduced++;
-			}
-		}
-	}
 	// create and check Hessian eigenvalues
 	TVectorT<double> eigenvalues;
-	reducedHessian.EigenVectors(eigenvalues);
+	TMatrixT<double> eigenvectors;
+	rpwa::partialWaveFitHelper::getEigenvectors(L, hessian, eigenvectors, eigenvalues);
 	if (not quiet) {
 		printInfo << "eigenvalues of (analytic) Hessian:" << endl;
 	}

--- a/partialWaveFit/eigenvectorLikelihoodSlices.cc
+++ b/partialWaveFit/eigenvectorLikelihoodSlices.cc
@@ -299,7 +299,8 @@ main(int    argc,
 	remove(waveListFileName.c_str());
 	if (not quiet)
 		cout << L << endl;
-	const unsigned int nmbPar = L.NDim();
+	const unsigned int nmbPar      = L.NDim();
+	const unsigned int nmbParFixed = L.nmbParsFixed();
 
 	unsigned int maxParNameLength = 0;  // maximum length of parameter names
 	for(unsigned int i = 0; i < nmbPar; ++i) {
@@ -319,14 +320,16 @@ main(int    argc,
 
 	const TMatrixT<double> covMatrixMinuit = result->fitParCovMatrix();
 	TVectorT<double> eigenvaluesMinuit;
-	const TMatrixT<double> eigenvectorsMinuit = covMatrixMinuit.EigenVectors(eigenvaluesMinuit);
+	TMatrixT<double> eigenvectorsMinuit;
+	rpwa::partialWaveFitHelper::getEigenvectors(L, covMatrixMinuit, eigenvectorsMinuit, eigenvaluesMinuit);
 
 	const TMatrixT<double> covMatrixAna = L.CovarianceMatrix(pars.data());
 	TVectorT<double> eigenvaluesAna;
-	const TMatrixT<double> eigenvectorsAna = covMatrixAna.EigenVectors(eigenvaluesAna);
+	TMatrixT<double> eigenvectorsAna;
+	rpwa::partialWaveFitHelper::getEigenvectors(L, covMatrixAna, eigenvectorsAna, eigenvaluesAna);
 
 	TFile* outFile = new TFile(outFileName.c_str(), "RECREATE");
-	for(unsigned int par = 0; par < nmbPar; ++par) {
+	for(unsigned int par = 0; par < nmbPar-nmbParFixed; ++par) {
 		std::vector<double> eigenvectorMinuit = getEigenvector(eigenvectorsMinuit, par);
 		if (not checkNorm(eigenvectorMinuit)) {
 			printWarn << "Minuit eigenvector " << par << " is not normalized. normalizing." << endl;

--- a/partialWaveFit/partialWaveFitHelper.h
+++ b/partialWaveFit/partialWaveFitHelper.h
@@ -26,6 +26,10 @@
 //-------------------------------------------------------------------------
 
 
+#ifndef PARTIALWAVEFITHELPER_HH
+#define PARTIALWAVEFITHELPER_HH
+
+
 #include <iostream>
 
 
@@ -47,3 +51,6 @@ namespace rpwa {
 
 
 }  // namespace rpwa
+
+
+#endif  // PARTIALWAVEFITHELPER_HH

--- a/partialWaveFit/partialWaveFitHelper.h
+++ b/partialWaveFit/partialWaveFitHelper.h
@@ -33,16 +33,27 @@
 #include <iostream>
 
 
+template<typename T> class TMatrixT;
+template<typename T> class TVectorT;
+
+
 namespace rpwa {
 
 
 	class fitResult;
+	template<typename T> class pwaLikelihood;
 
 
 	namespace partialWaveFitHelper {
 
 
 		void extractWaveList(const rpwa::fitResult& fitResult, std::ostream& waveList);
+
+		template<typename T1, typename T2>
+		void getEigenvectors(const rpwa::pwaLikelihood<T1>& L,
+                                     const TMatrixT<T2>&      matrix,
+                                     TMatrixT<T2>&            eigenvectors,
+                                     TVectorT<T2>&            eigenvalues);
 
 		int getReflectivity(const std::string& name);
 
@@ -51,6 +62,73 @@ namespace rpwa {
 
 
 }  // namespace rpwa
+
+
+// Get the Eigenvectors of a matrix taking care of fixed parameters. A reduced
+// matrix is created from the original one skipping the entries corresponding
+// to fixed parameters. The Eigenvectors and Eigenvalues of this reduced matrix
+// are calculated. Finally the matrix containing the Eigenvectors is modified
+// by adding rows containing only 0. for the fixed parameters, the number of
+// Eigenvalues does not change, so neither the number of columns, nor the size
+// of the Eigenvalues vector is changed.
+//
+// The input matrix can be the Hessian or covariance matrix.
+//
+// Eigenvectors is a (nmbPars x nmbPars-nmbParsFixed) matrix, Eigenvalues is
+// a vector with size (nmbPars-nmbParsFixed).
+template<typename T1, typename T2>
+inline
+void
+rpwa::partialWaveFitHelper::getEigenvectors(const pwaLikelihood<T1>& L,
+                                            const TMatrixT<T2>&      matrix,
+                                            TMatrixT<T2>&            eigenvectors,
+                                            TVectorT<T2>&            eigenvalues)
+{
+	const unsigned int nmbPars      = L.nmbPars();
+	const unsigned int nmbParsFixed = L.nmbParsFixed();
+
+	TMatrixT<T2> reducedMatrix(nmbPars - nmbParsFixed, nmbPars - nmbParsFixed);
+	{
+		unsigned int iSkip = 0;
+		for (unsigned int i = 0; i < nmbPars; ++i) {
+			if (L.parFixed(i)) {
+				iSkip++;
+				continue;
+			}
+
+			unsigned int jSkip = 0;
+			for (unsigned int j = 0; j < nmbPars; ++j) {
+				if (L.parFixed(j)) {
+					jSkip++;
+					continue;
+				}
+
+				reducedMatrix[i - iSkip][j - jSkip] = matrix[i][j];
+			}
+		}
+	}
+
+	eigenvalues.ResizeTo(nmbPars - nmbParsFixed);
+	TMatrixT<T2> reducedEigenvectors = reducedMatrix.EigenVectors(eigenvalues);
+
+	eigenvectors.ResizeTo(nmbPars, nmbPars - nmbParsFixed);
+	{
+		unsigned int iSkip = 0;
+		for (unsigned int i = 0; i < nmbPars; ++i) {
+			if (L.parFixed(i)) {
+				for (unsigned int j = 0; j < nmbPars - nmbParsFixed; ++j) {
+					eigenvectors[i][j] = 0.;
+				}
+				iSkip++;
+				continue;
+			}
+
+			for (unsigned int j = 0; j < nmbPars - nmbParsFixed; ++j) {
+				eigenvectors[i][j] = reducedEigenvectors[i - iSkip][j];
+			}
+		}
+	}
+}
 
 
 #endif  // PARTIALWAVEFITHELPER_HH

--- a/partialWaveFit/pwafit.cc
+++ b/partialWaveFit/pwafit.cc
@@ -56,6 +56,7 @@
 #include "conversionUtils.hpp"
 #include "pwaLikelihood.h"
 #include "fitResult.h"
+#include "partialWaveFitHelper.h"
 #ifdef USE_CUDA
 #include "complex.cuh"
 #include "likelihoodInterface.cuh"
@@ -501,24 +502,10 @@ main(int    argc,
 		if (checkHessian) {
 			// analytically calculate Hessian
 			TMatrixT<double> hessian = L.Hessian(correctParams.data());
-			// create reduced hessian without fixed parameters
-			TMatrixT<double> reducedHessian(nmbPar - L.nmbParsFixed(), nmbPar - L.nmbParsFixed());
-			unsigned int iReduced = 0;
-			for(unsigned int i = 0; i < nmbPar; ++i) {
-				unsigned int jReduced = 0;
-				if (not L.parFixed(i)) {
-					for(unsigned int j = 0; j < nmbPar; ++j) {
-						if (not L.parFixed(j)) {
-							reducedHessian[iReduced][jReduced] = hessian[i][j];
-							jReduced++;
-						}
-					}
-					iReduced++;
-				}
-			}
 			// create and check Hessian eigenvalues
 			TVectorT<double> eigenvalues;
-			reducedHessian.EigenVectors(eigenvalues);
+			TMatrixT<double> eigenvectors;
+			rpwa::partialWaveFitHelper::getEigenvectors(L, hessian, eigenvectors, eigenvalues);
 			if (not quiet) {
 				printInfo << "eigenvalues of (analytic) Hessian:" << endl;
 			}

--- a/resonanceFit/CMakeLists.txt
+++ b/resonanceFit/CMakeLists.txt
@@ -71,4 +71,14 @@ make_shared_library(
 	)
 
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.6.3)
+		# workaround for presumably a compiler bug
+		set_source_files_properties(massDepFitComponents.cc
+		                            PROPERTIES
+		                            COMPILE_FLAGS "-Wno-uninitialized")
+	endif()
+endif()
+
+
 make_executable(pwaMassFit pwaMassFit.cc ${THIS_LIB})

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -779,42 +779,11 @@ rpwa::massDepFit::massDepFit::updateConfigModelComponents(const libconfig::Setti
 		return false;
 	}
 
-	const int nrComponents = configComponents->getLength();
-	if(nrComponents < 0 || static_cast<size_t>(nrComponents) != fitModel.getNrComponents()) {
-		printErr << "number of components in configuration file and fit model does not match." << std::endl;
-		return false;
-	}
-
-	printInfo << "updating " << nrComponents << " components in configuration file." << std::endl;
-
-	for(int idxComponent=0; idxComponent<nrComponents; ++idxComponent) {
+	const size_t nrComponents = fitModel.getNrComponents();
+	for(size_t idxComponent=0; idxComponent<nrComponents; ++idxComponent) {
 		const libconfig::Setting* configComponent = &((*configComponents)[idxComponent]);
-
-		std::map<std::string, libconfig::Setting::Type> mandatoryArguments;
-		boost::assign::insert(mandatoryArguments)
-		                     ("name", libconfig::Setting::TypeString);
-		if(not checkIfAllVariablesAreThere(configComponent, mandatoryArguments)) {
-			printErr << "'components' list in 'model' section in configuration file contains errors." << std::endl;
-			return false;
-		}
-
-		std::string name;
-		configComponent->lookupValue("name", name);
-
-		const rpwa::massDepFit::component* component = NULL;
-		for(size_t idx=0; idx<fitModel.getNrComponents(); ++idx) {
-			if(fitModel.getComponent(idx)->getName() == name) {
-				component = fitModel.getComponent(idx);
-				break;
-			}
-		}
-		if(not component) {
-			printErr << "could not find component '" << name << "' in fit model." << std::endl;
-			return false;
-		}
-
-		if(not component->update(configComponent, fitParameters, fitParametersError, fitModel.useBranchings(), _debug)) {
-			printErr << "error while updating component '" << name << "'." << std::endl;
+		if(not fitModel.getComponent(idxComponent)->update(configComponent, fitParameters, fitParametersError, fitModel.useBranchings(), _debug)) {
+			printErr << "error while updating component at index " << idxComponent << " for result file." << std::endl;
 			return false;
 		}
 	}

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -102,11 +102,11 @@ rpwa::massDepFit::massDepFit::readConfig(const libconfig::Setting* configRoot,
 	// input section
 	const libconfig::Setting* configInput = findLibConfigGroup(*configRoot, "input");
 	if(not configInput) {
-		printErr << "'input' section in configuration file does not exist." << std::endl;
+		printErr << "'input' does not exist in configuration file." << std::endl;
 		return false;
 	}
 	if(not readConfigInput(configInput)) {
-		printErr << "error while reading 'input' section from configuration file." << std::endl;
+		printErr << "error while reading 'input' in configuration file." << std::endl;
 		return false;
 	}
 
@@ -135,7 +135,7 @@ rpwa::massDepFit::massDepFit::readConfig(const libconfig::Setting* configRoot,
 		return false;
 	}
 	if(not readConfigModel(configModel, fitModel, fitParameters, fitParametersError)) {
-		printErr << "error while reading fit model from configuration file." << std::endl;
+		printErr << "error while reading 'model' in configuration file." << std::endl;
 		return false;
 	}
 
@@ -180,22 +180,22 @@ rpwa::massDepFit::massDepFit::readConfigInput(const libconfig::Setting* configIn
 	// get information about fit results from mass-independent
 	const libconfig::Setting* configInputFitResults = findLibConfigList(*configInput, "fitresults");
 	if(not configInputFitResults) {
-		printErr << "'fitresults' list does not exist in section '" << configInput->getName() << "' in configuration file." << std::endl;
+		printErr << "'fitresults' does not exist in 'input'." << std::endl;
 		return false;
 	}
 	if(not readConfigInputFitResults(configInputFitResults)) {
-		printErr << "error while reading 'fitresults' in section '" << configInput->getName() << "' in configuration file." << std::endl;
+		printErr << "error while reading 'fitresults' in 'input'." << std::endl;
 		return false;
 	}
 
 	// get information about waves to be used in the fit
 	const libconfig::Setting* configInputWaves = findLibConfigList(*configInput, "waves");
 	if(not configInputWaves) {
-		printErr << "'waves' list does not exist in section '" << configInput->getName() << "' in configuration file." << std::endl;
+		printErr << "'waves' does not exist in 'input'." << std::endl;
 		return false;
 	}
 	if(not readConfigInputWaves(configInputWaves)) {
-		printErr << "error while reading 'waves' in section '" << configInput->getName() << "' in configuration file." << std::endl;
+		printErr << "error while reading 'waves' in 'input'." << std::endl;
 		return false;
 	}
 
@@ -203,7 +203,7 @@ rpwa::massDepFit::massDepFit::readConfigInput(const libconfig::Setting* configIn
 	const libconfig::Setting* configInputSystematics = findLibConfigArray(*configInput, "systematics", false);
 	if(configInputSystematics) {
 		if(not readConfigInputSystematics(configInputSystematics)) {
-			printErr << "error while reading 'systematics' in section '" << configInput->getName() << "' in configuration file." << std::endl;
+			printErr << "error while reading 'systematics' in 'input'." << std::endl;
 			return false;
 		}
 	} else {
@@ -214,7 +214,7 @@ rpwa::massDepFit::massDepFit::readConfigInput(const libconfig::Setting* configIn
 	const libconfig::Setting* configInputFreeParameters = findLibConfigArray(*configInput, "freeparameters", false);
 	if(configInputFreeParameters) {
 		if(not readConfigInputFreeParameters(configInputFreeParameters)) {
-			printErr << "error while reading 'freeparameters' in section '" << configInput->getName() << "' in configuration file." << std::endl;
+			printErr << "error while reading 'freeparameters' in 'input'." << std::endl;
 			return false;
 		}
 	} else {
@@ -252,7 +252,7 @@ rpwa::massDepFit::massDepFit::readConfigInputFitResults(const libconfig::Setting
 		                     ("name", libconfig::Setting::TypeString)
 		                     ("tPrimeMean", libconfig::Setting::TypeFloat);
 		if(not checkIfAllVariablesAreThere(configInputFitResult, mandatoryArguments)) {
-			printErr << "'fitresults' list in 'input' section in configuration file contains errors." << std::endl;
+			printErr << "'fitresults' entry at index " << idxFitResult << " does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -331,7 +331,7 @@ rpwa::massDepFit::massDepFit::readConfigInputWaves(const libconfig::Setting* con
 		boost::assign::insert(mandatoryArguments)
 		                     ("name", libconfig::Setting::TypeString);
 		if(not checkIfAllVariablesAreThere(configInputWave, mandatoryArguments)) {
-			printErr << "'waves' list in 'input' section in configuration file contains errors." << std::endl;
+			printErr << "'waves' entry at index " << idxWave << " does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -430,23 +430,21 @@ rpwa::massDepFit::massDepFit::readConfigInputFreeParameters(const libconfig::Set
 	const int nrItems = configInputFreeParameters->getLength();
 
 	if(_debug) {
-		printDebug << "going to extract " << nrItems << " items from '" << configInputFreeParameters->getName() << "'." << std::endl;
+		printDebug << "going to extract " << nrItems << " items from 'freeparameters'." << std::endl;
 	}
 
 	for(int idxItem=0; idxItem<nrItems; ++idxItem) {
 		const libconfig::Setting& item = (*configInputFreeParameters)[idxItem];
 
 		if(item.getType() != libconfig::Setting::TypeString) {
-			printErr << "'" << configInputFreeParameters->getName() << "' must be array of strings." << std::endl;
+			printErr << "'freeparameters' entry at index " << idxItem << " is not a string." << std::endl;
 			return false;
 		}
 
 		const std::string name = item;
-
 		if(_debug) {
 			printDebug << idxItem << ": '" << name << "'." << std::endl;
 		}
-
 		_freeParameters.push_back(name);
 	}
 
@@ -461,7 +459,7 @@ rpwa::massDepFit::massDepFit::readConfigModel(const libconfig::Setting* configMo
                                               rpwa::massDepFit::parameters& fitParametersError)
 {
 	if(not configModel) {
-		printErr << "error while reading 'model' section in configuration file." << std::endl;
+		printErr << "'configModel' is not a pointer to a valid object." << std::endl;
 		return false;
 	}
 
@@ -476,7 +474,7 @@ rpwa::massDepFit::massDepFit::readConfigModel(const libconfig::Setting* configMo
 		return false;
 	}
 	if(not readConfigModelAnchorWave(configAnchorWave)) {
-		printErr << "error while reading 'anchorwave' in section '" << configModel->getName() << "' in configuration file." << std::endl;
+		printErr << "error while reading 'anchorwave' in 'model'." << std::endl;
 		return false;
 	}
 
@@ -487,7 +485,7 @@ rpwa::massDepFit::massDepFit::readConfigModel(const libconfig::Setting* configMo
 		return false;
 	}
 	if(not readConfigModelComponents(configComponents, fitModel, fitParameters, fitParametersError)) {
-		printErr << "error while reading 'components' in section '" << configModel->getName() << "' in configuration file." << std::endl;
+		printErr << "error while reading 'components' in 'model'." << std::endl;
 		return false;
 	}
 
@@ -495,7 +493,7 @@ rpwa::massDepFit::massDepFit::readConfigModel(const libconfig::Setting* configMo
 	const libconfig::Setting* configFsmd = findLibConfigGroup(*configModel, "finalStateMassDependence", false);
 	if(configFsmd) {
 		if(not readConfigModelFsmd(configFsmd, fitModel, fitParameters, fitParametersError)) {
-			printErr << "error while reading 'finalStateMassDependence' in section '" << configModel->getName() << "' in configuration file." << std::endl;
+			printErr << "error while reading 'finalStateMassDependence' in 'model'." << std::endl;
 			return false;
 		}
 	} else {
@@ -519,7 +517,7 @@ rpwa::massDepFit::massDepFit::readConfigModelAnchorWave(const libconfig::Setting
 	                     ("name", libconfig::Setting::TypeString)
 	                     ("resonance", libconfig::Setting::TypeString);
 	if(not checkIfAllVariablesAreThere(configAnchorWave, mandatoryArguments)) {
-		printErr << "'anchorwave' list in 'input' section in configuration file contains errors." << std::endl;
+		printErr << "'anchorwave' does not contain all required variables." << std::endl;
 		return false;
 	}
 
@@ -554,7 +552,7 @@ rpwa::massDepFit::massDepFit::readConfigModelComponents(const libconfig::Setting
 		boost::assign::insert(mandatoryArguments)
 		                     ("name", libconfig::Setting::TypeString);
 		if(not checkIfAllVariablesAreThere(configComponent, mandatoryArguments)) {
-			printErr << "'components' list in 'model' section in configuration file contains errors." << std::endl;
+			printErr << "'components' entry at index " << idxComponent << " does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -697,7 +695,7 @@ rpwa::massDepFit::massDepFit::updateConfig(libconfig::Setting* configRoot,
 
 	const libconfig::Setting* configModel = findLibConfigGroup(*configRoot, "model");
 	if(not updateConfigModel(configModel, fitModel, fitParameters, fitParametersError)) {
-		printErr << "error while updating 'model' section of configuration file." << std::endl;
+		printErr << "error while updating 'model' for result file." << std::endl;
 		return false;
 	}
 
@@ -740,18 +738,18 @@ rpwa::massDepFit::massDepFit::updateConfigModel(const libconfig::Setting* config
                                                 const rpwa::massDepFit::parameters& fitParametersError) const
 {
 	if(not configModel) {
-		printErr << "error while updating 'model' section in configuration file." << std::endl;
+		printErr << "'configModel' is not a pointer to a valid object." << std::endl;
 		return false;
 	}
 
 	if(_debug) {
-		printDebug << "updating fit model in configuration file." << std::endl;
+		printDebug << "updating 'fitmodel'." << std::endl;
 	}
 
 	// update information of the individual components
 	const libconfig::Setting* configComponents = findLibConfigList(*configModel, "components");
 	if(not updateConfigModelComponents(configComponents, fitModel, fitParameters, fitParametersError)) {
-		printErr << "error while updating 'components' in section '" << configModel->getName() << "' in configuration file." << std::endl;
+		printErr << "error while updating 'components' for result file." << std::endl;
 		return false;
 	}
 
@@ -759,7 +757,7 @@ rpwa::massDepFit::massDepFit::updateConfigModel(const libconfig::Setting* config
 	const libconfig::Setting* configFsmd = findLibConfigGroup(*configModel, "finalStateMassDependence", false);
 	if(fitModel.getFsmd() != NULL) {
 		if(not updateConfigModelFsmd(configFsmd, fitModel, fitParameters, fitParametersError)) {
-			printErr << "error while updating 'finalStateMassDependence' in section '" << configModel->getName() << "' in configuration file." << std::endl;
+			printErr << "error while updating 'finalStateMassDependence' for result file." << std::endl;
 			return false;
 		}
 	}
@@ -777,6 +775,10 @@ rpwa::massDepFit::massDepFit::updateConfigModelComponents(const libconfig::Setti
 	if(not configComponents) {
 		printErr << "'configComponents' is not a pointer to a valid object." << std::endl;
 		return false;
+	}
+
+	if(_debug) {
+		printDebug << "updating 'components'." << std::endl;
 	}
 
 	const size_t nrComponents = fitModel.getNrComponents();
@@ -804,7 +806,7 @@ rpwa::massDepFit::massDepFit::updateConfigModelFsmd(const libconfig::Setting* co
 	}
 
 	if(_debug) {
-		printDebug << "updating final-state mass-dependence in configuration file." << std::endl;
+		printDebug << "updating 'finalStateMassDependence'." << std::endl;
 	}
 
 	if(not fitModel.getFsmd()) {
@@ -813,7 +815,7 @@ rpwa::massDepFit::massDepFit::updateConfigModelFsmd(const libconfig::Setting* co
 	}
 
 	if(not fitModel.getFsmd()->update(configFsmd, fitParameters, fitParametersError, _debug)) {
-		printErr << "error while updating final-state mass-dependence." << std::endl;
+		printErr << "error while updating 'finalStateMassDependence' for result file." << std::endl;
 		return false;
 	}
 

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -112,23 +112,23 @@ rpwa::massDepFit::massDepFit::readConfig(const libconfig::Setting* configRoot,
 
 	// extract information from fit results
 	if(not readInFiles(valTreeName, valBranchName)) {
-		printErr << "error while trying to read fit result." << std::endl;
+		printErr << "error while reading fit result." << std::endl;
 		return false;
 	}
 
 	// extract information for systematic errors
 	if(not readSystematicsFiles(valTreeName, valBranchName)) {
-		printErr << "error while trying to read fit results for systematic errors." << std::endl;
+		printErr << "error while reading fit results for systematic errors." << std::endl;
 		return false;
 	}
 
 	// prepare mass limits
 	if(not prepareMassLimits()) {
-		printErr << "error determine which bins to use in the fit." << std::endl;
+		printErr << "error while determining which bins to use in the fit." << std::endl;
 		return false;
 	}
 
-	// set-up fit model (resonances, background, final-state mass dependence)
+	// set-up fit model (resonances, background, final-state mass-dependence)
 	const libconfig::Setting* configModel = findLibConfigGroup(*configRoot, "model");
 	if(not configModel) {
 		printErr << "'model' does not exist in configuration file." << std::endl;
@@ -497,7 +497,7 @@ rpwa::massDepFit::massDepFit::readConfigModel(const libconfig::Setting* configMo
 			return false;
 		}
 	} else {
-		printInfo << "not using final-state mass dependence." << std::endl;
+		printInfo << "not using final-state mass-dependence." << std::endl;
 	}
 
 	return true;
@@ -638,7 +638,7 @@ rpwa::massDepFit::massDepFit::readConfigModelFsmd(const libconfig::Setting* conf
 	}
 	fitModel.setFsmd(fsmd);
 
-	printInfo << "using final-state mass dependence as defined in the configuration file." << std::endl;
+	printInfo << "using final-state mass-dependence as defined in the configuration file." << std::endl;
 
 	return true;
 }
@@ -810,12 +810,12 @@ rpwa::massDepFit::massDepFit::updateConfigModelFsmd(const libconfig::Setting* co
 	}
 
 	if(not fitModel.getFsmd()) {
-		printErr << "updating of 'finalStateMassDependence' requested, but there is no final-state mass-dependence." << std::endl;
+		printErr << "updating final-state mass-dependence requested, but there is no final-state mass-dependence." << std::endl;
 		return false;
 	}
 
 	if(not fitModel.getFsmd()->update(configFsmd, fitParameters, fitParametersError, _debug)) {
-		printErr << "error while updating 'finalStateMassDependence' for result file." << std::endl;
+		printErr << "error while updating final-state mass-dependence for result file." << std::endl;
 		return false;
 	}
 
@@ -1221,7 +1221,7 @@ rpwa::massDepFit::massDepFit::checkFitResultMassBins(TTree* tree,
 		for(size_t idx=0; idx<mapping.size(); ++idx) {
 			output << " " << idx << "->" << mapping[idx];
 		}
-		printDebug << "etablished mapping:" << output.str() << std::endl;
+		printDebug << "established mapping:" << output.str() << std::endl;
 	}
 
 	return true;

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -585,7 +585,6 @@ rpwa::massDepFit::massDepFit::readConfigModelFsmd(const libconfig::Setting* conf
 
 bool
 rpwa::massDepFit::massDepFit::init(rpwa::massDepFit::model& fitModel,
-                                   rpwa::massDepFit::parameters& fitParameters,
                                    rpwa::massDepFit::function& fitFunction)
 {
 	if(not fitModel.init(_waveNames,

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -1066,7 +1066,10 @@ rpwa::massDepFit::massDepFit::readSystematicsFiles(const std::string& valTreeNam
 	_sysPhases[0] = _inPhases[0];
 
 	for(size_t idxSystematics=1; idxSystematics<_nrSystematics; ++idxSystematics) {
-		readSystematicsFile(idxSystematics, valTreeName, valBranchName);
+		if(not readSystematicsFile(idxSystematics, valTreeName, valBranchName)) {;
+			printErr << "error while reading fit results for systematic errors." << std::endl;
+			return false;
+		}
 	}
 
 	return true;

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -115,7 +115,7 @@ namespace rpwa {
 			bool readConfigInputSystematics(const libconfig::Setting* configInputSystematics);
 			bool readConfigInputFreeParameters(const libconfig::Setting* configInputFreeParameters);
 
-			bool readConfigModel(const libconfig::Setting* configRoot,
+			bool readConfigModel(const libconfig::Setting* configModel,
 			                     rpwa::massDepFit::model& fitModel,
 			                     rpwa::massDepFit::parameters& fitParameters,
 			                     rpwa::massDepFit::parameters& fitParametersError);

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -69,6 +69,9 @@ namespace rpwa {
 			bool readConfig(const libconfig::Setting* configRoot,
 			                rpwa::massDepFit::model& fitModel,
 			                rpwa::massDepFit::parameters& fitParameters,
+			                rpwa::massDepFit::parameters& fitParametersError,
+			                double& chi2,
+			                unsigned int& ndf,
 			                const std::string& valTreeName   = "pwa",
 			                const std::string& valBranchName = "fitResult_v2");
 
@@ -80,8 +83,7 @@ namespace rpwa {
 			                  const rpwa::massDepFit::parameters& fitParameters,
 			                  const rpwa::massDepFit::parameters& fitParametersError,
 			                  const double chi2,
-			                  const int ndf,
-			                  const double chi2red) const;
+			                  const unsigned int ndf) const;
 
 // FIXME: make private
 			bool createPlots(const rpwa::massDepFit::model& fitModel,
@@ -103,6 +105,10 @@ namespace rpwa {
 
 			bool prepareMassLimits();
 
+			bool readConfigFitquality(const libconfig::Setting* configFitquality,
+			                          double& chi2,
+			                          unsigned int& ndf) const;
+
 			bool readConfigInput(const libconfig::Setting* configInput);
 			bool readConfigInputFitResults(const libconfig::Setting* configInputFitResults);
 			bool readConfigInputWaves(const libconfig::Setting* configInputWaves);
@@ -111,14 +117,21 @@ namespace rpwa {
 
 			bool readConfigModel(const libconfig::Setting* configRoot,
 			                     rpwa::massDepFit::model& fitModel,
-			                     rpwa::massDepFit::parameters& fitParameters);
+			                     rpwa::massDepFit::parameters& fitParameters,
+			                     rpwa::massDepFit::parameters& fitParametersError);
 			bool readConfigModelAnchorWave(const libconfig::Setting* configAnchorWave);
 			bool readConfigModelComponents(const libconfig::Setting* configComponents,
 			                               rpwa::massDepFit::model& fitModel,
-			                               rpwa::massDepFit::parameters& fitParameters) const;
+			                               rpwa::massDepFit::parameters& fitParameters,
+			                               rpwa::massDepFit::parameters& fitParametersError) const;
 			bool readConfigModelFsmd(const libconfig::Setting* configFsmd,
 			                         rpwa::massDepFit::model& fitModel,
-			                         rpwa::massDepFit::parameters& fitParameters)  const;
+			                         rpwa::massDepFit::parameters& fitParameters,
+			                         rpwa::massDepFit::parameters& fitParametersError) const;
+
+			bool updateConfigFitquality(libconfig::Setting* configFitquality,
+			                            const double chi2,
+			                            const unsigned int ndf) const;
 
 			bool updateConfigModel(const libconfig::Setting* configModel,
 			                       const rpwa::massDepFit::model& fitModel,

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -73,7 +73,6 @@ namespace rpwa {
 			                const std::string& valBranchName = "fitResult_v2");
 
 			bool init(rpwa::massDepFit::model& fitModel,
-			          rpwa::massDepFit::parameters& fitParameters,
 			          rpwa::massDepFit::function& fitFunction);
 
 			bool updateConfig(libconfig::Setting* configRoot,

--- a/resonanceFit/massDepFitCache.h
+++ b/resonanceFit/massDepFitCache.h
@@ -67,6 +67,8 @@ namespace rpwa {
 
 		};
 
+		std::ostream& operator<< (std::ostream& out, const rpwa::massDepFit::cache& cache);
+
 	} // end namespace massDepFit
 
 } // end namespace rpwa
@@ -74,7 +76,7 @@ namespace rpwa {
 
 inline
 std::ostream&
-operator<< (std::ostream& out, const rpwa::massDepFit::cache& cache)
+rpwa::massDepFit::operator<< (std::ostream& out, const rpwa::massDepFit::cache& cache)
 {
 	return cache.print(out);
 }

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -92,9 +92,11 @@ rpwa::massDepFit::channel::operator=(rpwa::massDepFit::channel& other)
 
 rpwa::massDepFit::component::component(const size_t id,
                                        const std::string& name,
+                                       const std::string& type,
                                        const size_t nrParameters)
 	: _id(id),
 	  _name(name),
+	  _type(type),
 	  _nrParameters(nrParameters),
 	  _nrCouplings(0),
 	  _nrBranchings(0),
@@ -609,7 +611,7 @@ rpwa::massDepFit::component::print(std::ostream& out) const
 
 rpwa::massDepFit::fixedWidthBreitWigner::fixedWidthBreitWigner(const size_t id,
                                                                const std::string& name)
-	: component(id, name, 2)
+	: component(id, name, "fixedWidthBreitWigner", 2)
 {
 	_parametersName[0] = "mass";
 	_parametersName[1] = "width";
@@ -712,7 +714,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::print(std::ostream& out) const
 
 rpwa::massDepFit::dynamicWidthBreitWigner::dynamicWidthBreitWigner(const size_t id,
                                                                    const std::string& name)
-	: component(id, name, 2)
+	: component(id, name, "dynamicWidthBreitWigner", 2)
 {
 	_parametersName[0] = "mass";
 	_parametersName[1] = "width";
@@ -937,7 +939,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::print(std::ostream& out) const
 
 rpwa::massDepFit::integralWidthBreitWigner::integralWidthBreitWigner(const size_t id,
                                                                      const std::string& name)
-	: component(id, name, 2)
+	: component(id, name, "integralWidthBreitWigner", 2)
 {
 	_parametersName[0] = "mass";
 	_parametersName[1] = "width";
@@ -1192,7 +1194,7 @@ rpwa::massDepFit::integralWidthBreitWigner::print(std::ostream& out) const
 
 rpwa::massDepFit::exponentialBackground::exponentialBackground(const size_t id,
                                                                const std::string& name)
-	: component(id, name, 2)
+	: component(id, name, "exponentialBackground", 2)
 {
 	_parametersName[0] = "m0";
 	_parametersName[1] = "g";
@@ -1320,7 +1322,7 @@ rpwa::massDepFit::exponentialBackground::print(std::ostream& out) const
 
 rpwa::massDepFit::tPrimeDependentBackground::tPrimeDependentBackground(const size_t id,
                                                                        const std::string& name)
-	: component(id, name, 5)
+	: component(id, name, "tPrimeDependentBackground", 5)
 {
 	_parametersName[0] = "m0";
 	_parametersName[1] = "c0";

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -972,6 +972,9 @@ rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* confi
 			values.push_back((*integral)[1]);
 		}
 
+		_masses[idxDecayChannel] = masses;
+		_values[idxDecayChannel] = values;
+
 		assert(_interpolator[idxDecayChannel] == NULL); // huh, init called twice?
 		_interpolator[idxDecayChannel] = new ROOT::Math::Interpolator(masses, values, ROOT::Math::Interpolation::kLINEAR);
 
@@ -1022,6 +1025,9 @@ rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* confi
 			masses.push_back((*integral)[0]);
 			values.push_back((*integral)[1]);
 		}
+
+		_masses[idxDecayChannel] = masses;
+		_values[idxDecayChannel] = values;
 
 		assert(_interpolator[nrDecayChannels + idxExtraDecayChannel] == NULL); // huh, init called twice?
 		_interpolator[nrDecayChannels + idxExtraDecayChannel] = new ROOT::Math::Interpolator(masses, values, ROOT::Math::Interpolation::kLINEAR);

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -125,7 +125,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
                                   const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'component' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'component' for component '" << getName() << "'." << std::endl;
 	}
 
 	// resize fitParamters without affecting the number of channels first
@@ -148,7 +148,6 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 		boost::assign::insert(mandatoryArguments)
 		                     ("val", libconfig::Setting::TypeFloat)
 		                     ("fix", libconfig::Setting::TypeBoolean);
-
 		if(not checkIfAllVariablesAreThere(configParameter, mandatoryArguments)) {
 			printErr << "'" << _parametersName[idxParameter] << "' of component '" << getName() << "' does not contain all required variables." << std::endl;
 			return false;
@@ -370,7 +369,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 	}
 
 	if(debug) {
-		printDebug << "finished initialization of 'component'." << std::endl;
+		printDebug << "finished initializing 'component'." << std::endl;
 	}
 
 	return true;
@@ -394,7 +393,7 @@ rpwa::massDepFit::component::update(const libconfig::Setting* configComponent,
                                     const bool debug) const
 {
 	if(debug) {
-		printDebug << "starting updating of 'component' for component '" << getName() << "'." << std::endl;
+		printDebug << "start updating 'component' for component '" << getName() << "'." << std::endl;
 		print(printDebug);
 	}
 
@@ -410,7 +409,6 @@ rpwa::massDepFit::component::update(const libconfig::Setting* configComponent,
 		if(not configParameter->exists("error")) {
 			configParameter->add("error", libconfig::Setting::TypeFloat);
 		}
-
 		(*configParameter)["error"] = fitParametersError.getParameter(getId(), idxParameter);
 	}
 
@@ -441,7 +439,7 @@ rpwa::massDepFit::component::update(const libconfig::Setting* configComponent,
 	}
 
 	if(debug) {
-		printDebug << "finished updating of 'component'." << std::endl;
+		printDebug << "finished updating 'component'." << std::endl;
 	}
 
 	return true;
@@ -582,7 +580,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::init(const libconfig::Setting* configCo
                                               const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'fixedWidthBreitWigner' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'fixedWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
 	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
@@ -592,7 +590,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::init(const libconfig::Setting* configCo
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of 'fixedWidthBreitWigner'." << std::endl;
+		printDebug << "finished initializing 'fixedWidthBreitWigner'." << std::endl;
 	}
 
 	return true;
@@ -685,7 +683,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::init(const libconfig::Setting* config
                                                 const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'dynamicWidthBreitWigner' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'dynamicWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
 	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
@@ -725,7 +723,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::init(const libconfig::Setting* config
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of 'dynamicWidthBreitWigner'." << std::endl;
+		printDebug << "finished initializing 'dynamicWidthBreitWigner'." << std::endl;
 	}
 	return true;
 }
@@ -737,7 +735,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::readDecayChannel(const libconfig::Set
                                                             const bool debug)
 {
 	if(debug) {
-		printDebug << "start initializing of decay channel at index " << idxDecayChannel << " in 'dynamicWidthBreitWigner' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing decay channel at index " << idxDecayChannel << " in 'dynamicWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
 	// make sure there are no holes in the vectors
@@ -908,7 +906,7 @@ rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* confi
                                                  const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
 	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
@@ -948,7 +946,7 @@ rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* confi
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of 'integralWidthBreitWigner'." << std::endl;
+		printDebug << "finished initializing 'integralWidthBreitWigner'." << std::endl;
 	}
 	return true;
 }
@@ -960,7 +958,7 @@ rpwa::massDepFit::integralWidthBreitWigner::readDecayChannel(const libconfig::Se
                                                              const bool debug)
 {
 	if(debug) {
-		printDebug << "start initializing of decay channel at index " << idxDecayChannel << " in 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing decay channel at index " << idxDecayChannel << " in 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
 	// make sure there are no holes in the vectors
@@ -1129,7 +1127,7 @@ rpwa::massDepFit::exponentialBackground::init(const libconfig::Setting* configCo
                                               const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'exponentialBackground' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'exponentialBackground' for component '" << getName() << "'." << std::endl;
 	}
 
 	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
@@ -1156,7 +1154,7 @@ rpwa::massDepFit::exponentialBackground::init(const libconfig::Setting* configCo
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of 'exponentialBackground'." << std::endl;
+		printDebug << "finished initializing 'exponentialBackground'." << std::endl;
 	}
 
 	return true;
@@ -1272,7 +1270,7 @@ rpwa::massDepFit::tPrimeDependentBackground::init(const libconfig::Setting* conf
                                                   const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of 'tPrimeDependentBackground' for component '" << getName() << "'." << std::endl;
+		printDebug << "start initializing 'tPrimeDependentBackground' for component '" << getName() << "'." << std::endl;
 	}
 
 	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
@@ -1304,7 +1302,7 @@ rpwa::massDepFit::tPrimeDependentBackground::init(const libconfig::Setting* conf
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of 'tPrimeDependentBackground'." << std::endl;
+		printDebug << "finished initializing 'tPrimeDependentBackground'." << std::endl;
 	}
 
 	return true;

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -676,6 +676,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::print(std::ostream& out) const
 	out << "component " << getId() << " '" << getName() << "' (fixedWidthBreitWigner):" << std::endl;
 
 	out << "    mass ";
+	out << "start value: " << _parametersStart[0] << " +/- " << _parametersError[0] << " ";
 	if(_parametersLimitedLower[0] && _parametersLimitedUpper[0]) {
 		out << "limits: " << _parametersLimitLower[0] << "-" << _parametersLimitUpper[0] << " GeV/c^2";
 	} else if(_parametersLimitedLower[0]) {
@@ -688,6 +689,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::print(std::ostream& out) const
 	out << (_parametersFixed[0] ? " (FIXED)" : "") << std::endl;
 
 	out << "    width ";
+	out << "start value: " << _parametersStart[1] << " +/- " << _parametersError[1] << " ";
 	if(_parametersLimitedLower[1] && _parametersLimitedUpper[1]) {
 		out << "limits: " << _parametersLimitLower[1] << "-" << _parametersLimitUpper[1] << " GeV/c^2";
 	} else if(_parametersLimitedLower[1]) {
@@ -891,6 +893,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::print(std::ostream& out) const
 	out << "component " << getId() << " '" << getName() << "' (dynamicWidthBreitWigner):" << std::endl;
 
 	out << "    mass ";
+	out << "start value: " << _parametersStart[0] << " +/- " << _parametersError[0] << " ";
 	if(_parametersLimitedLower[0] && _parametersLimitedUpper[0]) {
 		out << "limits: " << _parametersLimitLower[0] << "-" << _parametersLimitUpper[0] << " GeV/c^2";
 	} else if(_parametersLimitedLower[0]) {
@@ -903,6 +906,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::print(std::ostream& out) const
 	out << (_parametersFixed[0] ? " (FIXED)" : "") << std::endl;
 
 	out << "    width ";
+	out << "start value: " << _parametersStart[1] << " +/- " << _parametersError[1] << " ";
 	if(_parametersLimitedLower[1] && _parametersLimitedUpper[1]) {
 		out << "limits: " << _parametersLimitLower[1] << "-" << _parametersLimitUpper[1] << " GeV/c^2";
 	} else if(_parametersLimitedLower[1]) {
@@ -1150,6 +1154,7 @@ rpwa::massDepFit::integralWidthBreitWigner::print(std::ostream& out) const
 	out << "component " << getId() << " '" << getName() << "' (integralWidthBreitWigner):" << std::endl;
 
 	out << "    mass ";
+	out << "start value: " << _parametersStart[0] << " +/- " << _parametersError[0] << " ";
 	if(_parametersLimitedLower[0] && _parametersLimitedUpper[0]) {
 		out << "limits: " << _parametersLimitLower[0] << "-" << _parametersLimitUpper[0] << " GeV/c^2";
 	} else if(_parametersLimitedLower[0]) {
@@ -1162,6 +1167,7 @@ rpwa::massDepFit::integralWidthBreitWigner::print(std::ostream& out) const
 	out << (_parametersFixed[0] ? " (FIXED)" : "") << std::endl;
 
 	out << "    width ";
+	out << "start value: " << _parametersStart[1] << " +/- " << _parametersError[1] << " ";
 	if(_parametersLimitedLower[1] && _parametersLimitedUpper[1]) {
 		out << "limits: " << _parametersLimitLower[1] << "-" << _parametersLimitUpper[1] << " GeV/c^2";
 	} else if(_parametersLimitedLower[1]) {
@@ -1273,6 +1279,7 @@ rpwa::massDepFit::exponentialBackground::print(std::ostream& out) const
 	out << "component " << getId() << " '" << getName() << "' (exponentialBackground):" << std::endl;
 
 	out << "    mass threshold ";
+	out << "start value: " << _parametersStart[0] << " +/- " << _parametersError[0] << " ";
 	if(_parametersLimitedLower[0] && _parametersLimitedUpper[0]) {
 		out << "limits: " << _parametersLimitLower[0] << "-" << _parametersLimitUpper[0] << " GeV/c^2";
 	} else if(_parametersLimitedLower[0]) {
@@ -1285,6 +1292,7 @@ rpwa::massDepFit::exponentialBackground::print(std::ostream& out) const
 	out << (_parametersFixed[0] ? " (FIXED)" : "") << std::endl;
 
 	out << "    width ";
+	out << "start value: " << _parametersStart[1] << " +/- " << _parametersError[1] << " ";
 	if(_parametersLimitedLower[1] && _parametersLimitedUpper[1]) {
 		out << "limits: " << _parametersLimitLower[1] << "-" << _parametersLimitUpper[1] << " GeV/c^2";
 	} else if(_parametersLimitedLower[1]) {
@@ -1418,6 +1426,7 @@ rpwa::massDepFit::tPrimeDependentBackground::print(std::ostream& out) const
 	out << "component " << getId() << " '" << getName() << "' (tPrimeDependentBackground):" << std::endl;
 
 	out << "    mass threshold ";
+	out << "start value: " << _parametersStart[0] << " +/- " << _parametersError[0] << " ";
 	if(_parametersLimitedLower[0] && _parametersLimitedUpper[0]) {
 		out << "limits: " << _parametersLimitLower[0] << "-" << _parametersLimitUpper[0] << " GeV/c^2";
 	} else if(_parametersLimitedLower[0]) {
@@ -1431,6 +1440,7 @@ rpwa::massDepFit::tPrimeDependentBackground::print(std::ostream& out) const
 
 	for(size_t i=1; i<5; ++i) {
 		out << "    c" << i-1 << " ";
+		out << "start value: " << _parametersStart[i] << " +/- " << _parametersError[i] << " ";
 		if(_parametersLimitedLower[i] && _parametersLimitedUpper[i]) {
 			out << "limits: " << _parametersLimitLower[i] << "-" << _parametersLimitUpper[i] << " GeV/c^2";
 		} else if(_parametersLimitedLower[i]) {
@@ -1445,7 +1455,7 @@ rpwa::massDepFit::tPrimeDependentBackground::print(std::ostream& out) const
 
 	out << "    mass of isobar 1: " << _m1 << " GeV/c^2, mass of isobar 2: " << _m2 << " GeV/c^2" << std::endl;
 
-	out << "    for " << _tPrimeMeans.size() << " bins with mean t' values: " << _tPrimeMeans[0];
+	out << "    for " << _tPrimeMeans.size() << " bin" << ((_tPrimeMeans.size()>1)?"s":"") << " with mean t' value" << ((_tPrimeMeans.size()>1)?"s":"") << ": " << _tPrimeMeans[0];
 	for(size_t i=1; i<_tPrimeMeans.size(); ++i) {
 		out << ", " << _tPrimeMeans[i];
 	}

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -114,6 +114,7 @@ rpwa::massDepFit::component::component(const size_t id,
 bool
 rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
                                   rpwa::massDepFit::parameters& fitParameters,
+                                  rpwa::massDepFit::parameters& fitParametersError,
                                   const size_t nrBins,
                                   const std::vector<double>& massBinCenters,
                                   const std::map<std::string, size_t>& waveIndices,
@@ -128,6 +129,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 	// resize fitParamters without affecting the number of channels first
 	// as this is not yet known
 	fitParameters.resize(_id+1, 0, _nrParameters, nrBins);
+	fitParametersError.resize(_id+1, 0, _nrParameters, nrBins);
 
 	for(size_t idxParameter=0; idxParameter<_nrParameters; ++idxParameter) {
 		if(debug) {
@@ -158,6 +160,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 		double error;
 		if(configParameter->lookupValue("error", error)) {
 			_parametersError[idxParameter] = error;
+			fitParametersError.setParameter(getId(), idxParameter, error);
 		}
 
 		bool fixed;
@@ -183,6 +186,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 
 	// resize fitParamters to the correct number of channels
 	fitParameters.resize(_id+1, nrDecayChannels, _nrParameters, nrBins);
+	fitParametersError.resize(_id+1, nrDecayChannels, _nrParameters, nrBins);
 
 	std::map<std::string, size_t> couplingsQN;
 	std::map<std::string, size_t> branchingDecay;
@@ -618,6 +622,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::fixedWidthBreitWigner(const size_t id,
 bool
 rpwa::massDepFit::fixedWidthBreitWigner::init(const libconfig::Setting* configComponent,
                                               rpwa::massDepFit::parameters& fitParameters,
+                                              rpwa::massDepFit::parameters& fitParametersError,
                                               const size_t nrBins,
                                               const std::vector<double>& massBinCenters,
                                               const std::map<std::string, size_t>& waveIndices,
@@ -629,7 +634,7 @@ rpwa::massDepFit::fixedWidthBreitWigner::init(const libconfig::Setting* configCo
 		printDebug << "starting initialization of 'fixedWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
-	if(not component::init(configComponent, fitParameters, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
+	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
 		printErr << "error while reading configuration of 'component' class." << std::endl;
 		return false;
 	}
@@ -720,6 +725,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::dynamicWidthBreitWigner(const size_t 
 bool
 rpwa::massDepFit::dynamicWidthBreitWigner::init(const libconfig::Setting* configComponent,
                                                 rpwa::massDepFit::parameters& fitParameters,
+                                                rpwa::massDepFit::parameters& fitParametersError,
                                                 const size_t nrBins,
                                                 const std::vector<double>& massBinCenters,
                                                 const std::map<std::string, size_t>& waveIndices,
@@ -731,7 +737,7 @@ rpwa::massDepFit::dynamicWidthBreitWigner::init(const libconfig::Setting* config
 		printDebug << "starting initialization of 'dynamicWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
-	if(not component::init(configComponent, fitParameters, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
+	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
 		printErr << "error while reading configuration of 'component' class." << std::endl;
 		return false;
 	}
@@ -955,6 +961,7 @@ rpwa::massDepFit::integralWidthBreitWigner::~integralWidthBreitWigner()
 bool
 rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* configComponent,
                                                  rpwa::massDepFit::parameters& fitParameters,
+                                                 rpwa::massDepFit::parameters& fitParametersError,
                                                  const size_t nrBins,
                                                  const std::vector<double>& massBinCenters,
                                                  const std::map<std::string, size_t>& waveIndices,
@@ -966,7 +973,7 @@ rpwa::massDepFit::integralWidthBreitWigner::init(const libconfig::Setting* confi
 		printDebug << "starting initialization of 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
 	}
 
-	if(not component::init(configComponent, fitParameters, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
+	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
 		printErr << "error while reading configuration of 'component' class." << std::endl;
 		return false;
 	}
@@ -1198,6 +1205,7 @@ rpwa::massDepFit::exponentialBackground::exponentialBackground(const size_t id,
 bool
 rpwa::massDepFit::exponentialBackground::init(const libconfig::Setting* configComponent,
                                               rpwa::massDepFit::parameters& fitParameters,
+                                              rpwa::massDepFit::parameters& fitParametersError,
                                               const size_t nrBins,
                                               const std::vector<double>& massBinCenters,
                                               const std::map<std::string, size_t>& waveIndices,
@@ -1209,7 +1217,7 @@ rpwa::massDepFit::exponentialBackground::init(const libconfig::Setting* configCo
 		printDebug << "starting initialization of 'exponentialBackground' for component '" << getName() << "'." << std::endl;
 	}
 
-	if(not component::init(configComponent, fitParameters, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
+	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
 		printErr << "error while reading configuration of 'component' class." << std::endl;
 		return false;
 	}
@@ -1340,6 +1348,7 @@ rpwa::massDepFit::tPrimeDependentBackground::setTPrimeMeans(const std::vector<do
 bool
 rpwa::massDepFit::tPrimeDependentBackground::init(const libconfig::Setting* configComponent,
                                                   rpwa::massDepFit::parameters& fitParameters,
+                                                  rpwa::massDepFit::parameters& fitParametersError,
                                                   const size_t nrBins,
                                                   const std::vector<double>& massBinCenters,
                                                   const std::map<std::string, size_t>& waveIndices,
@@ -1351,7 +1360,7 @@ rpwa::massDepFit::tPrimeDependentBackground::init(const libconfig::Setting* conf
 		printDebug << "starting initialization of 'tPrimeDependentBackground' for component '" << getName() << "'." << std::endl;
 	}
 
-	if(not component::init(configComponent, fitParameters, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
+	if(not component::init(configComponent, fitParameters, fitParametersError, nrBins, massBinCenters, waveIndices, phaseSpaceIntegrals, useBranchings, debug)) {
 		printErr << "error while reading configuration of 'component' class." << std::endl;
 		return false;
 	}

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -140,7 +140,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 
 		const libconfig::Setting* configParameter = findLibConfigGroup(*configComponent, _parametersName[idxParameter]);
 		if(not configParameter) {
-			printErr << "component '" << getName() << "' has no section '" << _parametersName[idxParameter] << "'." << std::endl;
+			printErr << "component '" << getName() << "' does not define parameter '" << _parametersName[idxParameter] << "'." << std::endl;
 			return false;
 		}
 
@@ -150,7 +150,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 		                     ("fix", libconfig::Setting::TypeBoolean);
 
 		if(not checkIfAllVariablesAreThere(configParameter, mandatoryArguments)) {
-			printErr << "the '" << _parametersName[idxParameter] << "' section of the component '" << getName() << "' does not contain all required fields." << std::endl;
+			printErr << "'" << _parametersName[idxParameter] << "' of component '" << getName() << "' does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -199,7 +199,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 		boost::assign::insert(mandatoryArguments)
 		                     ("amp", libconfig::Setting::TypeString);
 		if(not checkIfAllVariablesAreThere(decayChannel, mandatoryArguments)) {
-			printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required fields." << std::endl;
+			printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -263,7 +263,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 			boost::assign::insert(mandatoryArguments)
 			                     ("couplings", libconfig::Setting::TypeList);
 			if(not checkIfAllVariablesAreThere(decayChannel, mandatoryArguments)) {
-				printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required fields." << std::endl;
+				printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required variables." << std::endl;
 				return false;
 			}
 
@@ -287,7 +287,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 				                     ("coupling_Re", libconfig::Setting::TypeFloat)
 				                     ("coupling_Im", libconfig::Setting::TypeFloat);
 				if(not checkIfAllVariablesAreThere(configCoupling, mandatoryArguments)) {
-					printErr << "one of the couplings of the decay channel '" << waveName << "' of the component '" << getName() << "' does not contain all required fields." << std::endl;
+					printErr << "one of the couplings of the decay channel '" << waveName << "' of the component '" << getName() << "' does not contain all required variables." << std::endl;
 					return false;
 				}
 
@@ -312,7 +312,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 			boost::assign::insert(mandatoryArguments)
 			                     ("branching", libconfig::Setting::TypeGroup);
 			if(not checkIfAllVariablesAreThere(decayChannel, mandatoryArguments)) {
-				printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required fields." << std::endl;
+				printErr << "one of the decay channels of the component '" << getName() << "' does not contain all required variables." << std::endl;
 				return false;
 			}
 
@@ -327,7 +327,7 @@ rpwa::massDepFit::component::init(const libconfig::Setting* configComponent,
 			                     ("branching_Re", libconfig::Setting::TypeFloat)
 			                     ("branching_Im", libconfig::Setting::TypeFloat);
 			if(not checkIfAllVariablesAreThere(configBranching, mandatoryArguments)) {
-				printErr << "branching of the decay channel '" << waveName << "' of the component '" << getName() << "' does not contain all required fields." << std::endl;
+				printErr << "branching of the decay channel '" << waveName << "' of the component '" << getName() << "' does not contain all required variables." << std::endl;
 				return false;
 			}
 

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -982,6 +982,11 @@ rpwa::massDepFit::integralWidthBreitWigner::readDecayChannel(const libconfig::Se
 	const libconfig::Setting* integrals = &((*decayChannel)["integral"]);
 
 	const int nrValues = integrals->getLength();
+	if(nrValues < 2) {
+		printErr << "phase-space integrals of component '" << getName() << "' has to contain at least two points." << std::endl;
+		return false;
+	}
+
 	std::vector<double> masses;
 	std::vector<double> values;
 

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -296,8 +296,10 @@ namespace rpwa {
 
 		private:
 
-			std::vector<double> _ratio;
+			std::vector<std::vector<double> > _masses;
+			std::vector<std::vector<double> > _values;
 			std::vector<ROOT::Math::Interpolator*> _interpolator;
+			std::vector<double> _ratio;
 
 		};
 

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -69,7 +69,7 @@ namespace rpwa {
 			rpwa::massDepFit::channel& operator=(rpwa::massDepFit::channel& other);
 #endif
 
-			const size_t getWaveIdx() const { return _waveIdx; }
+			size_t getWaveIdx() const { return _waveIdx; }
 			const std::string& getWaveName() const { return _waveName; }
 
 			bool isAnchor() const { return _anchor; }

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -119,6 +119,9 @@ namespace rpwa {
 			                  const boost::multi_array<double, 3>& phaseSpaceIntegrals,
 			                  const bool useBranchings,
 			                  const bool debug);
+			virtual bool readDecayChannel(const libconfig::Setting* decayChannel,
+			                              const size_t idxDecayChannel,
+			                              const bool debug);
 
 			virtual bool update(const libconfig::Setting* configComponent,
 			                    const rpwa::massDepFit::parameters& fitParameters,
@@ -250,6 +253,9 @@ namespace rpwa {
 			                  const boost::multi_array<double, 3>& phaseSpaceIntegrals,
 			                  const bool useBranchings,
 			                  const bool debug);
+			virtual bool readDecayChannel(const libconfig::Setting* decayChannel,
+			                              const size_t idxDecayChannel,
+			                              const bool debug);
 
 			virtual std::complex<double> val(const rpwa::massDepFit::parameters& fitParameters,
 			                                 rpwa::massDepFit::cache& cache,
@@ -285,6 +291,9 @@ namespace rpwa {
 			                  const boost::multi_array<double, 3>& phaseSpaceIntegrals,
 			                  const bool useBranchings,
 			                  const bool debug);
+			virtual bool readDecayChannel(const libconfig::Setting* decayChannel,
+			                              const size_t idxDecayChannel,
+			                              const bool debug);
 
 			virtual std::complex<double> val(const rpwa::massDepFit::parameters& fitParameters,
 			                                 rpwa::massDepFit::cache& cache,

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -210,6 +210,8 @@ namespace rpwa {
 
 		};
 
+		std::ostream& operator<< (std::ostream& out, const rpwa::massDepFit::component& component);
+
 		class fixedWidthBreitWigner : public component {
 
 		public:
@@ -432,7 +434,7 @@ rpwa::massDepFit::component::getCouplingPhaseSpace(const rpwa::massDepFit::param
 
 inline
 std::ostream&
-operator<< (std::ostream& out, const rpwa::massDepFit::component& component)
+rpwa::massDepFit::operator<< (std::ostream& out, const rpwa::massDepFit::component& component)
 {
 	return component.print(out);
 }

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -102,11 +102,13 @@ namespace rpwa {
 
 			component(const size_t id,
 			          const std::string& name,
+			          const std::string& type,
 			          const size_t nrParameters);
 			virtual ~component() {};
 
 			size_t getId() const { return _id; }
 			const std::string& getName() const { return _name; }
+			const std::string& getType() const { return _type; }
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
@@ -178,6 +180,7 @@ namespace rpwa {
 
 			const size_t _id;
 			const std::string _name;
+			const std::string _type;
 
 			std::vector<channel> _channels;
 			std::vector<size_t> _channelsCoupling;

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -110,6 +110,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,
@@ -212,6 +213,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,
@@ -238,6 +240,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,
@@ -272,6 +275,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,
@@ -303,6 +307,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,
@@ -336,6 +341,7 @@ namespace rpwa {
 
 			virtual bool init(const libconfig::Setting* configComponent,
 			                  rpwa::massDepFit::parameters& fitParameters,
+			                  rpwa::massDepFit::parameters& fitParametersError,
 			                  const size_t nrBins,
 			                  const std::vector<double>& massBinCenters,
 			                  const std::map<std::string, size_t>& waveIndices,

--- a/resonanceFit/massDepFitFsmd.cc
+++ b/resonanceFit/massDepFitFsmd.cc
@@ -60,6 +60,7 @@ rpwa::massDepFit::fsmd::~fsmd()
 bool
 rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
                              rpwa::massDepFit::parameters& fitParameters,
+                             rpwa::massDepFit::parameters& fitParametersError,
                              const std::vector<double>& massBinCenters,
                              const bool debug)
 {
@@ -149,9 +150,11 @@ rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
 	_parametersStep.resize(_nrParameters);
 
 	fitParameters.resize(_id+1, 0, _nrParameters, 0);
+	fitParametersError.resize(_id+1, 0, _nrParameters, 0);
 
 	for(size_t idxParameter=0; idxParameter<_nrParameters; ++idxParameter) {
 		fitParameters.setParameter(_id, idxParameter, configFsmdValue[idxParameter]);
+		fitParametersError.setParameter(_id, idxParameter, configFsmdError[idxParameter]);
 		_parametersFixed[idxParameter] = configFsmdFix[idxParameter];
 		_parametersLimitLower[idxParameter] = configFsmdLower[idxParameter];
 		_parametersLimitedLower[idxParameter] = true;

--- a/resonanceFit/massDepFitFsmd.cc
+++ b/resonanceFit/massDepFitFsmd.cc
@@ -65,14 +65,14 @@ rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
                              const bool debug)
 {
 	if(debug) {
-		printDebug << "starting initialization of final-state mass-dependence." << std::endl;
+		printDebug << "start initializing final-state mass-dependence." << std::endl;
 	}
 
 	std::map<std::string, libconfig::Setting::Type> mandatoryArguments;
 	boost::assign::insert(mandatoryArguments)
 	                     ("formula", libconfig::Setting::TypeString);
 	if(not checkIfAllVariablesAreThere(configFsmd, mandatoryArguments)) {
-		printErr << "'finalStateMassDependence' section in configuration file contains errors." << std::endl;
+		printErr << "'finalStateMassDependence' does not contain all required variables." << std::endl;
 		return false;
 	}
 
@@ -106,7 +106,7 @@ rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
 
 		const libconfig::Setting* configParameter = findLibConfigGroup(*configFsmd, parName.str());
 		if (not configParameter) {
-			printErr << "final-state mass dependence does not define parameter '" << parName.str() << "'." << std::endl;
+			printErr << "final-state mass-dependence does not define parameter '" << parName.str() << "'." << std::endl;
 			return false;
 		}
 
@@ -115,7 +115,7 @@ rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
 		                     ("val", libconfig::Setting::TypeFloat)
 		                     ("fix", libconfig::Setting::TypeBoolean);
 		if(not checkIfAllVariablesAreThere(configParameter, mandatoryArguments)) {
-			printErr << "'" << parName.str() << "' of final-state mass dependence does not contain all required variables." << std::endl;
+			printErr << "'" << parName.str() << "' of final-state mass-dependence does not contain all required variables." << std::endl;
 			return false;
 		}
 
@@ -143,7 +143,7 @@ rpwa::massDepFit::fsmd::init(const libconfig::Setting* configFsmd,
 
 	if(debug) {
 		print(printDebug);
-		printDebug << "finished initialization of final-state mass-dependence." << std::endl;
+		printDebug << "finished initializing final-state mass-dependence." << std::endl;
 	}
 
 	return true;
@@ -176,7 +176,6 @@ rpwa::massDepFit::fsmd::update(const libconfig::Setting* configFsmd,
 		if(not configParameter->exists("error")) {
 			configParameter->add("error", libconfig::Setting::TypeFloat);
 		}
-
 		(*configParameter)["error"] = fitParametersError.getParameter(_id, idxParameter);
 	}
 

--- a/resonanceFit/massDepFitFsmd.cc
+++ b/resonanceFit/massDepFitFsmd.cc
@@ -179,7 +179,7 @@ rpwa::massDepFit::fsmd::update(const libconfig::Setting* configFsmd,
                                const bool debug) const
 {
 	if(debug) {
-		printDebug << "starting updating of final-state mass-dependence." << std::endl;
+		printDebug << "updating final-state mass-dependence." << std::endl;
 	}
 
 	const libconfig::Setting& configFsmdValue = (*configFsmd)["val"];
@@ -188,10 +188,6 @@ rpwa::massDepFit::fsmd::update(const libconfig::Setting* configFsmd,
 	for(size_t idxParameter=0; idxParameter<_nrParameters; ++idxParameter) {
 		configFsmdValue[idxParameter] = fitParameters.getParameter(_id, idxParameter);
 		configFsmdError[idxParameter] = fitParametersError.getParameter(_id, idxParameter);
-	}
-
-	if(debug) {
-		printDebug << "finished updating of final-state mass-dependence." << std::endl;
 	}
 
 	return true;

--- a/resonanceFit/massDepFitFsmd.h
+++ b/resonanceFit/massDepFitFsmd.h
@@ -98,7 +98,6 @@ namespace rpwa {
 			std::vector<bool> _parametersLimitedLower;
 			std::vector<double> _parametersLimitUpper;
 			std::vector<bool> _parametersLimitedUpper;
-			std::vector<std::string> _parametersName;
 			std::vector<double> _parametersStep;
 		};
 

--- a/resonanceFit/massDepFitFsmd.h
+++ b/resonanceFit/massDepFitFsmd.h
@@ -101,6 +101,8 @@ namespace rpwa {
 			std::vector<double> _parametersStep;
 		};
 
+		std::ostream& operator<< (std::ostream& out, const rpwa::massDepFit::fsmd& fsmd);
+
 	} // end namespace massDepFit
 
 } // end namespace rpwa
@@ -108,7 +110,7 @@ namespace rpwa {
 
 inline
 std::ostream&
-operator<< (std::ostream& out, const rpwa::massDepFit::fsmd& fsmd)
+rpwa::massDepFit::operator<< (std::ostream& out, const rpwa::massDepFit::fsmd& fsmd)
 {
 	return fsmd.print(out);
 }

--- a/resonanceFit/massDepFitFsmd.h
+++ b/resonanceFit/massDepFitFsmd.h
@@ -57,6 +57,7 @@ namespace rpwa {
 
 			bool init(const libconfig::Setting* configComponent,
 			          rpwa::massDepFit::parameters& fitParameters,
+			          rpwa::massDepFit::parameters& fitParametersError,
 			          const std::vector<double>& massBinCenters,
 			          const bool debug);
 

--- a/resonanceFit/massDepFitFunction.cc
+++ b/resonanceFit/massDepFitFunction.cc
@@ -490,7 +490,7 @@ rpwa::massDepFit::function::chiSquare(const std::vector<double>& par) const
 double
 rpwa::massDepFit::function::chiSquare(const double* par) const
 {
-#if __cplusplus >= 201103L
+#ifdef COMPILER_PROVIDES_THREAD_LOCAL
 	// in C++11 we can use a static variable per thread so that the
 	// parameters are kept over function calls and we can implement some
 	// caching

--- a/resonanceFit/massDepFitModel.h
+++ b/resonanceFit/massDepFitModel.h
@@ -140,6 +140,8 @@ namespace rpwa {
 
 		};
 
+		std::ostream& operator<< (std::ostream& out, const rpwa::massDepFit::model& fitModel);
+
 	} // end namespace massDepFit
 
 } // end namespace rpwa
@@ -147,7 +149,7 @@ namespace rpwa {
 
 inline
 std::ostream&
-operator<< (std::ostream& out, const rpwa::massDepFit::model& fitModel)
+rpwa::massDepFit::operator<< (std::ostream& out, const rpwa::massDepFit::model& fitModel)
 {
 	return fitModel.print(out);
 }

--- a/resonanceFit/massDepFitParameters.h
+++ b/resonanceFit/massDepFitParameters.h
@@ -75,6 +75,8 @@ namespace rpwa {
 
 		};
 
+		std::ostream& operator<< (std::ostream& out, const rpwa::massDepFit::parameters& parameters);
+
 	} // end namespace massDepFit
 
 } // end namespace rpwa
@@ -82,7 +84,7 @@ namespace rpwa {
 
 inline
 std::ostream&
-operator<< (std::ostream& out, const rpwa::massDepFit::parameters& parameters)
+rpwa::massDepFit::operator<< (std::ostream& out, const rpwa::massDepFit::parameters& parameters)
 {
 	return parameters.print(out);
 }

--- a/resonanceFit/pwaMassFit.cc
+++ b/resonanceFit/pwaMassFit.cc
@@ -217,7 +217,7 @@ main(int    argc,
 	}
 
 	// set-up fit model and fit function
-	if(not mdepFit.init(compset, fitParameters, fitFunction)) {
+	if(not mdepFit.init(compset, fitFunction)) {
 		printErr << "error while reading configuration file '" << configFileName << "'." << std::endl;
 		return 1;
 	}

--- a/resonanceFit/pwaMassFit.cc
+++ b/resonanceFit/pwaMassFit.cc
@@ -291,7 +291,7 @@ main(int    argc,
 	}
 
 	if(debug) {
-		printDebug << "name of output ROOT file: '" << confFileName << "'." << std::endl;
+		printDebug << "name of output ROOT file: '" << rootFileName << "'." << std::endl;
 	}
 	std::auto_ptr<TFile> outFile(TFile::Open(rootFileName.c_str(), "RECREATE"));
 	if(outFile.get() == NULL || outFile->IsZombie()) {

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -62,6 +62,9 @@ ADD_CUSTOM_TARGET(
 	                 -D ROOTSYS=${ROOTSYS}
 	                 -D CUDA_VERSION=${CUDA_VERSION}
 	                 -D CUDA_LIB_DIRS=${CUDA_LIB_DIRS}
+	                 -D BAT_VERSION=${BAT_VERSION}
+	                 -D BAT_ROOT_DIR=${BAT_ROOT_DIR}
+	                 -D NLopt_DIR=${NLopt_DIR}
 	                 -D PYTHONLIBS_VERSION_STRING=${PYTHONLIBS_VERSION_STRING}
 	                 -D PYTHON_INCLUDE_DIRS=${PYTHON_INCLUDE_DIRS}
 	                 -P ${CMAKE_CURRENT_SOURCE_DIR}/environment.cmake

--- a/utilities/environment.h.in
+++ b/utilities/environment.h.in
@@ -15,6 +15,9 @@
 #cmakedefine ROOTSYS "@ROOTSYS@"
 #cmakedefine CUDA_VERSION "@CUDA_VERSION@"
 #cmakedefine CUDA_LIB_DIRS "@CUDA_LIB_DIRS@"
+#cmakedefine BAT_VERSION "@BAT_VERSION@"
+#cmakedefine BAT_ROOT_DIR "@BAT_ROOT_DIR@"
+#cmakedefine NLopt_DIR "@NLopt_DIR@"
 #cmakedefine PYTHONLIBS_VERSION_STRING "@PYTHONLIBS_VERSION_STRING@"
 #cmakedefine PYTHON_INCLUDE_DIRS "@PYTHON_INCLUDE_DIRS@"
 
@@ -67,6 +70,15 @@
 #endif
 #ifndef CUDA_LIB_DIRS
 #define CUDA_LIB_DIRS "undefined"
+#endif
+#ifndef BAT_VERSION
+#define BAT_VERSION "undefined"
+#endif
+#ifndef BAT_ROOT_DIR
+#define BAT_ROOT_DIR "undefined"
+#endif
+#ifndef NLopt_DIR
+#define NLopt_DIR "undefined"
 #endif
 #ifndef PYTHONLIBS_VERSION_STRING
 #define PYTHONLIBS_VERSION_STRING "undefined"

--- a/utilities/reportingUtilsEnvironment.cc
+++ b/utilities/reportingUtilsEnvironment.cc
@@ -41,6 +41,12 @@ void rpwa::printLibraryInfo()
 #ifdef USE_CUDA
 	std::cout << "    CUDA version " << CUDA_VERSION << " in '" << CUDA_LIB_DIRS << "'" << std::endl;
 #endif
+#ifdef USE_BAT
+	std::cout << "    BAT version " << BAT_VERSION << " in '" << BAT_ROOT_DIR << "'" << std::endl;
+#endif
+#ifdef USE_NLOPT
+	std::cout << "    NLopt in '" << NLopt_DIR << "'" << std::endl;
+#endif
 #ifdef USE_MPI
 	std::cout << "    MPI libraries; using Boost.MPI" << std::endl;
 #endif


### PR DESCRIPTION
* Fix building with 'Apple LLVM 6.1.0' (Xcode 6.3):
 * ignore warnings concerning ignored qualifiers while building the ROOT dictionaries (for ROOTv5 only)
 * test whether the compiler understands thread_local (independent from using -std=c++11) because Apple does not support thread_local yet
* remove one test and definition not used anymore
* add BAT and NLopt to 'printLibraryInfo'

* add a function to the partialWaveFitHelper to extract Eigenvalues and -vectors from covariance and Hessian matrices taking into account fixed parameters, use this across the code; enable 'eigenvectorLikelihoodSlices' to (properly; i.e. no bogus plots for the last eigenvalues) work with fixed parameters
* draw parabolas in 'eigenvectorLikelihoodSlices'

* clean the code reading and writing the configuration file of the resonance fit
  * be less paranoid about the in memory configuration changing while running, this should never happen
  * put the functionality needed to read extra information from one decay channel into an own method, not to have it implemented multiple times (e.g., for 'decaychannels' and 'extradecaychannels'), also in 'init' of the individual components it is no longer necessary to loop over the 'decaychannels' again