### PR TITLE
partialWaveFit: Clean up wave name escaping.

### DIFF
--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -516,7 +516,7 @@ fitResult::spinDensityMatrixElemCov(const unsigned int waveIndexA,
 ///
 /// int = sum_i int(i) + sum_i sum_{j < i} overlap(i, j)
 double
-fitResult::intensity(const char* waveNamePattern) const
+fitResult::intensity(const string& waveNamePattern) const
 {
 	vector<unsigned int> waveIndices = waveIndicesMatchingPattern(waveNamePattern);
 	if(waveIndices.size() == 1) {
@@ -566,7 +566,7 @@ fitResult::normIntegralForProdAmp(const unsigned int prodAmpIndexA,
 ///
 /// error calculation is performed on amplitude level using: int = sum_ij Norm_ij sum_r A_ir A_jr*
 double
-fitResult::intensityErr(const char* waveNamePattern) const
+fitResult::intensityErr(const string& waveNamePattern) const
 {
 	// get amplitudes that correspond to wave name pattern
 	const vector<unsigned int> prodAmpIndices = prodAmpIndicesMatchingPattern(waveNamePattern);

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -62,30 +62,36 @@
 namespace rpwa {
 
 	inline
-	TString
+	std::string
 	escapeRegExpSpecialChar(const std::string& s)  ///< escapes all special characters used in regular expressions
 	{
 		TString escapedS(s);
-		const char specialChars[] = {'^', '$', '.', '[', ']', '^', '*', '+', '?'};
+		const char specialChars[] = {'^', '$', '.', '[', ']', '*', '+', '?'};
 		for (unsigned int i = 0; i < sizeof(specialChars) / sizeof(specialChars[0]); ++i) {
-			TString escapedChar = TString("\\").Append(specialChars[i]);
+			const TString escapedChar = TString("\\").Append(specialChars[i]);
 			escapedS.ReplaceAll(specialChars[i], escapedChar);
+			const TString escapedTwiceChar = TString("\\").Append(escapedChar);
+			while(escapedS.Contains(escapedTwiceChar)) {
+				escapedS.ReplaceAll(escapedTwiceChar, escapedChar);
+			}
 		}
-		return escapedS;
+		return std::string(escapedS.Data());
 	}
 
 
 	inline
-	TString
-	unescapeRegExpSpecialChar(const std::string& s)  ///< escapes all special characters used in regular expressions
+	std::string
+	unescapeRegExpSpecialChar(const std::string& s)  ///< unescapes all special characters used in regular expressions
 	{
 		TString escapedS(s);
-		const char specialChars[] = {'^', '$', '.', '[', ']', '^', '*', '+', '?'};
+		const char specialChars[] = {'^', '$', '.', '[', ']', '*', '+', '?'};
 		for (unsigned int i = 0; i < sizeof(specialChars) / sizeof(specialChars[0]); ++i) {
-			TString escapedChar = TString("\\").Append(specialChars[i]);
-			escapedS.ReplaceAll(escapedChar, specialChars[i]);
+			const TString escapedChar = TString("\\").Append(specialChars[i]);
+			while(escapedS.Contains(escapedChar)) {
+				escapedS.ReplaceAll(escapedChar, specialChars[i]);
+			}
 		}
-		return escapedS;
+		return std::string(escapedS.Data());
 	}
 
 
@@ -186,8 +192,8 @@ namespace rpwa {
 		double intensity   (const unsigned int waveIndex)         const { return spinDensityMatrixElem(waveIndex, waveIndex).real();         }
 		/// returns error of intensity of single wave at index
 		double intensityErr(const unsigned int waveIndex)         const { return sqrt(spinDensityMatrixElemCov(waveIndex, waveIndex)[0][0]); }
-		double intensity   (const char*        waveNamePattern) const;                                ///< returns intensity of sum of waves matching name pattern
-		double intensityErr(const char*        waveNamePattern) const;                                ///< returns error of intensity of sum of waves matching name pattern
+		double intensity   (const std::string& waveNamePattern) const;                                ///< returns intensity of sum of waves matching name pattern
+		double intensityErr(const std::string& waveNamePattern) const;                                ///< returns error of intensity of sum of waves matching name pattern
 		double intensity   ()                                   const { return intensity   (".*"); }  ///< returns total intensity
 		double intensityErr()                                   const { return intensityErr(".*"); }  ///< returns error of total intensity
 
@@ -493,14 +499,9 @@ namespace rpwa {
 	std::vector<unsigned int>
 	fitResult::waveIndicesMatchingPattern(const std::string& waveNamePattern) const
 	{
-		// escape special characters:
-		TString Pattern(waveNamePattern);
-		Pattern.ReplaceAll("+","\\+");
-		Pattern.ReplaceAll("\\\\+","\\+");
-		TPRegexp Regexp(Pattern);
+		TPRegexp Regexp(waveNamePattern);
 		std::vector<unsigned int> waveIndices;
 		for (unsigned int waveIndex = 0; waveIndex < nmbWaves(); ++waveIndex){
-			//std::cout<<waveName(waveIndex)<<std::endl;
 			if (waveName(waveIndex).Contains(Regexp))
 				waveIndices.push_back(waveIndex);
 		}
@@ -513,11 +514,7 @@ namespace rpwa {
 	std::vector<unsigned int>
 	fitResult::prodAmpIndicesMatchingPattern(const std::string& ampNamePattern) const
 	{
-		// escape special characters:
-		TString Pattern(ampNamePattern);
-		Pattern.ReplaceAll("+","\\+");
-		Pattern.ReplaceAll("\\\\+","\\+");
-		TPRegexp Regexp(Pattern);
+		TPRegexp Regexp(ampNamePattern);
 		std::vector<unsigned int> prodAmpIndices;
 		for (unsigned int prodAmpIndex = 0; prodAmpIndex < nmbProdAmps(); ++prodAmpIndex)
 			if (prodAmpName(prodAmpIndex).Contains(Regexp))

--- a/plotScripts/plotGui.C
+++ b/plotScripts/plotGui.C
@@ -188,7 +188,7 @@ plotGuiMainFrame::plotGuiMainFrame(const TGWindow *p,
 				}
 				for(unsigned int treeIndex = 0; treeIndex < _fitResults.size(); ++treeIndex) {
 					for(unsigned int bin_i = 0; bin_i < _fitResults[treeIndex].size(); ++bin_i) {
-						const double intensity = _fitResults[treeIndex][bin_i]->intensity(waveName.c_str());
+						const double intensity = _fitResults[treeIndex][bin_i]->intensity(escapeRegExpSpecialChar(waveName));
 						if(intensity >= intensityThreshold) {
 							whitelistedWaves.insert(waveName);
 							break;
@@ -464,16 +464,16 @@ void plotGuiMainFrame::PrintSelected(const int sel1, const int sel2)
 			complex<double> rho(0., 0.);
 			TMatrixT<double> rhoCov(2, 2);
 			if(wi1 >= 0) {
-				intensity1 = result->intensity(w1.c_str());
-				intensityErr1 = result->intensityErr(w1.c_str());
+				intensity1 = result->intensity(escapeRegExpSpecialChar(w1));
+				intensityErr1 = result->intensityErr(escapeRegExpSpecialChar(w1));
 			}
 			if(wi2 >= 0) {
-				intensity2 = result->intensity(w2.c_str());
-				intensityErr2 = result->intensityErr(w2.c_str());
+				intensity2 = result->intensity(escapeRegExpSpecialChar(w2));
+				intensityErr2 = result->intensityErr(escapeRegExpSpecialChar(w2));
 			}
 			if(wi1 >= 0 and wi2 >= 0) {
-				ph = result->phase(w1.c_str(), w2.c_str());
-				phErr = result->phaseErr(w1.c_str(), w2.c_str());
+				ph = result->phase(w1, w2);
+				phErr = result->phaseErr(w1, w2);
 				rho = result->spinDensityMatrixElem(wi1, wi2);
 				rhoCov = result->spinDensityMatrixElemCov(wi1, wi2);
 			}

--- a/pyInterface/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/partialWaveFit/fitResult_py.cc
@@ -286,6 +286,9 @@ namespace {
 
 void rpwa::py::exportFitResult() {
 
+	bp::def("escapeRegExpSpecialChar", &rpwa::escapeRegExpSpecialChar);
+	bp::def("unescapeRegExpSpecialChar", &rpwa::unescapeRegExpSpecialChar);
+
 	bp::class_<rpwa::fitResult>("fitResult")
 		.def(bp::init<const rpwa::fitResult&>())
 		.def(bp::self_ns::str(bp::self))


### PR DESCRIPTION
Clean up the business with the pattern matching for wave names in the fit
result by removing some ancient lines, making the escaping functions available
in python and adjusting plotGui accordingly. This probably breaks some of the
root scripts using the fit result, but all the compiled code seems to continue
to work.