### PR TITLE
partialWaveFit: Remove TString from interface.

### DIFF
--- a/generators/weightEvents.cc
+++ b/generators/weightEvents.cc
@@ -338,8 +338,8 @@ main(int    argc,
 			}
 
 			for (unsigned int iProdAmp = 0; iProdAmp < result->nmbProdAmps(); ++iProdAmp) {
-				const string prodAmpName = result->prodAmpName(iProdAmp).Data();
-				const string waveName    = result->waveNameForProdAmp(iProdAmp).Data();
+				const string prodAmpName = result->prodAmpName(iProdAmp);
+				const string waveName    = result->waveNameForProdAmp(iProdAmp);
 				const int iWave          = result->waveIndex(waveName);
 
 				// extract rank and reflectivity from wave name

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -189,7 +189,7 @@ fitResult::evidenceComponents() const
 	set<unsigned int> thrWaveIndices;
 	for (set<unsigned int>::const_iterator it = thrProdAmpIndices.begin();
 	     it != thrProdAmpIndices.end(); ++it) {
-		const int index = waveIndex(waveNameForProdAmp(*it).Data());
+		const int index = waveIndex(waveNameForProdAmp(*it));
 		// printDebug << " wave[" << index << "] = '" << waveNameForProdAmp(*it).Data()
 		//            << "' has zero production amp[" << *it << "] = '"
 		//            << _prodAmpNames[*it] << "'" << endl;
@@ -543,8 +543,8 @@ fitResult::normIntegralForProdAmp(const unsigned int prodAmpIndexA,
                                   const unsigned int prodAmpIndexB) const
 {
 	// treat special case of flat wave which has no normalization integral
-	const bool flatWaveA = prodAmpName(prodAmpIndexA).Contains("flat");
-	const bool flatWaveB = prodAmpName(prodAmpIndexB).Contains("flat");
+	const bool flatWaveA = (prodAmpName(prodAmpIndexA).find("flat") != string::npos);
+	const bool flatWaveB = (prodAmpName(prodAmpIndexB).find("flat") != string::npos);
 	if (flatWaveA and flatWaveB)
 		return 1;
 	else if (flatWaveA or flatWaveB)
@@ -820,7 +820,7 @@ fitResult::fill
 		// look for index of first occurence
 		unsigned int j;
 		for (j = 0; j < _prodAmpNames.size(); ++j)
-			if (prodAmpName(j).Contains(waveName))
+			if (prodAmpName(j).find(waveName) != string::npos)
 				break;
 		_normIntIndexMap[i] = j;
 	}

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -141,11 +141,11 @@ namespace rpwa {
 		unsigned int nmbWaves     () const { return _waveNames.size();  }  ///< returns number of waves in fit
 		unsigned int nmbProdAmps  () const { return _prodAmps.size();   }  ///< returns number of production amplitudes
 
-		TString waveName      (const unsigned int waveIndex)    const { return _waveNames[waveIndex];                                }  ///< returns name of wave at index
-		TString waveNameEsc   (const unsigned int waveIndex)    const { return escapeRegExpSpecialChar(_waveNames[waveIndex]);       }  ///< returns name of wave at index with special regexp characters escaped
-		TString prodAmpName   (const unsigned int prodAmpIndex) const { return _prodAmpNames[prodAmpIndex];                          }  ///< returns name of production amplitude at index
-		TString prodAmpNameEsc(const unsigned int prodAmpIndex) const { return escapeRegExpSpecialChar(_prodAmpNames[prodAmpIndex]); }  ///< returns name of production amplitude at index with special regexp characters escaped
-		inline TString waveNameForProdAmp(const unsigned int prodAmpIndex) const;
+		std::string waveName      (const unsigned int waveIndex)    const { return _waveNames[waveIndex];                                }  ///< returns name of wave at index
+		std::string waveNameEsc   (const unsigned int waveIndex)    const { return escapeRegExpSpecialChar(_waveNames[waveIndex]);       }  ///< returns name of wave at index with special regexp characters escaped
+		std::string prodAmpName   (const unsigned int prodAmpIndex) const { return _prodAmpNames[prodAmpIndex];                          }  ///< returns name of production amplitude at index
+		std::string prodAmpNameEsc(const unsigned int prodAmpIndex) const { return escapeRegExpSpecialChar(_prodAmpNames[prodAmpIndex]); }  ///< returns name of production amplitude at index with special regexp characters escaped
+		inline std::string waveNameForProdAmp(const unsigned int prodAmpIndex) const;
 		inline int     rankOfProdAmp     (const unsigned int prodAmpIndex) const;
 
 
@@ -268,7 +268,7 @@ namespace rpwa {
 		inline std::vector<unsigned int> waveIndicesMatchingPattern   (const std::string& waveNamePattern   ) const;
 		inline std::vector<unsigned int> prodAmpIndicesMatchingPattern(const std::string& prodAmpNamePattern) const;
 		std::vector<unsigned int>        prodAmpIndicesForWave        (const unsigned int waveIndex         ) const
-		{ return prodAmpIndicesMatchingPattern(waveNameEsc(waveIndex).Data()); }  ///< returns indices of production amplitudes that belong to wave at index
+		{ return prodAmpIndicesMatchingPattern(waveNameEsc(waveIndex)); }  ///< returns indices of production amplitudes that belong to wave at index
 		inline std::vector<std::pair<unsigned int, unsigned int> > prodAmpIndexPairsForWaves
 		(const unsigned int waveIndexA,
 		 const unsigned int waveIndexB) const;
@@ -502,7 +502,7 @@ namespace rpwa {
 		TPRegexp Regexp(waveNamePattern);
 		std::vector<unsigned int> waveIndices;
 		for (unsigned int waveIndex = 0; waveIndex < nmbWaves(); ++waveIndex){
-			if (waveName(waveIndex).Contains(Regexp))
+			if (TString(waveName(waveIndex)).Contains(Regexp))
 				waveIndices.push_back(waveIndex);
 		}
 		return waveIndices;
@@ -517,7 +517,7 @@ namespace rpwa {
 		TPRegexp Regexp(ampNamePattern);
 		std::vector<unsigned int> prodAmpIndices;
 		for (unsigned int prodAmpIndex = 0; prodAmpIndex < nmbProdAmps(); ++prodAmpIndex)
-			if (prodAmpName(prodAmpIndex).Contains(Regexp))
+			if (TString(prodAmpName(prodAmpIndex)).Contains(Regexp))
 				prodAmpIndices.push_back(prodAmpIndex);
 		return prodAmpIndices;
 	}
@@ -572,18 +572,16 @@ namespace rpwa {
 	/// "V<rank>_<wave name>" with exception "V_flat" for flat wave
 	/// <rank> is assumed to be a single-digit number
 	inline
-	TString
+	std::string
 	fitResult::waveNameForProdAmp(const unsigned int prodAmpIndex) const
 	{
-		const TString prodAmpName = _prodAmpNames[prodAmpIndex];
-		if (prodAmpName == "V_flat")
-			return "flat";
-		if (not prodAmpName.BeginsWith('V') or (prodAmpName[2] != '_')) {
+		const std::string& prodAmpName = _prodAmpNames[prodAmpIndex];
+		if (prodAmpName.length() == 0 or prodAmpName[0] != 'V' or prodAmpName.find('_') == std::string::npos) {
 			printErr << "production amplitude name '" << prodAmpName << "' does not follow the naming convention. "
 			         << "cannot deduce corresponding wave name." << std::endl;
 			return "";
 		}
-		return prodAmpName(3, prodAmpName.Length() - 3);
+		return prodAmpName.substr(prodAmpName.find('_')+1);
 	}
 
 

--- a/pyInterface/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/partialWaveFit/fitResult_py.cc
@@ -72,31 +72,6 @@ namespace {
 		return bp::list(self.evidenceComponents());
 	}
 
-	std::string fitResult_waveName(const rpwa::fitResult& self, const unsigned int waveIndex)
-	{
-		return std::string((const char*)self.waveName(waveIndex));
-	}
-
-	std::string fitResult_waveNameEsc(const rpwa::fitResult& self, const unsigned int waveIndex)
-	{
-		return std::string((const char*)self.waveNameEsc(waveIndex));
-	}
-
-	std::string fitResult_prodAmpName(const rpwa::fitResult& self, const unsigned int prodAmpIndex)
-	{
-		return std::string((const char*)self.prodAmpName(prodAmpIndex));
-	}
-
-	std::string fitResult_prodAmpNameEsc(const rpwa::fitResult& self, const unsigned int prodAmpIndex)
-	{
-		return std::string((const char*)self.prodAmpNameEsc(prodAmpIndex));
-	}
-
-	std::string fitResult_waveNameForProdAmp(const rpwa::fitResult& self, const unsigned int prodAmpIndex)
-	{
-		return std::string((const char*)self.waveNameForProdAmp(prodAmpIndex));
-	}
-
 	PyObject* fitResult_prodAmpCov_1(const rpwa::fitResult& self, const unsigned int prodAmpIndex)
 	{
 		return rpwa::py::convertToPy<TMatrixT<double> >(self.prodAmpCov(prodAmpIndex));
@@ -311,11 +286,11 @@ void rpwa::py::exportFitResult() {
 		.def("normNmbEvents", &rpwa::fitResult::normNmbEvents)
 		.def("nmbWaves", &rpwa::fitResult::nmbWaves)
 		.def("nmbProdAmps", &rpwa::fitResult::nmbProdAmps)
-		.def("waveName", &fitResult_waveName)
-		.def("waveNameEsc", &fitResult_waveNameEsc)
-		.def("prodAmpName", &fitResult_prodAmpName)
-		.def("prodAmpNameEsc", &fitResult_prodAmpNameEsc)
-		.def("waveNameForProdAmp", &fitResult_waveNameForProdAmp)
+		.def("waveName", &rpwa::fitResult::waveName)
+		.def("waveNameEsc", &rpwa::fitResult::waveNameEsc)
+		.def("prodAmpName", &rpwa::fitResult::prodAmpName)
+		.def("prodAmpNameEsc", &rpwa::fitResult::prodAmpNameEsc)
+		.def("waveNameForProdAmp", &rpwa::fitResult::waveNameForProdAmp)
 		.def("waveIndex", &rpwa::fitResult::waveIndex)
 		.def("prodAmpIndex", &rpwa::fitResult::prodAmpIndex)
 		.def("fitParameter", &rpwa::fitResult::fitParameter)

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -1606,7 +1606,7 @@ rpwa::massDepFit::massDepFit::readFitResultMatrices(TTree* tree,
 		// amplitudes of the fit result
 		std::vector<unsigned int> prodAmpIndicesForCov(_nrWaves);
 		for(unsigned int idxProdAmp=0; idxProdAmp < fit->nmbProdAmps(); ++idxProdAmp) {
-			const std::string waveName = fit->waveNameForProdAmp(idxProdAmp).Data();
+			const std::string waveName = fit->waveNameForProdAmp(idxProdAmp);
 
 			const std::map<std::string, size_t>::const_iterator it = _waveIndices.find(waveName);
 			// most of the waves are ignored


### PR DESCRIPTION
Change all the TStrings appearing in the interface of fitResult to std::string
and adapt all affected places accordingly.