### PR TITLE
Various things

### DIFF
--- a/decayAmplitude/ampIntegralMatrix.cc
+++ b/decayAmplitude/ampIntegralMatrix.cc
@@ -324,7 +324,7 @@ ampIntegralMatrix::integrate(const vector<const amplitudeMetadata*>& ampMetadata
 	accumulator_set<double, stats<tag::sum(compensated)> > weightAcc;
 	typedef accumulator_set<complex<double>, stats<tag::sum(compensated)> > complexAcc;
 	vector<vector<complexAcc> > ampProdAcc(_nmbWaves, vector<complexAcc>(_nmbWaves));
-	// process weight file and binary amplitude files
+	// process weight file and amplitudes
 	vector<vector<complex<double> > > amps(_nmbWaves);
 	progress_display progressIndicator(_nmbEvents, cout, "");
 	bool             success = true;

--- a/decayAmplitude/createGraphDiagram.cc
+++ b/decayAmplitude/createGraphDiagram.cc
@@ -21,9 +21,8 @@
 //-------------------------------------------------------------------------
 //
 // Description:
-//      reads in data files in .evt or tree format, calculates
-//      amplitudes for each event based on given key file, and writes
-//      out amplitudes in PWA2000 binary or ascii format
+//      creates graphical representation of decay graphs specified
+//      in key files
 //
 //
 // Author List:

--- a/generators/weightEvents.cc
+++ b/generators/weightEvents.cc
@@ -57,6 +57,7 @@
 #include "amplitudeTreeLeaf.h"
 #include "fitResult.h"
 #include "fileUtils.hpp"
+#include "partialWaveFitHelper.h"
 #include "reportingUtilsEnvironment.h"
 
 
@@ -355,12 +356,8 @@ main(int    argc,
 				const int iWave          = result->waveIndex(waveName);
 
 				// extract rank and reflectivity from wave name
-				int rank = result->rankOfProdAmp(iProdAmp);
-				int refl = 0;
-				if (prodAmpName != "V_flat") {
-					// check reflectivity to sort into correct production vector
-					refl = ((waveName[6] == '+') ? +1 : -1);
-				}
+				const int rank = result->rankOfProdAmp(iProdAmp);
+				const int refl = partialWaveFitHelper::getReflectivity(waveName);
 				// read production amplitude
 				const complex<double> prodAmp = result->prodAmp(iProdAmp);
 				prodAmps[iSample].push_back(prodAmp);

--- a/legacy/calcAmplitudes.cc
+++ b/legacy/calcAmplitudes.cc
@@ -23,7 +23,7 @@
 // Description:
 //      reads in data files in .evt or ROOT tree format, calculates
 //      amplitudes for each event based on given key file, and writes
-//      out amplitudes in ROOT tree or PWA2000 binary or ascii format
+//      out amplitudes in ROOT tree format
 //
 //
 // Author List:

--- a/legacy/calcIntegrals.cc
+++ b/legacy/calcIntegrals.cc
@@ -151,7 +151,7 @@ main(int    argc,
 
 		const amplitudeMetadata* ampMeta = amplitudeMetadata::readAmplitudeFile(file, waveName);
 		if (ampMeta == NULL) {
-			printErr << "cannot read event data from event file '" << ampFileName << "'. Aborting..." << endl;
+			printErr << "cannot read amplitude metadata from amplitude file '" << ampFileName << "'. Aborting..." << endl;
 			exit(1);
 		}
 

--- a/legacy/pwaNloptFit.cc
+++ b/legacy/pwaNloptFit.cc
@@ -272,7 +272,7 @@ main(int    argc,
 
 			const amplitudeMetadata* ampMeta = amplitudeMetadata::readAmplitudeFile(file, waveName);
 			if (ampMeta == NULL) {
-				printErr << "cannot read event data from event file '" << waveFileName << "'. Aborting..." << endl;
+				printErr << "cannot read amplitude metadata from amplitude file '" << waveFileName << "'. Aborting..." << endl;
 				exit(1);
 			}
 
@@ -357,7 +357,7 @@ main(int    argc,
 
 		const amplitudeMetadata* ampMeta = amplitudeMetadata::readAmplitudeFile(file, waveName);
 		if (ampMeta == NULL) {
-			printErr << "cannot read event data from event file '" << waveFileName << "'. Aborting..." << endl;
+			printErr << "cannot read amplitude metadata from amplitude file '" << waveFileName << "'. Aborting..." << endl;
 			exit(1);
 		}
 

--- a/legacy/pwafit.cc
+++ b/legacy/pwafit.cc
@@ -272,7 +272,7 @@ main(int    argc,
 
 			const amplitudeMetadata* ampMeta = amplitudeMetadata::readAmplitudeFile(file, waveName);
 			if (ampMeta == NULL) {
-				printErr << "cannot read event data from event file '" << waveFileName << "'. Aborting..." << endl;
+				printErr << "cannot read amplitude metadata from amplitude file '" << waveFileName << "'. Aborting..." << endl;
 				exit(1);
 			}
 
@@ -357,7 +357,7 @@ main(int    argc,
 
 		const amplitudeMetadata* ampMeta = amplitudeMetadata::readAmplitudeFile(file, waveName);
 		if (ampMeta == NULL) {
-			printErr << "cannot read event data from event file '" << waveFileName << "'. Aborting..." << endl;
+			printErr << "cannot read amplitude metadata from amplitude file '" << waveFileName << "'. Aborting..." << endl;
 			exit(1);
 		}
 

--- a/legacy/pyInterface/package/_calcAmplitudes.py
+++ b/legacy/pyInterface/package/_calcAmplitudes.py
@@ -17,10 +17,6 @@ def calcAmplitudes(configFileName, massBins, **arguments):
 	pyRootPwa.core.printLibraryInfo()
 	pyRootPwa.core.printGitHash()
 
-	# making the output nice for multi-threading
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	# Check and get the arguments
 	nJobs = 1
 	if 'nJobs' in arguments:

--- a/pyInterface/CMakeLists.txt
+++ b/pyInterface/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
 	${NBODYPHASESPACE_SUBDIR}/randomNumberGenerator_py.cc
 	${PARTIALWAVEFIT_SUBDIR}/complexMatrix_py.cc
 	${PARTIALWAVEFIT_SUBDIR}/fitResult_py.cc
+	${PARTIALWAVEFIT_SUBDIR}/partialWaveFitHelper_py.cc
 	${PARTIALWAVEFIT_SUBDIR}/pwaLikelihood_py.cc
 	${PARTICLEDATA_SUBDIR}/particle_py.cc
 	${PARTICLEDATA_SUBDIR}/particleDataTable_py.cc

--- a/pyInterface/amplitudeBenchmark.py
+++ b/pyInterface/amplitudeBenchmark.py
@@ -83,9 +83,6 @@ FILE_LINKS = {
 
 if __name__ == "__main__":
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	parser = argparse.ArgumentParser(description="amplitude benchmark")
 
 	parser.add_argument("path", type=str, metavar="<path>", help="path where benchmark should be run (will be created if it doesn't exist)")

--- a/pyInterface/compareAmplitudeFiles.py
+++ b/pyInterface/compareAmplitudeFiles.py
@@ -84,9 +84,6 @@ if __name__ == "__main__":
 	parser.add_argument("file2", type=str, metavar="<filename>", help="path to second amplitude file")
 	args = parser.parse_args()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	real1, imag1 = extractRealImagListsFromAmpFile(args.file1)
 	real2, imag2 = extractRealImagListsFromAmpFile(args.file2)
 	if not len(real1) == len(real2):

--- a/pyInterface/genPseudoData.py
+++ b/pyInterface/genPseudoData.py
@@ -61,9 +61,6 @@ if __name__ == "__main__":
 	pyRootPwa.core.printLibraryInfo()
 	pyRootPwa.core.printGitHash()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	printErr  = pyRootPwa.utils.printErr
 	printWarn = pyRootPwa.utils.printWarn
 	printSucc = pyRootPwa.utils.printSucc

--- a/pyInterface/genPseudoData.py
+++ b/pyInterface/genPseudoData.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
 		if not os.path.isfile(keyfile):
 			printErr('keyfile "' + keyfile + '" does not exist. Aborting...')
 			sys.exit(1)
-		reflectivities.append(1 if waveName[6] == '+' else -1)
+		reflectivities.append(pyRootPwa.core.partialWaveFitHelper.getReflectivity(waveName))
 		waveIndex = fitResult.waveIndex(waveName)
 
 		if not waveName == fitResult.prodAmpName(waveIndex)[3:]:

--- a/pyInterface/genpw.py
+++ b/pyInterface/genpw.py
@@ -35,9 +35,6 @@ if __name__ == "__main__":
 	pyRootPwa.core.printLibraryInfo()
 	pyRootPwa.core.printGitHash()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	printErr  = pyRootPwa.utils.printErr
 	printWarn = pyRootPwa.utils.printWarn
 	printSucc = pyRootPwa.utils.printSucc

--- a/pyInterface/integralBenchmark.py
+++ b/pyInterface/integralBenchmark.py
@@ -49,9 +49,6 @@ FILE_LINKS = {
 
 if __name__ == "__main__":
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	parser = argparse.ArgumentParser(description="integral benchmark")
 
 	parser.add_argument("path", type=str, metavar="<path>", help="path where benchmark should be run (will be created if it doesn't exist)")

--- a/pyInterface/package/utils/_printingUtils.py
+++ b/pyInterface/package/utils/_printingUtils.py
@@ -5,8 +5,9 @@ import sys as _sys
 
 import pyRootPwa.utils
 
-stdoutisatty = None
-stderrisatty = None
+# making the output nice for multi-threading
+stdoutisatty = _sys.stdout.isatty()
+stderrisatty = _sys.stderr.isatty()
 
 def printPrintingSummary(printingCounter):
 	print

--- a/pyInterface/partialWaveFit/partialWaveFitHelper_py.cc
+++ b/pyInterface/partialWaveFit/partialWaveFitHelper_py.cc
@@ -1,0 +1,39 @@
+#include "partialWaveFitHelper_py.h"
+
+#include <boost/python.hpp>
+
+#include "partialWaveFitHelper.h"
+
+namespace bp = boost::python;
+
+
+void rpwa::py::exportPartialWaveFitHelper() {
+
+	// the functions from the 'partialWaveFitHelper' namespace should not
+	// be available from Python at the 'pyRootPwa.core.function' level,
+	// but should also be included into their own module like
+	// 'pyRootPwa.core.partialWaveFitHelper.function'. So below a submodule
+	// 'partialWaveFitHelper' is added and the functions are added at that
+	// scope.
+
+	bp::scope current;
+	std::string submoduleName(bp::extract<std::string>(current.attr("__name__")));
+	submoduleName.append(".partialWaveFitHelper");
+
+	bp::object submodule(bp::borrowed(PyImport_AddModule(submoduleName.c_str())));
+	current.attr("partialWaveFitHelper") = submodule;
+
+	{
+
+		// switch the scope to the submodule
+		bp::scope submoduleScope = submodule;
+
+		bp::def(
+			"getReflectivity"
+			, &rpwa::partialWaveFitHelper::getReflectivity
+			, (bp::arg("name"))
+		);
+
+	}
+
+}

--- a/pyInterface/partialWaveFit/partialWaveFitHelper_py.h
+++ b/pyInterface/partialWaveFit/partialWaveFitHelper_py.h
@@ -1,0 +1,10 @@
+#ifndef PARTIALWAVEFITHELPER_PY_H
+#define PARTIALWAVEFITHELPER_PY_H
+
+namespace rpwa {
+	namespace py {
+		void exportPartialWaveFitHelper();
+	}
+}
+
+#endif

--- a/pyInterface/plotAngles.py
+++ b/pyInterface/plotAngles.py
@@ -110,9 +110,6 @@ if __name__ == "__main__":
 	if len(arguments.massBins) == 0:
 		arguments.massBins.append("all")
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	if arguments.type not in ["data", "acc", "gen"]:
 		pyRootPwa.utils.printErr("invalid type '" + arguments.type + "' found, must be either 'data', 'gen' or 'acc'. Aborting...")
 		sys.exit(5)

--- a/pyInterface/rootPwaPy.cc
+++ b/pyInterface/rootPwaPy.cc
@@ -41,6 +41,7 @@
 // partialWaveFit
 #include "complexMatrix_py.h"
 #include "fitResult_py.h"
+#include "partialWaveFitHelper_py.h"
 #include "pwaLikelihood_py.h"
 
 // particleData
@@ -90,6 +91,7 @@ BOOST_PYTHON_MODULE(libRootPwaPy){
 	rpwa::py::exportBeamAndVertexGenerator();
 	rpwa::py::exportComplexMatrix();
 	rpwa::py::exportFitResult();
+	rpwa::py::exportPartialWaveFitHelper();
 	rpwa::py::exportPhysUtils();
 	rpwa::py::exportReportingUtilsEnvironment();
 	rpwa::py::exportEventFileWriter();

--- a/pyInterface/rootpwa.config
+++ b/pyInterface/rootpwa.config
@@ -5,6 +5,7 @@ fileManagerPath                        = fileManager.pkl
 dataFileDirectory                      = data
 keyFileDirectory                       = keyfiles
 ampFileDirectory                       = amps
+intFileDirectory                       = ints
 
 # -1 for no limit, 0 for subfolder for each binID
 limitFilesPerDir                       = -1

--- a/pyInterface/testFileManager.py
+++ b/pyInterface/testFileManager.py
@@ -9,10 +9,6 @@ import pyRootPwa.core
 
 if __name__ == "__main__":
 
-	# making the output nice for multi-threading
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	f = pyRootPwa.fileManager()
 	if not f.initialize("rootpwa.config"):
 		pyRootPwa.utils.printErr("initializing the file manager failed. Aborting...")

--- a/pyInterface/userInterface/calcAmplitudes.py
+++ b/pyInterface/userInterface/calcAmplitudes.py
@@ -39,9 +39,6 @@ def readWaveList(waveListFileName):
 
 if __name__ == "__main__":
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	# parse command line arguments
 	parser = argparse.ArgumentParser(
 	                                 description="calculates decay amplitudes "

--- a/pyInterface/userInterface/calcIntegrals.py
+++ b/pyInterface/userInterface/calcIntegrals.py
@@ -19,9 +19,6 @@ if __name__ == "__main__":
 	parser.add_argument("-w", type=str, metavar="path", dest="weightsFileName", default="", help="path to MC weight file for de-weighting (default: none)")
 	args = parser.parse_args()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	printErr  = pyRootPwa.utils.printErr
 	printWarn = pyRootPwa.utils.printWarn
 	printSucc = pyRootPwa.utils.printSucc

--- a/pyInterface/userInterface/pwaFit.py
+++ b/pyInterface/userInterface/pwaFit.py
@@ -28,9 +28,6 @@ if __name__ == "__main__":
 	parser.add_argument("-v", "--verbose", help="verbose; print debug output (default: false)", action="store_true")
 	args = parser.parse_args()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	printErr  = pyRootPwa.utils.printErr
 	printWarn = pyRootPwa.utils.printWarn
 	printSucc = pyRootPwa.utils.printSucc

--- a/pyInterface/userInterface/pwaNloptFit.py
+++ b/pyInterface/userInterface/pwaNloptFit.py
@@ -28,9 +28,6 @@ if __name__ == "__main__":
 	parser.add_argument("-v", "--verbose", help="verbose; print debug output (default: false)", action="store_true")
 	args = parser.parse_args()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	printErr  = pyRootPwa.utils.printErr
 	printWarn = pyRootPwa.utils.printWarn
 	printSucc = pyRootPwa.utils.printSucc

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -1311,7 +1311,7 @@ rpwa::massDepFit::integralWidthBreitWigner::val(const rpwa::massDepFit::paramete
 
 		gamma += _ratio[i] * ps / ps0;
 	}
-	gamma *= gamma0 * m0/m;
+	gamma *= gamma0;
 
 	const std::complex<double> component = gamma0*m0 / std::complex<double>(m0*m0-m*m, -gamma*m0);
 
@@ -1963,7 +1963,7 @@ rpwa::massDepFit::exponentialBackgroundIntegral::init(const YAML::Node& configCo
 
 	_exponent = configComponent["exponent"].as<double>();
 
-	_norm = 1. / _interpolator->Eval(massBinCenters.back());
+	_norm = 1. / (massBinCenters.back() * _interpolator->Eval(massBinCenters.back()));
 
 	if(debug) {
 		print(printDebug);
@@ -2035,7 +2035,7 @@ rpwa::massDepFit::exponentialBackgroundIntegral::val(const rpwa::massDepFit::par
 	}
 
 	const double ps = _interpolator->Eval(m);
-	const double c = std::pow(ps * _norm, _exponent);
+	const double c = std::pow(m * ps * _norm, _exponent);
 
 	const std::complex<double> component = exp(-fitParameters.getParameter(getId(), 0)*c);
 
@@ -2188,7 +2188,7 @@ rpwa::massDepFit::tPrimeDependentBackgroundIntegral::init(const YAML::Node& conf
 
 	_exponent = configComponent["exponent"].as<double>();
 
-	_norm = 1. / _interpolator->Eval(massBinCenters.back());
+	_norm = 1. / (massBinCenters.back() * _interpolator->Eval(massBinCenters.back()));
 
 	if(_tPrimeMeans.size() != nrBins) {
 		printErr << "array of mean t' value in each bin does not contain the correct number of entries (is: " << _tPrimeMeans.size() << ", expected: " << nrBins << ")." << std::endl;
@@ -2265,7 +2265,7 @@ rpwa::massDepFit::tPrimeDependentBackgroundIntegral::val(const rpwa::massDepFit:
 	}
 
 	const double ps = _interpolator->Eval(m);
-	const double c = std::pow(ps * _norm, _exponent);
+	const double c = std::pow(m * ps * _norm, _exponent);
 
 	// get mean t' value for current bin
 	const double tPrime = _tPrimeMeans[idxBin];

--- a/storageFormats/convertEventFile.py
+++ b/storageFormats/convertEventFile.py
@@ -14,9 +14,6 @@ if __name__ == "__main__":
 	pyRootPwa.core.printLibraryInfo()
 	pyRootPwa.core.printGitHash()
 
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	parser = argparse.ArgumentParser(description="convert event file")
 	parser.add_argument("inputFile", type=str, metavar="inputFile", help="input file in ROOTPWA format without meta data")
 	parser.add_argument("outputFile", type=str, metavar="outputFile", help="input file in ROOTPWA format with meta data")

--- a/storageFormats/printMetadata.py
+++ b/storageFormats/printMetadata.py
@@ -13,10 +13,6 @@ if __name__ == "__main__":
 	pyRootPwa.core.printLibraryInfo()
 	pyRootPwa.core.printGitHash()
 
-	# making the output nice for multi-threading
-	pyRootPwa.utils.stdoutisatty = sys.stdout.isatty()
-	pyRootPwa.utils.stderrisatty = sys.stderr.isatty()
-
 	#initialize the printing functors
 	printingCounter = multiprocessing.Array('i', [0]*5)
 	pyRootPwa.utils.printErr = pyRootPwa.utils.printErrClass(printingCounter)


### PR DESCRIPTION
* continue to remove the old binary amplitude file format and change the ROOT format over to using metadata
 * change a couple of comments
 * remove the option to read binary amplitude files and ASCII integral matrices from `weightEvents`, use `amplitudeMetadata` to get the tree containing the amplitudes

* new wave naming scheme in
 * `weightEvents`
 * `genPseudoData.py` (exporting `partialWaveFitHelper::getReflectivity` for this)

* move the initialization of `stdoutisatty` and `stderrisatty` so that it is done while `import pyRootPwa` so that not every script needs to set this

* phase-space integral used in the mass dependent fit now is the real phase-space integral without the factor `mass` that Dima includes

* correct various error messages and warnings