### PR TITLE
Fix phaseSpaceIntegral and small stuff

### DIFF
--- a/decayAmplitude/isobarAmplitude.cc
+++ b/decayAmplitude/isobarAmplitude.cc
@@ -136,6 +136,25 @@ TLorentzRotation
 isobarAmplitude::gjTransform(const TLorentzVector& beamLv,  // beam Lorentz-vector
                              const TLorentzVector& XLv)     // X  Lorentz-vector
 {
+	if (beamLv == XLv) {
+		// Beam and X Lorentz vector are equal if the amplitude is to
+		// be calculated starting with a non-interaction vertex as it
+		// is the case for, e.g., the 'phaseSpaceIntegral' class. In
+		// this case the production plane is not well defined. Any
+		// rotation might skew the angles as there might be a prefered
+		// orientation due to numerical instabilities, so only perform
+		// the boost. Print a warning if this boost is not small.
+		const TVector3 boostVector(-XLv.BoostVector());
+		if (boostVector.Mag() > numeric_limits<double>::epsilon()) {
+			printWarn << "Lorentz-vectors of beam and X are collinear and the boost vector to the center-of-mass system of X is not negligible (" << maxPrecisionAlign(boostVector.Mag()) << ")." << std::endl;
+		}
+
+		TLorentzRotation boost;
+		boost.Boost(boostVector);
+
+		return boost;
+	}
+
 	TLorentzVector beam    = beamLv;
 	TLorentzVector X       = XLv;
 	const TVector3 yGjAxis = beam.Vect().Cross(X.Vect());  // y-axis of Gottfried-Jackson frame

--- a/decayAmplitude/waveDescription.cc
+++ b/decayAmplitude/waveDescription.cc
@@ -119,7 +119,8 @@ waveDescription::waveDescription(const waveDescription& waveDesc)
 	  _keyFileLocalCopy(waveDesc._keyFileLocalCopy)
 {
 	//waveDescription::Class()->IgnoreTObjectStreamer();  // don't store TObject's fBits and fUniqueID
-	parseKeyFileContent(_keyFileLocalCopy);
+	if (waveDesc._keyFileParsed)
+		parseKeyFileContent(_keyFileLocalCopy);
 }
 
 waveDescription::waveDescription(const amplitudeMetadata* amplitudeMeta)
@@ -159,7 +160,8 @@ waveDescription::operator =(const waveDescription& waveDesc)
 		_key              = 0;
 		_keyFileParsed    = false;
 		_keyFileLocalCopy = waveDesc._keyFileLocalCopy;
-		parseKeyFileContent(_keyFileLocalCopy);
+		if (waveDesc._keyFileParsed)
+			parseKeyFileContent(_keyFileLocalCopy);
 	}
 	return *this;
 }

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -1060,8 +1060,14 @@ pwaLikelihood<complexT>::addAmplitude(const amplitudeMetadata& meta)
 		}
 		assert(ampTreeLeaf->nmbIncohSubAmps() == 1);
 		complexT amp(ampTreeLeaf->incohSubAmp(0).real(), ampTreeLeaf->incohSubAmp(0).imag());
-		if (_useNormalizedAmps)         // normalize data, if option is switched on
-			amp /= sqrt(normInt.real());  // rescale decay amplitude
+		if (_useNormalizedAmps) {  // normalize data, if option is switched on
+			if (normInt == (value_type)0. && amp != (value_type)0.) {
+				printErr << "normalization integral for wave '" << waveName << "' is zero, but the amplitude is not. Aborting...";
+				return false;
+			}
+			if (normInt != (value_type)0.)
+				amp /= sqrt(normInt.real());  // rescale decay amplitude
+		}
 		amps.push_back(amp);
 	}
 

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -1429,11 +1429,11 @@ rpwa::massDepFit::constantBackground::write(YAML::Emitter& yamlOutput,
 
 
 std::complex<double>
-rpwa::massDepFit::constantBackground::val(const rpwa::massDepFit::parameters& fitParameters,
-                                          rpwa::massDepFit::cache& cache,
-                                          const size_t idxBin,
-                                          const double m,
-                                          const size_t idxMass) const
+rpwa::massDepFit::constantBackground::val(const rpwa::massDepFit::parameters& /* fitParameters */,
+                                          rpwa::massDepFit::cache& /* cache */,
+                                          const size_t /* idxBin */,
+                                          const double /* m */,
+                                          const size_t /* idxMass */) const
 {
 	return 1.;
 }


### PR DESCRIPTION
Fix the values calculated by the `phaseSpaceIntegral` class. The volume of the integration was taken into account twice, once in the normalization of the `S_U_CHUNG` weight, and once explicitly in the calculation this class. Now only use the one from the normalization.

Also issue #91 is partially fixed. If the two Lorentz-vectors of beam and X are equal and X is at rest (a small variation is allowed), the boost matrix, which is basically the unit matrix except for the small allowed variation, is returned. The boost is also performed if X is not at rest, however, then a warning is printed.

The effects of those two corrections are depicted here:
![plots](https://cloud.githubusercontent.com/assets/7747454/8255740/8178553e-16a2-11e5-801c-57d8bb0c167b.png)

Also fix a couple of smaller stuff:
* the copy and assignment constructors of the `waveDescription` should only parse the key file content, if they were successfully parse before, otherwise it is not possible to copy an empty `waveDescription` object without an error message.
* fix to compile with `-Wextra`
* fix normalization of amplitudes in view of zero entries in the normalization integral, zero entries might occur when using the flatRange mass-dependence, however, then integral and amplitude should be zero. So in case of zero amplitude and integral do nothing (the amplitude remains zero (but does no longer become NaN spoiling everything)), in case of zero integral and non-zero amplitude print an error and exit because this should neverhappen, and in the case of non-zero integral do the normalization. (Note that this was rather poorly fixed in case of the binary amplitudes already before.)