### PR TITLE
pyInterface: Add more physUtils bindings.

### DIFF
--- a/pyInterface/utilities/physUtils_py.cc
+++ b/pyInterface/utilities/physUtils_py.cc
@@ -25,6 +25,14 @@ void rpwa::py::exportPhysUtils() {
 		   bp::arg("m2"))
 	);
 	bp::def(
+		"breakupMomentumSquared"
+		, &rpwa::breakupMomentumSquared
+		, (bp::arg("M"),
+		   bp::arg("m1"),
+		   bp::arg("m2"),
+		   bp::arg("allowSubThr")=false)
+	);
+	bp::def(
 		"barrierFactorSquared"
 		, &rpwa::barrierFactorSquared
 		, (bp::arg("L"),


### PR DESCRIPTION
Add the bindings for the physUtils functions breakupMomentumSquared and
breitWigner.