### PR TITLE
pyInterface: short term fix for genPseudoData

### DIFF
--- a/pyInterface/decayAmplitude/ampIntegralMatrix_py.cc
+++ b/pyInterface/decayAmplitude/ampIntegralMatrix_py.cc
@@ -135,14 +135,10 @@ void rpwa::py::exportAmpIntegralMatrix() {
 
 		.def("Write", &ampIntegralMatrix_Write, bp::arg("name")=0)
 		.def("setBranchAddress", &rpwa::py::setBranchAddress<rpwa::ampIntegralMatrix*>)
+		.def("getFromTDirectory", &rpwa::py::getFromTDirectory<rpwa::ampIntegralMatrix>, bp::return_value_policy<bp::manage_new_object>())
+		.staticmethod("getFromTDirectory")
 
 		.add_static_property("debugAmpIntegralMatrix", &rpwa::ampIntegralMatrix::debug, &rpwa::ampIntegralMatrix::setDebug)
 		.def_readonly("integralObjectName", &rpwa::ampIntegralMatrix::integralObjectName);
-
-	bp::def(
-		"getFromTDirectory"
-		, &rpwa::py::getFromTDirectory<rpwa::ampIntegralMatrix>
-		, bp::return_value_policy<bp::manage_new_object>()
-	);
 
 }

--- a/pyInterface/genPseudoData.py
+++ b/pyInterface/genPseudoData.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
 	# read integral matrix from ROOT file
 	integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile)
-	integral = pyRootPwa.core.getFromTDirectory(integralFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
+	integral = pyRootPwa.core.ampIntegralMatrix.getFromTDirectory(integralFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
 	integralFile.Close()
 	nmbNormEvents = integral.nmbEvents()
 

--- a/pyInterface/genPseudoData.py
+++ b/pyInterface/genPseudoData.py
@@ -72,10 +72,14 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("loading config file '" + args.configFileName + "' failed. Aborting...")
 		sys.exit(1)
 	pyRootPwa.core.particleDataTable.instance.readFile(config.pdgFileName)
+	fileManager = pyRootPwa.loadFileManager(config.fileManagerPath)
+	if not fileManager:
+		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
+		sys.exit(1)
 
 	# read integral matrix from ROOT file
 	integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile)
-	integral = pyRootPwa.core.ampIntegralMatrix(integralFile.Get(pyRootPwa.core.ampIntegralMatrix.integralObjectName))
+	integral = pyRootPwa.core.getFromTDirectory(integralFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
 	integralFile.Close()
 	nmbNormEvents = integral.nmbEvents()
 
@@ -136,7 +140,7 @@ if __name__ == "__main__":
 		waveNames.remove('flat')  # ignore flat wave
 
 	for waveName in waveNames:
-		keyfile = keyfileDirectory + "/" + waveName + ".key"
+		keyfile = fileManager.getKeyFile(waveName)
 		if not os.path.isfile(keyfile):
 			printErr('keyfile "' + keyfile + '" does not exist. Aborting...')
 			sys.exit(1)


### PR DESCRIPTION
Fix genPseudoData in the short term. Not yet a nice implementation of the file
manager since there is currently work being done on that front. Just a quick
and dirty fix so the script works.