### PR TITLE
Fix a couple of things concerning mass dependencies and keyfiles

### DIFF
--- a/decayAmplitude/massDependence.h
+++ b/decayAmplitude/massDependence.h
@@ -108,7 +108,7 @@ namespace rpwa {
 
 		virtual std::complex<double> amp(const isobarDecayVertex&);
 
-		virtual std::string name() const { return "flatMassDependence"; }  ///< returns label used in graph visualization, reporting, and key file
+		virtual std::string name() const { return "flat"; }  ///< returns label used in graph visualization, reporting, and key file
 
 	};
 
@@ -136,7 +136,7 @@ namespace rpwa {
 
 		virtual std::complex<double> amp(const isobarDecayVertex&);
 
-		virtual std::string name() const { return "flatRangeMassDependence"; }  ///< returns label used in graph visualization, reporting, and key file
+		virtual std::string name() const { return "flatRange"; }  ///< returns label used in graph visualization, reporting, and key file
 
 	};
 
@@ -255,7 +255,7 @@ namespace rpwa {
 
 		virtual std::complex<double> amp(const isobarDecayVertex& v);
 
-		virtual std::string name() const { return "f0980BreitWigner"; }  ///< returns label used in graph visualization, reporting, and key file
+		virtual std::string name() const { return "f_0(980)"; }  ///< returns label used in graph visualization, reporting, and key file
 
 	};
 
@@ -284,7 +284,7 @@ namespace rpwa {
 
 		virtual std::complex<double> amp(const isobarDecayVertex& v);
 
-		virtual std::string name() const { return "f0980Flatte"; }  ///< returns label used in graph visualization, reporting, and key file
+		virtual std::string name() const { return "f_0(980)Flatte"; }  ///< returns label used in graph visualization, reporting, and key file
 
 	private:
 		double _piChargedMass;
@@ -430,7 +430,7 @@ namespace rpwa {
 
 		virtual std::complex<double> amp(const isobarDecayVertex& v);
 
-		virtual std::string name() const { return "rhoPrimeMassDep"; }  ///< returns label used in graph visualization, reporting, and key file
+		virtual std::string name() const { return "rhoPrime"; }  ///< returns label used in graph visualization, reporting, and key file
 
 	};
 

--- a/decayAmplitude/waveDescription.cc
+++ b/decayAmplitude/waveDescription.cc
@@ -867,13 +867,14 @@ waveDescription::setXQuantumNumbersKeys(Setting&        XQnKey,
 
 bool
 waveDescription::setMassDependence(Setting&              isobarDecayKey,
-                                   const massDependence& massDep)
+                                   const massDependence& massDep,
+                                   const bool            XDecay)
 {
 	const string massDepName = massDep.name();
-	if (massDepName == "flat")
+	if (XDecay && massDepName == "flat")
 		// default for X
 		return true;
-	else if (massDepName == "relativisticBreitWigner")
+	else if ((not XDecay) && massDepName == "relativisticBreitWigner")
 		// default mass dependence for isobars
 		return true;
 	else {
@@ -894,7 +895,7 @@ waveDescription::setXDecayKeys(Setting&                   parentDecayKey,
 {
 	if (_debug)
 		printDebug << "setting keys for decay " << vert << endl;
-	setMassDependence(parentDecayKey, *vert.massDependence());
+	setMassDependence(parentDecayKey, *vert.massDependence(), *topo.XIsobarDecayVertex() == vert);
 	vector<particlePtr> fsParticles;
 	vector<particlePtr> isobars;
 	for (unsigned int i = 0; i < vert.nmbOutParticles(); ++i) {

--- a/decayAmplitude/waveDescription.cc
+++ b/decayAmplitude/waveDescription.cc
@@ -658,7 +658,7 @@ massDependencePtr
 waveDescription::mapMassDependenceType(const string& massDepType)
 {
 	massDependencePtr massDep;
-	if (   (massDepType == "BreitWigner")
+	if (   (massDepType == "relativisticBreitWigner")
 	    or (massDepType == ""))  // default mass dependence
 		massDep = createRelativisticBreitWigner();
 	else if (massDepType == "constWidthBreitWigner")
@@ -870,7 +870,7 @@ waveDescription::setMassDependence(Setting&              isobarDecayKey,
                                    const massDependence& massDep)
 {
 	const string massDepName = massDep.name();
-	if (massDepName == "flatMassDependence")
+	if (massDepName == "flat")
 		// default for X
 		return true;
 	else if (massDepName == "relativisticBreitWigner")

--- a/decayAmplitude/waveDescription.h
+++ b/decayAmplitude/waveDescription.h
@@ -140,7 +140,8 @@ namespace rpwa {
 		static bool setXQuantumNumbersKeys(libconfig::Setting& XQnKey,
 		                                   const particle&     X);  ///< puts X quantum numbers into keys
 		static bool setMassDependence(libconfig::Setting&   isobarMassDepKey,
-		                              const massDependence& massDep);  ///< puts mass dependence into key
+		                              const massDependence& massDep,
+		                              const bool            XDecay = false);  ///< puts mass dependence into key
 		static bool setXDecayKeys(libconfig::Setting&        parentDecayKey,
 		                          const isobarDecayTopology& topo,
 		                          const isobarDecayVertex&   vert);  ///< recursive function that puts X decay chain into keys

--- a/pyInterface/decayAmplitude/waveDescription_py.cc
+++ b/pyInterface/decayAmplitude/waveDescription_py.cc
@@ -36,7 +36,7 @@ namespace {
 
 	bool waveDescription_writeKeyFile(const std::string& keyFileName,
 	                                  const bp::object   pyTopoOrAmp,
-							          const bool         writeProdVert = true)
+	                                  const bool         writeProdVert)
 	{
 		bp::extract<rpwa::isobarDecayTopology> get_iDT(pyTopoOrAmp);
 		if(get_iDT.check()) {
@@ -79,7 +79,7 @@ void rpwa::py::exportWaveDescription() {
 			, &waveDescription_writeKeyFile
 			, (bp::arg("keyFileName"),
 			   bp::arg("topoOrAmp"),
-			   bp::arg("writeProdVert")=false)
+			   bp::arg("writeProdVert")=true)
 		)
 		.staticmethod("writeKeyFile")
 

--- a/pyInterface/testPyRootPwa.py
+++ b/pyInterface/testPyRootPwa.py
@@ -470,7 +470,7 @@ do_test(isobarDecVtxTestMD, "Testing isobarDecayVertex.massDependence()")
 
 def isobarDecVtxTestSetMD():
 	isobDecVtx.setMassDependence(pyRootPwa.core.flatMassDependence())
-	assert(isobDecVtx.massDependence().name() == "flatMassDependence")
+	assert(isobDecVtx.massDependence().name() == "flat")
 do_test(isobarDecVtxTestSetMD, "Testing isobarDecayVertex.setMassDependence()")
 
 def isobarDecVtxTestCC():
@@ -512,7 +512,7 @@ do_test(flatMassDepTestDebug, "Testing massDependence debug flag.")
 def flatMassDepTestAmp(): assert(flatMassDep.amp(isobDecVtx) == (1+0j))
 do_test(flatMassDepTestAmp, "Testing flatMassDependence.amp()")
 
-def flatMassDepTestName(): assert(flatMassDep.name() == "flatMassDependence")
+def flatMassDepTestName(): assert(flatMassDep.name() == "flat")
 do_test(flatMassDepTestName, "Testing flatMassDependence.name()")
 
 def relBreitWigTestConst(): return pyRootPwa.core.relativisticBreitWigner()
@@ -560,7 +560,7 @@ def f0980BreitWigTestAmp():
 	assert(math.isnan(amp.real) and math.isnan(amp.imag))
 do_test(f0980BreitWigTestAmp, "Testing f0980BreitWigner.amp()")
 
-def f0980BreitWigTestName(): assert(f0980BreitWig.name() == "f0980BreitWigner")
+def f0980BreitWigTestName(): assert(f0980BreitWig.name() == "f_0(980)")
 do_test(f0980BreitWigTestName, "Testing f0980BreitWigner.name()")
 
 def SAuMoPenMTestConst(): return pyRootPwa.core.piPiSWaveAuMorganPenningtonM()
@@ -612,7 +612,7 @@ def rhoPrimeTestAmp():
 	assert(zero.imag < 1e-5)
 do_test(rhoPrimeTestAmp, "Testing rhoPrimeMassDep.amp()")
 
-def rhoPrimeTestName(): assert(rhoPrime.name() == "rhoPrimeMassDep")
+def rhoPrimeTestName(): assert(rhoPrime.name() == "rhoPrime")
 do_test(rhoPrimeTestName, "Testing rhoPrimeMassDep.name()")
 
 print


### PR DESCRIPTION
* use same mass dependence names when writing and reading keyfile
* allow to store `flatMassDependence` for an isobar decay
* Python default value in `waveDescription::writeKeyFile` is same as in C++