### PR TITLE
Custom cauchy width

### DIFF
--- a/nlopt/pwaNloptFit.cc
+++ b/nlopt/pwaNloptFit.cc
@@ -68,7 +68,7 @@ using namespace rpwa;
 
 double rpwaNloptFunc(unsigned n, const double* x, double* gradient, void* func_data)
 {
-	pwaLikelihood<complex<double> >* L = (pwaLikelihood<complex<double> >*)func_data;
+	const pwaLikelihood<complex<double> >* L = (pwaLikelihood<complex<double> >*)func_data;
 	if(n != L->nmbPars()) {
 		printErr << "parameter mismatch between NLopt and pwaLikelihood. Aborting..." << endl;
 		return 1;

--- a/nlopt/pwaNloptFit.cc
+++ b/nlopt/pwaNloptFit.cc
@@ -92,8 +92,8 @@ usage(const string& progName,
 	     << endl
 	     << "usage:" << endl
 	     << progName
-	     << " -l # -u # -w wavelist [-d amplitude directory -R -o outfile -s seed -x [startvalue] -N -n normfile"
-	     << " -a normfile -A # normalisation events -r rank -t # -m # -C -P -q -z -h]" << endl
+	     << " -l # -u # -w wavelist [-d amplitude directory -R -o outfile -s seed -x -V startValue -N -n normfile"
+	     << " -a normfile -A # normalisation events -r rank -t # -m # -C -P width -q -z -h]" << endl
 	     << "    where:" << endl
 	     << "        -l #       lower edge of mass bin [MeV/c^2]" << endl
 	     << "        -u #       upper edge of mass bin [MeV/c^2]" << endl
@@ -106,8 +106,8 @@ usage(const string& progName,
 #endif
 	     << "        -o file    path to output file (default: 'fitresult.root')" << endl
 	     << "        -s #       seed for random start values (default: 1234567)" << endl
-	     << "        -x #       use fixed instead of random start values (default: 0.01)" << endl
-
+	     << "        -x         use fixed instead of random start values" << endl
+	     << "        -V #       start values to use (only in combination with -x) (default: 0.01)" << endl
 	     << "        -N         use normalization of decay amplitudes (default: false)" << endl
 	     << "        -n file    path to normalization integral file (default: 'norm.int')" << endl
 	     << "        -a file    path to acceptance integral file (default: 'norm.int')" << endl
@@ -116,7 +116,7 @@ usage(const string& progName,
 	     << "        -t #       relative parameter tolerance (default: 0.0001)" << endl
 	     << "        -m #       absolute likelihood tolerance (default: 0.000001)" << endl
 	     << "        -C         use half-Cauchy priors (default: false)" << endl
-	     << "        -P         width of half-Cauchy priors (default: 0.5)" << endl
+	     << "        -P #       width of half-Cauchy priors (default: 0.5)" << endl
 	     << "        -q         run quietly (default: false)" << endl
 	     << "        -z         save space by not saving integral and covariance matrices (default: false)" << endl
 	     << "        -h         print help" << endl
@@ -168,10 +168,11 @@ main(int    argc,
 	double       cauchyWidth         = 0.5;
 	bool         quiet               = false;
 	bool         saveSpace           = false;
+
 	extern char* optarg;
 	// extern int optind;
 	int c;
-	while ((c = getopt(argc, argv, "l:u:w:d:Ro:s:x::Nn:a:A:r:t:m:CP:qzh")) != -1)
+	while ((c = getopt(argc, argv, "l:u:w:d:Ro:s:xV:Nn:a:A:r:t:m:CP:qzh")) != -1)
 		switch (c) {
 		case 'l':
 			massBinMin = atof(optarg);
@@ -197,9 +198,10 @@ main(int    argc,
 			startValSeed = atoi(optarg);
 			break;
 		case 'x':
-			if (optarg)
-				defaultStartValue = atof(optarg);
 			useFixedStartValues = true;
+			break;
+		case 'V':
+			defaultStartValue = atof(optarg);
 			break;
 		case 'N':
 			useNormalizedAmps = true;

--- a/src/pwaLikelihood.cc
+++ b/src/pwaLikelihood.cc
@@ -66,7 +66,6 @@ using namespace boost;
 using namespace boost::accumulators;
 
 
-template<typename complexT> const double pwaLikelihood<complexT>::_cauchyWidth = 0.5;
 template<typename complexT> bool pwaLikelihood<complexT>::_debug = true;
 
 
@@ -113,6 +112,7 @@ pwaLikelihood<complexT>::pwaLikelihood()
 #endif
 	  _useNormalizedAmps(true),
 	  _priorType        (FLAT),
+	  _cauchyWidth      (0.5),
 	  _numbAccEvents    (0)
 {
 	_nmbWavesRefl[0] = 0;

--- a/src/pwaLikelihood.h
+++ b/src/pwaLikelihood.h
@@ -157,12 +157,14 @@ namespace rpwa {
 		//const integral& normInt() const { return _normInt; }
 
 		// modifiers
-		void        enableCuda       (const bool      enableCuda = true);
-		bool        cudaEnabled      () const;
-		void        useNormalizedAmps(const bool      useNorm    = true) { _useNormalizedAmps = useNorm;   }
-		void        setPriorType     (const priorEnum priorType  = FLAT) { _priorType         = priorType; }
-		priorEnum   priorType        () const                            { return _priorType;              }
-		static void setQuiet         (const bool      flag       = true) { _debug             = !flag;     }
+		void          enableCuda       (const bool      enableCuda = true);
+		bool          cudaEnabled      () const;
+		void          useNormalizedAmps(const bool      useNorm    = true) { _useNormalizedAmps = useNorm;   }
+		void          setPriorType     (const priorEnum priorType  = FLAT) { _priorType         = priorType; }
+		priorEnum     priorType        () const                            { return _priorType;              }
+		void          setCauchyWidth   (const double&   cauchyWidth)       { _cauchyWidth = cauchyWidth;     }
+		const double& cauchyWidth      ()                                  { return _cauchyWidth;            }
+		static void   setQuiet         (const bool      flag       = true) { _debug             = !flag;     }
 
 		// operations
 		void init(const unsigned int rank,
@@ -237,7 +239,7 @@ namespace rpwa {
 	#endif
 		bool                _useNormalizedAmps;  // if true normalized amplitudes are used
 		priorEnum           _priorType;          // which prior to apply to parameters
-		static const double _cauchyWidth;        // width for the half-Cauchy prior
+		double              _cauchyWidth;        // width for the half-Cauchy prior
 		static bool         _debug;              // if true debug messages are printed
 
 		unsigned int _numbAccEvents; // number of input events used for acceptance integrals (accepted + rejected!)

--- a/src/pwafit.cc
+++ b/src/pwafit.cc
@@ -77,7 +77,7 @@ usage(const string& progName,
 	     << endl
 	     << "usage:" << endl
 	     << progName
-	     << " -l # -u # -w wavelist [-d amplitude directory -R -o outfile -S start value file -s seed -x [start value] -N -n normfile"
+	     << " -l # -u # -w wavelist [-d amplitude directory -R -o outfile -S start value file -s seed -x -V startValue -N -n normfile"
 	     << " -a normfile -A # normalisation events -r rank -M minimizer -m algorithm -g strategy -t # -e -c -H -q -h]" << endl
 	     << "    where:" << endl
 	     << "        -l #       lower edge of mass bin [MeV/c^2]" << endl
@@ -92,8 +92,8 @@ usage(const string& progName,
 	     << "        -o file    path to output file (default: 'fitresult.root')" << endl
 	     << "        -S file    path to file with start values (default: none; highest priority)" << endl
 	     << "        -s #       seed for random start values (default: 1234567)" << endl
-	     << "        -x #       use fixed instead of random start values (default: 0.01)" << endl
-
+	     << "        -x         use fixed instead of random start values" << endl
+	     << "        -V #       start values to use (only in combination with -x) (default: 0.01)" << endl
 	     << "        -N         use normalization of decay amplitudes (default: false)" << endl
 	     << "        -n file    path to normalization integral file (default: 'norm.int')" << endl
 	     << "        -a file    path to acceptance integral file (default: 'norm.int')" << endl
@@ -209,10 +209,11 @@ main(int    argc,
 	bool         cudaEnabled         = false;                  // if true CUDA kernels are activated
 	bool         checkHessian        = false;                  // if true checks analytical Hessian eigenvalues
 	bool         quiet               = false;
+
 	extern char* optarg;
 	// extern int optind;
 	int c;
-	while ((c = getopt(argc, argv, "l:u:w:d:Ro:S:s:x::Nn:a:A:r:M:m:g:t:ecHqh")) != -1)
+	while ((c = getopt(argc, argv, "l:u:w:d:Ro:S:s:xV:Nn:a:A:r:M:m:g:t:ecHqh")) != -1)
 		switch (c) {
 		case 'l':
 			massBinMin = atof(optarg);
@@ -241,9 +242,10 @@ main(int    argc,
 			startValSeed = atoi(optarg);
 			break;
 		case 'x':
-			if (optarg)
-				defaultStartValue = atof(optarg);
 			useFixedStartValues = true;
+			break;
+		case 'V':
+			defaultStartValue = atof(optarg);
 			break;
 		case 'N':
 			useNormalizedAmps = true;


### PR DESCRIPTION
Make the width of the half-Cauchy prior changeable at runtime by making it a
standard member variable of the pwaLikelihood (as opposed to a const static
one) and adding a getter and setter for it. Also introduce a new command line
option in pwaNloptFit.cc which allows to set the prior width.

This is a re-opening of pull request #79, which was inadvertently merged and then force-un-merged. It contains all the changes mentioned in the discussion there.