### PR TITLE
add tprime function from kinematic variables

### DIFF
--- a/pyInterface/utilities/physUtils_py.cc
+++ b/pyInterface/utilities/physUtils_py.cc
@@ -1,14 +1,29 @@
 #include "physUtils_py.h"
 
 #include <boost/python.hpp>
-
+#include <TLorentzVector.h>
 #include "physUtils.hpp"
-
+#include "rootConverters_py.h"
 namespace bp = boost::python;
 
 
+double tPrime_py(PyObject* beam, PyObject* target, PyObject* out){
+        TLorentzVector* lvBeam   = rpwa::py::convertFromPy<TLorentzVector*>(beam  );
+        TLorentzVector* lvTarget = rpwa::py::convertFromPy<TLorentzVector*>(target);
+        TLorentzVector* lvOut    = rpwa::py::convertFromPy<TLorentzVector*>(out   );
+
+        return rpwa::tPrime(*lvBeam,*lvTarget,*lvOut);
+};
+
 void rpwa::py::exportPhysUtils() {
 
+        bp::def(
+	        "tPrime"
+	        , &tPrime_py
+	        , (bp::arg("pBeam"),
+	           bp::arg("pTarget"),
+	           bp::arg("pOut"))
+	);
 	bp::def(
 		"breakupMomentumSquared"
 		, &rpwa::breakupMomentumSquared

--- a/utilities/physUtils.hpp
+++ b/utilities/physUtils.hpp
@@ -34,6 +34,7 @@
 #ifndef PHYSUTILS_H
 #define PHYSUTILS_H
 
+#include <TLorentzVector.h>
 
 #include "mathUtils.hpp"
 #include "reportingUtils.hpp"
@@ -42,6 +43,29 @@
 
 namespace rpwa {
 
+
+	inline
+	double
+	tPrime(
+		TLorentzVector          lvBeam,         // Beam
+		TLorentzVector          lvTarget,       // Target
+		TLorentzVector          lvOut){         // Outgoing resonance X
+
+		TVector3 boostTarget = lvTarget.BoostVector();
+		lvTarget.Boost(boostTarget);
+		lvBeam.Boost(boostTarget);
+		lvOut.Boost(boostTarget);
+
+		const double a = 4.*std::pow(lvBeam.P(), 2.) - 4.*std::pow(lvBeam.E()+lvTarget.M(), 2.);
+		const double b = 4.*lvBeam.P()*(lvBeam.M2() + lvOut.M2() + 2.*lvTarget.M()*lvBeam.E());
+		const double c = std::pow(lvBeam.M2() + lvOut.M2() + 2.*0.938272*lvBeam.E(), 2.) - 4.*lvOut.M2()*std::pow(lvBeam.E()+lvTarget.M(), 2.);
+		const double p3 = (-b/2. - sqrt(std::pow(b/2., 2.) - a*c)) / a;
+		const double tMin = lvBeam.M2() + lvOut.M2() - 2.*lvBeam.E()*sqrt(p3*p3 + lvOut.M2()) + 2.*lvBeam.P()*p3;
+
+		TLorentzVector lvT = lvBeam - lvOut;	// Four momentum transfer
+
+		return tMin - lvT.M2();
+	};
 
 	// computes squared breakup momentum of 2-body decay
 	inline


### PR DESCRIPTION
function added to calculate tprime (t') from kinematic variables as
TLorentzVectors. Implement this as method for the decayTopology as well
as in the python bindings to be called from python