### PR TITLE
Try to get travis to work again.

### DIFF
--- a/travisCI/install-cmake.sh
+++ b/travisCI/install-cmake.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -exv
-wget http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz
+curl -L -O https://cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz
 tar -xzf cmake-3.2.2-Linux-x86_64.tar.gz
 mv ./cmake-3.2.2-Linux-x86_64 ./cmake


### PR DESCRIPTION
`wget` apparently does not understand the new certificate use for the `Cmake` servers, so use `curl` instead.

The error message was
```
ERROR: no certificate subject alternative name matches
	requested host name `cmake.org'.
```