### PR TITLE
pwaLikelihood: support boost and ROOT wrappers

### DIFF
--- a/pyInterface/partialWaveFit/pwaLikelihood_py.cc
+++ b/pyInterface/partialWaveFit/pwaLikelihood_py.cc
@@ -244,9 +244,16 @@ void rpwa::py::exportPwaLikelihood() {
 			   bp::arg("massBinCenter") = 0.)
 		)
 		.def("addNormIntegral", ::pwaLikelihood_addNormIntegral)
+		.def("addNormIntegral", &rpwa::pwaLikelihood<std::complex<double> >::addNormIntegral)
 		.def(
 			"addAccIntegral"
 			, ::pwaLikelihood_addAccIntegral
+			, (bp::arg("accMatrix"),
+			   bp::arg("accEventsOverride") = 0)
+		)
+		.def(
+			"addAccIntegral"
+			, &rpwa::pwaLikelihood<std::complex<double> >::addAccIntegral
 			, (bp::arg("accMatrix"),
 			   bp::arg("accEventsOverride") = 0)
 		)


### PR DESCRIPTION
add a second addNormIntegral and addAccIntegral python wrapper
to also support boost wrapped ampIntegralMatrices alongside with
the ROOT wrapped ones