### PR TITLE
pyInterface: Fix several root related problems.

### DIFF
--- a/pyInterface/decayAmplitude/ampIntegralMatrix_py.cc
+++ b/pyInterface/decayAmplitude/ampIntegralMatrix_py.cc
@@ -134,7 +134,6 @@ void rpwa::py::exportAmpIntegralMatrix() {
 		.def("readAscii", &ampIntegralMatrix_readAscii)
 
 		.def("Write", &ampIntegralMatrix_Write, bp::arg("name")=0)
-		.def("setBranchAddress", &rpwa::py::setBranchAddress<rpwa::ampIntegralMatrix*>)
 		.def("getFromTDirectory", &rpwa::py::getFromTDirectory<rpwa::ampIntegralMatrix>, bp::return_value_policy<bp::manage_new_object>())
 		.staticmethod("getFromTDirectory")
 

--- a/pyInterface/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/partialWaveFit/fitResult_py.cc
@@ -346,7 +346,15 @@ void rpwa::py::exportFitResult() {
 
 		.def("Write", &fitResult_Write, bp::arg("name")=0)
 		.def("setBranchAddress", &rpwa::py::setBranchAddress<rpwa::fitResult*>)
-		.def("branch", &rpwa::py::branch<rpwa::fitResult*>);
+		.def(
+			"branch"
+			, &rpwa::py::branch<rpwa::fitResult*>
+			, (bp::arg("fitResult"),
+			   bp::arg("tree"),
+			   bp::arg("name"),
+			   bp::arg("bufsize")=32000,
+			   bp::arg("splitlevel")=99)
+		);
 
 	bp::register_ptr_to_python<rpwa::fitResultPtr>();
 

--- a/pyInterface/pyUtils/rootConverters_py.cc
+++ b/pyInterface/pyUtils/rootConverters_py.cc
@@ -10,6 +10,7 @@
 
 #include<ampIntegralMatrix.h>
 #include<amplitudeMetadata.h>
+#include<amplitudeTreeLeaf.h>
 #include<pwaLikelihood.h>
 #include<fitResult.h>
 
@@ -45,8 +46,12 @@ int rpwa::py::setBranchAddress(T objectPtr, PyObject* pyTree, const std::string&
 		return tree->SetBranchAddress(name.c_str(), pointerMap[objectPtr]);
 }
 
+// explicit template instantiation
+template int rpwa::py::setBranchAddress<rpwa::fitResult*>(rpwa::fitResult* objectPtr, PyObject* pyTree, const std::string& name);
+template int rpwa::py::setBranchAddress<rpwa::amplitudeTreeLeaf*>(rpwa::amplitudeTreeLeaf* objectPtr, PyObject* pyTree, const std::string& name);
+
 template<typename T>
-bool rpwa::py::branch(T objectPtr, PyObject* pyTree, const std::string& name)
+bool rpwa::py::branch(T objectPtr, PyObject* pyTree, const std::string& name, int bufsize, int splitlevel)
 {
 		TTree* tree = rpwa::py::convertFromPy<TTree*>(pyTree);
 		if(not tree) {
@@ -58,13 +63,17 @@ bool rpwa::py::branch(T objectPtr, PyObject* pyTree, const std::string& name)
 		{
 			pointerMap[objectPtr] = new T(objectPtr);
 		}
-		TBranch* branch = tree->Branch(name.c_str(), pointerMap[objectPtr]);
+		TBranch* branch = tree->Branch(name.c_str(), pointerMap[objectPtr], bufsize, splitlevel);
 		if (branch == 0) {
 			return false;
 		} else {
 			return true;
 		}
 }
+
+// explicit template instantiation
+template bool rpwa::py::branch<rpwa::fitResult*>(rpwa::fitResult* objectPtr, PyObject* pyTree, const std::string& name, int bufsize, int splitlevel);
+template bool rpwa::py::branch<rpwa::amplitudeTreeLeaf*>(rpwa::amplitudeTreeLeaf* objectPtr, PyObject* pyTree, const std::string& name, int bufsize, int splitlevel);
 
 namespace {
 
@@ -170,9 +179,5 @@ void rpwa::py::exportRootConverters() {
 		"__RootConverters_convertFromPy_rpwaPwaLikelihood", &rpwa::py::convertFromPy<rpwa::pwaLikelihood<std::complex<double> >* >
 		, bp::return_internal_reference<1>()
 	);
-
-	rpwa::py::setBranchAddress<rpwa::fitResult*>(0, 0, "");
-	rpwa::py::setBranchAddress<rpwa::ampIntegralMatrix*>(0, 0, "");
-	rpwa::py::branch<rpwa::fitResult*>(0, 0, "");
 
 }

--- a/pyInterface/pyUtils/rootConverters_py.h
+++ b/pyInterface/pyUtils/rootConverters_py.h
@@ -20,7 +20,11 @@ namespace rpwa {
 		int setBranchAddress(T objectPtr, PyObject* pyTree, const std::string& name);
 
 		template<typename T>
-		bool branch(T objectPtr, PyObject* pyTree, const std::string& name);
+		bool branch(T objectPtr,
+		            PyObject* pyTree,
+		            const std::string& name,
+		            int bufsize = 32000,
+		            int splitlevel = 99);
 
 		template<typename T>
 		T* getFromTDirectory(PyObject* pyDir, const std::string& name);

--- a/pyInterface/storageFormats/amplitudeMetadata_py.cc
+++ b/pyInterface/storageFormats/amplitudeMetadata_py.cc
@@ -2,6 +2,9 @@
 
 #include <boost/python.hpp>
 
+#include <TPython.h>
+#include <TTree.h>
+
 #include "amplitudeMetadata.h"
 #include "rootConverters_py.h"
 
@@ -30,6 +33,12 @@ namespace {
 			bp::throw_error_already_set();
 		}
 		return rpwa::amplitudeMetadata::readAmplitudeFile(inputFile, objectBaseName, quiet);
+	}
+
+	PyObject* amplitudeMetadata_amplitudeTree(rpwa::amplitudeMetadata& self)
+	{
+		TTree* tree = self.amplitudeTree();
+		return TPython::ObjectProxy_FromVoidPtr(tree, tree->ClassName());
 	}
 
 }
@@ -72,6 +81,7 @@ void rpwa::py::exportAmplitudeMetadata() {
 			, bp::return_value_policy<bp::reference_existing_object>()
 		)
 		.staticmethod("readAmplitudeFile")
+		.def("amplitudeTree", &amplitudeMetadata_amplitudeTree)
 		.def_readonly("amplitudeLeafName", &rpwa::amplitudeMetadata::amplitudeLeafName)
 		;
 

--- a/pyInterface/storageFormats/amplitudeTreeLeaf_py.cc
+++ b/pyInterface/storageFormats/amplitudeTreeLeaf_py.cc
@@ -24,24 +24,6 @@ namespace {
 		return self.incohSubAmp(subAmpLabel);
 	}
 
-	int amplitudeTreeLeaf_setBranchAddress(rpwa::amplitudeTreeLeaf& self, PyObject* pyTree, std::string branchName) {
-		TTree* tree = rpwa::py::convertFromPy<TTree*>(pyTree);
-		if(not tree) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for tree when executing rpwa::amplitudeTreeLeaf::setBranchAddress()");
-			bp::throw_error_already_set();
-		}
-		return tree->SetBranchAddress(branchName.c_str(), &self);
-	}
-
-	void amplitudeTreeLeaf_branch(rpwa::amplitudeTreeLeaf& self, PyObject* pyTree, std::string name, int bufsize = 32000, int splitlevel = 99) {
-		TTree* tree = rpwa::py::convertFromPy<TTree*>(pyTree);
-		if(not tree) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for tree when executing rpwa::amplitudeTreeLeaf::branch()");
-			bp::throw_error_already_set();
-		}
-		tree->Branch(name.c_str(), &self, bufsize, splitlevel);
-	}
-
 }
 
 void rpwa::py::exportAmplitudeTreeLeaf() {
@@ -105,12 +87,12 @@ void rpwa::py::exportAmplitudeTreeLeaf() {
 		.def("setAmp", &rpwa::amplitudeTreeLeaf::setAmp)
 
 		.def("Write", &amplitudeTreeLeaf_Write, bp::arg("name")=0)
-		.def("setBranchAddress", &amplitudeTreeLeaf_setBranchAddress)
+		.def("setBranchAddress", &rpwa::py::setBranchAddress<rpwa::amplitudeTreeLeaf*>)
 		.def(
 			"branch"
-			, &amplitudeTreeLeaf_branch
-			, (bp::arg("pyTree"),
-			   bp::arg("pyAmplitudeTreeLeaf"),
+			, &rpwa::py::branch<rpwa::amplitudeTreeLeaf*>
+			, (bp::arg("amplitudeTreeLeaf"),
+			   bp::arg("tree"),
 			   bp::arg("name"),
 			   bp::arg("bufsize")=32000,
 			   bp::arg("splitlevel")=99)


### PR DESCRIPTION
Fix some problems in the python bindings for the amplitudeTreeLeaf concerning
writing and reading from a root tree, adapt the branch-creating function to
utilize the possibility to set bufsize and splitlevel and add a function which
was missing to the bindings of the amplitudeMetadata. Remove a tree-related
function from the bindings of the ampIntegralMatrix, as these classes are not
stored in trees.