### PR TITLE
partialWaveFit: fix second derivative of Cauchy prior.

### DIFF
--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -96,7 +96,7 @@ namespace {
 		}
 		const double x2 = x*x;
 		const double gamma2 = gamma*gamma;
-		return (6. * x2 * gamma2 - 2 * gamma2*gamma2) / ((gamma2 + x2) * (gamma2 + x2) + (gamma2 + x2));
+		return gamma2 / ((gamma2 + x2) * (gamma2 + x2)) * (-2. + 8. * x2 / (gamma2 + x2));
 	}
 
 }


### PR DESCRIPTION
Fix the second derivative of the Cauchy prior, this also fixes negative
eigenvalues in the Hesse matrix that appeared when using the Cauchy
prior.