### PR TITLE
Fix and improve resonance fit.

### DIFF
--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -45,7 +45,6 @@
 #include <TTree.h>
 #include <TFile.h>
 #include <TGraph.h>
-#include <TGraph2D.h>
 #include <TGraphErrors.h>
 #include <TMatrixD.h>
 #include <TMultiGraph.h>
@@ -1910,7 +1909,6 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 	TMultiGraph graphs;
 	graphs.SetName(_waveNames[idxWave].c_str());
 	graphs.SetTitle(_waveNames[idxWave].c_str());
-	graphs.SetDrawOption("AP");
 
 	TGraphErrors* systematics = NULL;
 	if(_sysPlotting) {
@@ -1919,14 +1917,12 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 		systematics->SetTitle((_waveNames[idxWave] + "__sys").c_str());
 		systematics->SetLineColor(kAzure-9);
 		systematics->SetFillColor(kAzure-9);
-		systematics->SetDrawOption("2");
 		graphs.Add(systematics, "2");
 	}
 
 	TGraphErrors* data = new TGraphErrors;
 	data->SetName((_waveNames[idxWave] + "__data").c_str());
 	data->SetTitle((_waveNames[idxWave] + "__data").c_str());
-	data->SetDrawOption("AP");
 	graphs.Add(data, "P");
 
 	TGraph* fit = new TGraph;
@@ -1935,13 +1931,12 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 	fit->SetLineColor(kRed);
 	fit->SetLineWidth(2);
 	fit->SetMarkerColor(kRed);
-	fit->SetDrawOption("AP");
-	graphs.Add(fit, "CP");
+	graphs.Add(fit, "L");
 
 	TGraph* phaseSpace = new TGraph;
 	phaseSpace->SetName((_waveNames[idxWave] + "__ps").c_str());
 	phaseSpace->SetTitle((_waveNames[idxWave] + "__ps").c_str());
-	graphs.Add(phaseSpace, "CP");
+	graphs.Add(phaseSpace, "L");
 
 	const std::vector<std::pair<size_t, size_t> >& compChannel = fitModel.getComponentChannel(idxWave);
 	std::vector<TGraph*> components;
@@ -1958,7 +1953,7 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 		component->SetLineColor(color);
 		component->SetMarkerColor(color);
 
-		graphs.Add(component, "CP");
+		graphs.Add(component, "L");
 		components.push_back(component);
 	}
 
@@ -1989,7 +1984,7 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 
 		double ps = pow(_inPhaseSpaceIntegrals[idxBin][idxMass][idxWave], 2);
 		if(fitModel.getFsmd() != NULL) {
-			ps *= std::norm(fitModel.getFsmd()->val(fitParameters, cache, _massBinCenters[idxMass], idxMass));
+			ps *= std::norm(fitModel.getFsmd()->val(fitParameters, cache, mass, idxMass));
 		}
 		phaseSpace->SetPoint(point, mass, ps);
 		maxP = std::max(maxP, ps);
@@ -2001,7 +1996,7 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 		}
 		++pointLimit;
 
-		const double intensity = fitModel.intensity(fitParameters, cache, idxWave, idxBin, _massBinCenters[idxMass], idxMass);
+		const double intensity = fitModel.intensity(fitParameters, cache, idxWave, idxBin, mass, idxMass);
 		fit->SetPoint(pointLimit, mass, intensity);
 		maxIE = std::max(maxIE, intensity);
 
@@ -2009,10 +2004,10 @@ rpwa::massDepFit::massDepFit::createPlotsWave(const rpwa::massDepFit::model& fit
 			const size_t idxComponent = compChannel[idxComponents].first;
 			const size_t idxChannel = compChannel[idxComponents].second;
 
-			std::complex<double> prodAmp = fitModel.getComponent(idxComponent)->val(fitParameters, cache, idxBin, _massBinCenters[idxMass], idxMass);
-			prodAmp *= fitModel.getComponent(idxComponent)->getCouplingPhaseSpace(fitParameters, cache, idxChannel, idxBin, _massBinCenters[idxMass], idxMass);
+			std::complex<double> prodAmp = fitModel.getComponent(idxComponent)->val(fitParameters, cache, idxBin, mass, idxMass);
+			prodAmp *= fitModel.getComponent(idxComponent)->getCouplingPhaseSpace(fitParameters, cache, idxChannel, idxBin, mass, idxMass);
 			if(fitModel.getFsmd() != NULL) {
-				prodAmp *= fitModel.getFsmd()->val(fitParameters, cache, _massBinCenters[idxMass], idxMass);
+				prodAmp *= fitModel.getFsmd()->val(fitParameters, cache, mass, idxMass);
 			}
 
 			components[idxComponents]->SetPoint(pointLimit, mass, norm(prodAmp));
@@ -2054,17 +2049,14 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 	TMultiGraph phase;
 	phase.SetName(phaseName.c_str());
 	phase.SetTitle(phaseName.c_str());
-	phase.SetDrawOption("AP");
 
 	TMultiGraph real;
 	real.SetName(realName.c_str());
 	real.SetTitle(realName.c_str());
-	real.SetDrawOption("AP");
 
 	TMultiGraph imag;
 	imag.SetName(imagName.c_str());
 	imag.SetTitle(imagName.c_str());
-	imag.SetDrawOption("AP");
 
 	TGraphErrors* phaseSystematics = NULL;
 	TGraphErrors* realSystematics = NULL;
@@ -2075,7 +2067,6 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 		phaseSystematics->SetTitle((phaseName + "__sys").c_str());
 		phaseSystematics->SetLineColor(kAzure-9);
 		phaseSystematics->SetFillColor(kAzure-9);
-		phaseSystematics->SetDrawOption("2");
 		phase.Add(phaseSystematics, "2");
 
 		realSystematics = new TGraphErrors;
@@ -2083,7 +2074,6 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 		realSystematics->SetTitle((realName + "__sys").c_str());
 		realSystematics->SetLineColor(kAzure-9);
 		realSystematics->SetFillColor(kAzure-9);
-		realSystematics->SetDrawOption("2");
 		real.Add(realSystematics, "2");
 
 		imagSystematics = new TGraphErrors;
@@ -2091,26 +2081,22 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 		imagSystematics->SetTitle((imagName + "__sys").c_str());
 		imagSystematics->SetLineColor(kAzure-9);
 		imagSystematics->SetFillColor(kAzure-9);
-		imagSystematics->SetDrawOption("2");
 		imag.Add(imagSystematics, "2");
 	}
 
 	TGraphErrors* phaseData = new TGraphErrors;
 	phaseData->SetName((phaseName + "__data").c_str());
 	phaseData->SetTitle((phaseName + "__data").c_str());
-	phaseData->SetDrawOption("AP");
 	phase.Add(phaseData, "P");
 
 	TGraphErrors* realData = new TGraphErrors;
 	realData->SetName((realName + "__data").c_str());
 	realData->SetTitle((realName + "__data").c_str());
-	realData->SetDrawOption("AP");
 	real.Add(realData, "P");
 
 	TGraphErrors* imagData = new TGraphErrors;
 	imagData->SetName((imagName + "__data").c_str());
 	imagData->SetTitle((imagName + "__data").c_str());
-	imagData->SetDrawOption("AP");
 	imag.Add(imagData, "P");
 
 	TGraph* phaseFit = new TGraph;
@@ -2119,8 +2105,7 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 	phaseFit->SetLineColor(kRed);
 	phaseFit->SetLineWidth(2);
 	phaseFit->SetMarkerColor(kRed);
-	phaseFit->SetDrawOption("AP");
-	phase.Add(phaseFit, "CP");
+	phase.Add(phaseFit, "L");
 
 	TGraph* realFit = new TGraph;
 	realFit->SetName((realName + "__fit").c_str());
@@ -2128,8 +2113,7 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 	realFit->SetLineColor(kRed);
 	realFit->SetLineWidth(2);
 	realFit->SetMarkerColor(kRed);
-	realFit->SetDrawOption("AP");
-	real.Add(realFit, "CP");
+	real.Add(realFit, "L");
 
 	TGraph* imagFit = new TGraph;
 	imagFit->SetName((imagName + "__fit").c_str());
@@ -2137,8 +2121,7 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 	imagFit->SetLineColor(kRed);
 	imagFit->SetLineWidth(2);
 	imagFit->SetMarkerColor(kRed);
-	imagFit->SetDrawOption("AP");
-	imag.Add(imagFit, "CP");
+	imag.Add(imagFit, "L");
 
 	// keep track of phase over full mass range
 	TGraph phaseFitAll;
@@ -2196,7 +2179,7 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 			imagSystematics->SetPointError(point, halfBin, (maxSI-minSI)/2.);
 		}
 
-		phaseFitAll.SetPoint(point, mass, fitModel.phase(fitParameters, cache, idxWave, jdxWave, idxBin, _massBinCenters[idxMass], idxMass) * TMath::RadToDeg());
+		phaseFitAll.SetPoint(point, mass, fitModel.phase(fitParameters, cache, idxWave, jdxWave, idxBin, mass, idxMass) * TMath::RadToDeg());
 
 		// check that this mass bin should be taken into account for this
 		// combination of waves
@@ -2205,7 +2188,7 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 		}
 		++pointLimit;
 
-		const std::complex<double> element = fitModel.spinDensityMatrix(fitParameters, cache, idxWave, jdxWave, idxBin, _massBinCenters[idxMass], idxMass);
+		const std::complex<double> element = fitModel.spinDensityMatrix(fitParameters, cache, idxWave, jdxWave, idxBin, mass, idxMass);
 		realFit->SetPoint(pointLimit, mass, element.real());
 		imagFit->SetPoint(pointLimit, mass, element.imag());
 	}
@@ -2294,14 +2277,13 @@ rpwa::massDepFit::massDepFit::createPlotsFsmd(const rpwa::massDepFit::model& fit
 	TGraph graph;
 	graph.SetName("finalStateMassDependence");
 	graph.SetTitle("finalStateMassDependence");
-	graph.SetDrawOption("CP");
 
 	Int_t point = -1;
 	for(size_t idxMass=0; idxMass<_nrMassBins; ++idxMass) {
 		++point;
 		const double mass = _massBinCenters[idxMass];
 
-		graph.SetPoint(point, mass, std::norm(fitModel.getFsmd()->val(fitParameters, cache, _massBinCenters[idxMass], idxMass)));
+		graph.SetPoint(point, mass, std::norm(fitModel.getFsmd()->val(fitParameters, cache, mass, idxMass)));
 	}
 
 	outDirectory->cd();

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -226,8 +226,8 @@ rpwa::massDepFit::massDepFit::readConfigInput(const YAML::Node& configInput)
 		}
 	} else {
 		_freeParameters.clear();
-		_freeParameters.push_back("branching");
-		_freeParameters.push_back("branching mass m0");
+		_freeParameters.push_back("coupling branching");
+		_freeParameters.push_back("coupling branching mass m0");
 		_freeParameters.push_back("*");
 	}
 

--- a/resonanceFit/massDepFit.cc
+++ b/resonanceFit/massDepFit.cc
@@ -1881,22 +1881,9 @@ rpwa::massDepFit::massDepFit::createPlots(const rpwa::massDepFit::model& fitMode
 		}
 	}
 
-	if(fitModel.getFsmd() != NULL) {
-		TGraph graph;
-		graph.SetName("finalStateMassDependence");
-		graph.SetTitle("finalStateMassDependence");
-		graph.SetDrawOption("CP");
-
-		Int_t point = -1;
-		for(size_t idxMass=0; idxMass<_nrMassBins; ++idxMass) {
-			++point;
-			const double mass = _massBinCenters[idxMass];
-
-			graph.SetPoint(point, mass, std::norm(fitModel.getFsmd()->val(fitParameters, cache, _massBinCenters[idxMass], idxMass)));
-		}
-
-		outFile->cd();
-		graph.Write();
+	if(not createPlotsFsmd(fitModel, fitParameters, cache, outFile, rangePlotting)) {
+		printErr << "error while creating plots for final-state mass-dependence." << std::endl;
+		return false;
 	}
 
 	if(_debug) {
@@ -2284,6 +2271,41 @@ rpwa::massDepFit::massDepFit::createPlotsWavePair(const rpwa::massDepFit::model&
 	phase.Write();
 	real.Write();
 	imag.Write();
+
+	return true;
+}
+
+
+bool
+rpwa::massDepFit::massDepFit::createPlotsFsmd(const rpwa::massDepFit::model& fitModel,
+                                              const rpwa::massDepFit::parameters& fitParameters,
+                                              rpwa::massDepFit::cache& cache,
+                                              TDirectory* outDirectory,
+                                              const bool /*rangePlotting*/) const
+{
+	if(fitModel.getFsmd() == NULL) {
+		return true;
+	}
+
+	if(_debug) {
+		printDebug << "start creating plots for final-state mass-dependence." << std::endl;
+	}
+
+	TGraph graph;
+	graph.SetName("finalStateMassDependence");
+	graph.SetTitle("finalStateMassDependence");
+	graph.SetDrawOption("CP");
+
+	Int_t point = -1;
+	for(size_t idxMass=0; idxMass<_nrMassBins; ++idxMass) {
+		++point;
+		const double mass = _massBinCenters[idxMass];
+
+		graph.SetPoint(point, mass, std::norm(fitModel.getFsmd()->val(fitParameters, cache, _massBinCenters[idxMass], idxMass)));
+	}
+
+	outDirectory->cd();
+	graph.Write();
 
 	return true;
 }

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -91,7 +91,8 @@ namespace rpwa {
 			                 const rpwa::massDepFit::parameters& fitParameters,
 			                 rpwa::massDepFit::cache& cache,
 			                 TFile* outFile,
-			                 const bool rangePlotting) const;
+			                 const bool rangePlotting,
+			                 const size_t extraBinning) const;
 
 // FIXME: get rid
 			const std::vector<std::string>& getFreeParameters() const { return _freeParameters; }
@@ -194,6 +195,7 @@ namespace rpwa {
 			                     rpwa::massDepFit::cache& cache,
 			                     TDirectory* outDirectory,
 			                     const bool rangePlotting,
+			                     const size_t extraBinning,
 			                     const size_t idxWave,
 			                     const size_t idxBin) const;
 			bool createPlotsWavePair(const rpwa::massDepFit::model& fitModel,
@@ -201,6 +203,7 @@ namespace rpwa {
 			                         rpwa::massDepFit::cache& cache,
 			                         TDirectory* outDirectory,
 			                         const bool rangePlotting,
+			                         const size_t extraBinning,
 			                         const size_t idxWave,
 			                         const size_t jdxWave,
 			                         const size_t idxBin) const;
@@ -208,7 +211,8 @@ namespace rpwa {
 			                     const rpwa::massDepFit::parameters& fitParameters,
 			                     rpwa::massDepFit::cache& cache,
 			                     TDirectory* outDirectory,
-			                     const bool rangePlotting) const;
+			                     const bool rangePlotting,
+			                     const size_t extraBinning) const;
 
 			std::vector<std::string> _inFileName;
 			std::vector<std::vector<std::string> > _inOverwritePhaseSpace;

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -198,6 +198,13 @@ namespace rpwa {
 			                     const size_t extraBinning,
 			                     const size_t idxWave,
 			                     const size_t idxBin) const;
+			bool createPlotsWaveSum(const rpwa::massDepFit::model& fitModel,
+			                        const rpwa::massDepFit::parameters& fitParameters,
+			                        rpwa::massDepFit::cache& cache,
+			                        TDirectory* outDirectory,
+			                        const bool rangePlotting,
+			                        const size_t extraBinning,
+			                        const size_t idxWave) const;
 			bool createPlotsWavePair(const rpwa::massDepFit::model& fitModel,
 			                         const rpwa::massDepFit::parameters& fitParameters,
 			                         rpwa::massDepFit::cache& cache,

--- a/resonanceFit/massDepFit.h
+++ b/resonanceFit/massDepFit.h
@@ -204,6 +204,11 @@ namespace rpwa {
 			                         const size_t idxWave,
 			                         const size_t jdxWave,
 			                         const size_t idxBin) const;
+			bool createPlotsFsmd(const rpwa::massDepFit::model& fitModel,
+			                     const rpwa::massDepFit::parameters& fitParameters,
+			                     rpwa::massDepFit::cache& cache,
+			                     TDirectory* outDirectory,
+			                     const bool rangePlotting) const;
 
 			std::vector<std::string> _inFileName;
 			std::vector<std::vector<std::string> > _inOverwritePhaseSpace;

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -563,7 +563,7 @@ rpwa::massDepFit::component::importCouplings(const double* par,
 
 				// invalidate the cache
 				for(size_t idxChannel=0; idxChannel<_channels.size(); ++idxChannel) {
-					if (_channelsFromCoupling[idxCoupling] == _channelsCoupling[idxChannel]) {
+					if (_channelsCoupling[idxChannel] == idxCoupling) {
 						cache.setCoupling(getId(), idxChannel, idxBin, std::numeric_limits<size_t>::max(), 0.);
 						cache.setProdAmp(_channels[idxChannel].getWaveIdx(), idxBin, std::numeric_limits<size_t>::max(), 0.);
 					}
@@ -601,7 +601,7 @@ rpwa::massDepFit::component::importBranchings(const double* par,
 
 			// invalidate the cache
 			for(size_t idxChannel=0; idxChannel<_channels.size(); ++idxChannel) {
-				if (_channelsFromBranching[idxBranching] == _channelsBranching[idxChannel]) {
+				if (_channelsBranching[idxChannel] == idxBranching) {
 					cache.setCoupling(getId(), idxChannel, std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max(), 0.);
 					cache.setProdAmp(_channels[idxChannel].getWaveIdx(), std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max(), 0.);
 				}

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -478,7 +478,7 @@ rpwa::massDepFit::component::write(YAML::Emitter& yamlOutput,
 		yamlOutput << YAML::Key << "amp";
 		yamlOutput << YAML::Value << getChannel(idxDecayChannel).getWaveName();
 
-		if(idxDecayChannel == getChannelIdxCoupling(idxDecayChannel)) {
+		if(idxDecayChannel == _channelsFromCoupling[_channelsCoupling[idxDecayChannel]]) {
 			yamlOutput << YAML::Key << "couplings";
 			yamlOutput << YAML::Value;
 			yamlOutput << YAML::BeginSeq;
@@ -488,8 +488,8 @@ rpwa::massDepFit::component::write(YAML::Emitter& yamlOutput,
 				yamlOutput << YAML::Flow;
 				yamlOutput << YAML::BeginSeq;
 
-				yamlOutput << fitParameters.getCoupling(getId(), idxDecayChannel, idxBin).real();
-				yamlOutput << fitParameters.getCoupling(getId(), idxDecayChannel, idxBin).imag();
+				yamlOutput << fitParameters.getCoupling(getId(), _channelsCoupling[idxDecayChannel], idxBin).real();
+				yamlOutput << fitParameters.getCoupling(getId(), _channelsCoupling[idxDecayChannel], idxBin).imag();
 
 				yamlOutput << YAML::EndSeq;
 				yamlOutput << YAML::Block;
@@ -499,15 +499,15 @@ rpwa::massDepFit::component::write(YAML::Emitter& yamlOutput,
 		}
 
 		if(useBranchings && nrDecayChannels > 1) {
-			if(idxDecayChannel == getChannelIdxBranching(idxDecayChannel)) {
+			if(idxDecayChannel == _channelsFromBranching[_channelsBranching[idxDecayChannel]]) {
 				yamlOutput << YAML::Key << "branching";
 				yamlOutput << YAML::Value;
 
 				yamlOutput << YAML::Flow;
 				yamlOutput << YAML::BeginSeq;
 
-				yamlOutput << fitParameters.getBranching(getId(), idxDecayChannel).real();
-				yamlOutput << fitParameters.getBranching(getId(), idxDecayChannel).imag();
+				yamlOutput << fitParameters.getBranching(getId(), _channelsBranching[idxDecayChannel]).real();
+				yamlOutput << fitParameters.getBranching(getId(), _channelsBranching[idxDecayChannel]).imag();
 
 				yamlOutput << YAML::EndSeq;
 				yamlOutput << YAML::Block;

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -1210,10 +1210,10 @@ rpwa::massDepFit::integralWidthBreitWigner::readDecayChannel(const YAML::Node& d
 
 bool
 rpwa::massDepFit::integralWidthBreitWigner::write(YAML::Emitter& yamlOutput,
-                                            const rpwa::massDepFit::parameters& fitParameters,
-                                            const rpwa::massDepFit::parameters& fitParametersError,
-                                            const bool useBranchings,
-                                            const bool debug) const
+                                                  const rpwa::massDepFit::parameters& fitParameters,
+                                                  const rpwa::massDepFit::parameters& fitParametersError,
+                                                  const bool useBranchings,
+                                                  const bool debug) const
 {
 	if(debug) {
 		printDebug << "start writing 'integralWidthBreitWigner' for component '" << getName() << "'." << std::endl;
@@ -1429,11 +1429,11 @@ rpwa::massDepFit::constantBackground::write(YAML::Emitter& yamlOutput,
 
 
 std::complex<double>
-rpwa::massDepFit::constantBackground::val(const rpwa::massDepFit::parameters& /* fitParameters */,
-                                          rpwa::massDepFit::cache& /* cache */,
-                                          const size_t /* idxBin */,
-                                          const double /* m */,
-                                          const size_t /* idxMass */) const
+rpwa::massDepFit::constantBackground::val(const rpwa::massDepFit::parameters& /*fitParameters*/,
+                                          rpwa::massDepFit::cache& /*cache*/,
+                                          const size_t /*idxBin*/,
+                                          const double /*m*/,
+                                          const size_t /*idxMass*/) const
 {
 	return 1.;
 }

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -139,8 +139,6 @@ namespace rpwa {
 			const channel& getChannelFromBranchingIdx(const size_t i) const { return _channels[_channelsFromBranching[i]]; }
 			const channel& getChannelFromCouplingIdx(const size_t i) const { return _channels[_channelsFromCoupling[i]]; }
 			void setChannelAnchor(const size_t i, const bool anchor) { _channels[i].setAnchor(anchor); }
-			size_t getChannelIdxCoupling(const size_t i) const { return _channelsCoupling[i]; }
-			size_t getChannelIdxBranching(const size_t i) const { return _channelsBranching[i]; }
 
 			size_t getNrCouplings() const { return _nrCouplings; }
 			size_t importCouplings(const double* par,

--- a/resonanceFit/massDepFitMinimizerRoot.cc
+++ b/resonanceFit/massDepFitMinimizerRoot.cc
@@ -228,22 +228,45 @@ rpwa::massDepFit::minimizerRoot::initParameters(const rpwa::massDepFit::paramete
 					prefixName << channel.getWaveName();
 				}
 
+				bool free = false;
+				if(find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), "*")!=tokenizeFreeParameters.end()
+				   || find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), "coupling")!=tokenizeFreeParameters.end() ) {
+					free = true;
+				}
+				bool fix = not free;
+
 				const std::complex<double> parameter = fitParameters.getCoupling(idxComponent, idxCoupling, idxBin);
 
-				printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__real") << "') set to " << parameter.real() << std::endl;
-				_minimizer->SetVariable(parcount,
-				                        prefixName.str() + "__real",
-				                        parameter.real(),
-				                        0.1);
-				++parcount;
+				if (fix) {
+					printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__real") << "') fixed to " << parameter.real() << std::endl;
+					_minimizer->SetFixedVariable(parcount,
+					                             prefixName.str() + "__real",
+					                             parameter.real());
+					++parcount;
 
-				if(not channel.isAnchor()) {
-					printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__imag") << "') set to " << parameter.imag() << std::endl;
+					if(not channel.isAnchor()) {
+						printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__imag") << "') fixed to " << parameter.imag() << std::endl;
+						_minimizer->SetFixedVariable(parcount,
+						                             prefixName.str() + "__imag",
+						                             parameter.imag());
+						++parcount;
+					}
+				} else {
+					printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__real") << "') set to " << parameter.real() << std::endl;
 					_minimizer->SetVariable(parcount,
-					                        prefixName.str() + "__imag",
-					                        parameter.imag(),
+					                        prefixName.str() + "__real",
+					                        parameter.real(),
 					                        0.1);
 					++parcount;
+
+					if(not channel.isAnchor()) {
+						printInfo << "parameter " << parcount << " ('" << (prefixName.str() + "__imag") << "') set to " << parameter.imag() << std::endl;
+						_minimizer->SetVariable(parcount,
+						                        prefixName.str() + "__imag",
+						                        parameter.imag(),
+						                        0.1);
+						++parcount;
+					}
 				}
 			}
 		} // end loop over channels

--- a/resonanceFit/massDepFitMinimizerRoot.cc
+++ b/resonanceFit/massDepFitMinimizerRoot.cc
@@ -313,7 +313,7 @@ rpwa::massDepFit::minimizerRoot::initParameters(const rpwa::massDepFit::paramete
 			if(find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), "*")!=tokenizeFreeParameters.end()
 			   || find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), comp->getName())!=tokenizeFreeParameters.end()
 			   || find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), comp->getParameterName(idxParameter))!=tokenizeFreeParameters.end()
-			   || find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), comp->getName() + "__" + comp->getParameterName(idxParameter))!=tokenizeFreeParameters.end()) {
+			   || find(tokenizeFreeParameters.begin(), tokenizeFreeParameters.end(), name)!=tokenizeFreeParameters.end()) {
 				free = true;
 			}
 			bool fix = not free;

--- a/resonanceFit/pwaMassFit.cc
+++ b/resonanceFit/pwaMassFit.cc
@@ -58,7 +58,7 @@ usage(const std::string& progName,
 	          << std::endl
 	          << "usage:" << std::endl
 	          << progName
-	          << " [-o outfile -M minimizer -m algorithm -g # -t # -P -R -A -B -C # -d -q -h] config file" << std::endl
+	          << " [-o outfile -M minimizer -m algorithm -g # -t # -P -R -F # -A -B -C # -d -q -h] config file" << std::endl
 	          << "    where:" << std::endl
 	          << "        -o file    path to output file (default: 'mDep.result.root')" << std::endl
 	          << "        -M name    minimizer (default: Minuit2)" << std::endl
@@ -74,6 +74,7 @@ usage(const std::string& progName,
 	          << "        -t #       minimizer tolerance (default: 1e-10)" << std::endl
 	          << "        -P         plotting only - no fit" << std::endl
 	          << "        -R         plot in fit range only" << std::endl
+	          << "        -F #       finer binning for plotting (default: 1)" << std::endl
 	          << "        -A         fit to the production amplitudes (default: spin-density matrix)" << std::endl
 	          << "        -B         use branchings (reducing number of couplings)" << std::endl
 	          << "        -C #       part of the covariance matrix to use:" << std::endl
@@ -117,6 +118,7 @@ main(int    argc,
 	double            minimizerTolerance = 1e-10;                  // minimizer tolerance
 	bool              onlyPlotting       = false;
 	bool              rangePlotting      = false;
+	size_t            extraBinning       = 1;
 	bool              doProdAmp          = false;
 	bool              doBranching        = false;
 	bool              debug              = false;
@@ -127,7 +129,7 @@ main(int    argc,
 	extern char* optarg;
 	extern int   optind;
 	int c;
-	while ((c = getopt(argc, argv, "o:M:m:g:t:PRABC:dqh")) != -1) {
+	while ((c = getopt(argc, argv, "o:M:m:g:t:PRF:ABC:dqh")) != -1) {
 		switch (c) {
 		case 'o':
 			outFileName = optarg;
@@ -149,6 +151,9 @@ main(int    argc,
 			break;
 		case 'R':
 			rangePlotting = true;
+			break;
+		case 'F':
+			extraBinning = atoi(optarg);
 			break;
 		case 'A':
 			doProdAmp = true;
@@ -301,7 +306,7 @@ main(int    argc,
 		printErr << "error while creating ROOT file '" << rootFileName << "' for plots of fit result."<< std::endl;
 		return 1;
 	}
-	if(not mdepFit.createPlots(compset, fitParameters, cache, outFile.get(), rangePlotting)) {
+	if(not mdepFit.createPlots(compset, fitParameters, cache, outFile.get(), rangePlotting, extraBinning)) {
 		printErr << "error while creating plots." << std::endl;
 		return 1;
 	}


### PR DESCRIPTION
* Fix a bug while using branchings, the cache was not invalidated correctly. Fits using only couplings were not affected.
* Fix a bug while writing the result of a fit using branchings to the output file. Fits using only couplings were not affected.

* No longer automatically free the couplings, they have to be explicitly freed using the `freeparameters` option. The default if the `freeparameters` option is not in the option file is to free the couplings.
* Create the graphs of the fit result with an adjustable granularity, no longer use the smooth line (ROOT TGraph draw option `C`) but a simple polyline (`L`). The default is to only have points at the mass bin centers, with the command line option `-F` the number of points can be increased (default value 1).
* In case multiple bins are fitted, also create graphs of the intensities showing the sum of all bins.

* Refactor plotting of final-state mass-dependence.
* Remove draw options that have no effect.
* More cosmetic changes.