### PR TITLE
pyInterface: Fix a bug in amplitudeMetadata_py.

### DIFF
--- a/pyInterface/storageFormats/amplitudeMetadata_py.cc
+++ b/pyInterface/storageFormats/amplitudeMetadata_py.cc
@@ -12,7 +12,12 @@ namespace {
 
 	bp::list amplitudeMetadata_eventMetadata(const rpwa::amplitudeMetadata& self)
 	{
-		return bp::list(self.eventMetadata());
+		bp::list retval;
+		const std::vector<rpwa::eventMetadata>& metas = self.eventMetadata();
+		for(unsigned int i = 0; i < metas.size(); ++i) {
+			retval.append(bp::object(boost::cref(metas[i])));
+		}
+		return retval;
 	}
 
 	const rpwa::amplitudeMetadata* amplitudeMetadata_readAmplitudeFile(PyObject* pyInputFile,


### PR DESCRIPTION
Fix a bug in the python bindings for amplitudeMetadata, which prevented the
retrieval of the event metadata information.