### PR TITLE
Fix things.

### DIFF
--- a/pyInterface/package/utils/_fitTreeUtils.py
+++ b/pyInterface/package/utils/_fitTreeUtils.py
@@ -20,5 +20,9 @@ def getFitResultDict(fitResultTree):
 	return retval
 
 def getBestFitResults(fitResultTree):
-	return { massBin: res[0] for massBin, res in getFitResultDict(fitResultTree).iteritems() }
+	retval = { }
+	fitResultDict = getFitResultDict(fitResultTree)
+	for massBinCenter, results in fitResultDict.iteritems():
+		retval[massBinCenter] = results[0]
+	return retval
 

--- a/pyInterface/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/partialWaveFit/fitResult_py.cc
@@ -231,6 +231,11 @@ namespace {
 		return retval;
 	}
 
+	bp::list fitResult_phaseSpaceIntegralVector(const rpwa::fitResult& self)
+	{
+		return bp::list(self.phaseSpaceIntegralVector());
+	}
+
 	bp::dict fitResult_normIntIndexMap(const rpwa::fitResult self)
 	{
 		bp::dict retval;
@@ -356,6 +361,7 @@ void rpwa::py::exportFitResult() {
 			, &rpwa::fitResult::acceptedNormIntegralMatrix
 			, bp::return_value_policy<bp::copy_const_reference>()
 		)
+		.def("phaseSpaceIntegralVector", &fitResult_phaseSpaceIntegralVector)
 		.def("normIntIndexMap", &fitResult_normIntIndexMap)
 		.def("printProdAmpNames", &fitResult_printProdAmpNames)
 		.def("printWaveNames", &fitResult_printWaveNames)


### PR DESCRIPTION
Add a python binding for a fit result function which was missed and make rootpwa compile again in a python 2.6 environment.