### PR TITLE
Add some utilities to disable bose symmetrization

### DIFF
--- a/decayAmplitude/isobarAmplitude.cc
+++ b/decayAmplitude/isobarAmplitude.cc
@@ -328,19 +328,22 @@ isobarAmplitude::initSymTermMaps()
 			printInfo << "Found " << nmbIsoSymTerms << " isospin symmetrization terms." << endl;
 		}
 	}
-	if(_boseSymmetrize) {
-		boseSymTermMaps = _decay->getBoseSymmetrization();
+	boseSymTermMaps = _decay->getBoseSymmetrization();
+	nmbBoseSymTerms = boseSymTermMaps.size();
+	if (nmbBoseSymTerms < 1) {
+		printErr << "array of Bose-symmetrization terms is empty. "
+		         << "cannot Bose-symmetrize amplitude." << endl;
+		return false;
+	}
+	if (nmbBoseSymTerms == 1) {
+		printInfo << "no Bose symmetrization needed for this amplitude." << endl;
+	} else {
+		printInfo << "Found " << nmbBoseSymTerms << " Bose symmetrization terms." << endl;
+	}
+	if (not _boseSymmetrize) {
+		printInfo << "Bose symmetrization disabled. Reduce boseSymTermMaps to first entry." << std::endl;
+		boseSymTermMaps = vector<symTermMap>(1, boseSymTermMaps[0]);
 		nmbBoseSymTerms = boseSymTermMaps.size();
-		if (nmbBoseSymTerms < 1) {
-			printErr << "array of Bose-symmetrization terms is empty. "
-			         << "cannot Bose-symmetrize amplitude." << endl;
-			return false;
-		}
-		if (nmbBoseSymTerms == 1) {
-			printInfo << "no Bose symmetrization needed for this amplitude." << endl;
-		} else {
-			printInfo << "Found " << nmbBoseSymTerms << " Bose symmetrization terms." << endl;
-		}
 	}
 	if(nmbIsoSymTerms + nmbBoseSymTerms > 0) {
 		_symTermMaps.clear();

--- a/pyInterface/decayAmplitude/isobarAmplitude_py.cc
+++ b/pyInterface/decayAmplitude/isobarAmplitude_py.cc
@@ -51,7 +51,6 @@ namespace {
 			rpwa::isobarAmplitude::printParameters(sstr);
 			return sstr.str();
 		}
-
 	};
 
 	rpwa::isobarDecayTopology& isobarAmplitude_decayTopology(const rpwa::isobarAmplitude& self) {
@@ -105,6 +104,7 @@ void rpwa::py::exportIsobarAmplitude() {
 
 		.def("__call__", &rpwa::isobarAmplitude::operator())
 
+		.def("enableBoseSymmetrization", &rpwa::isobarAmplitude::enableBoseSymmetrization)
 		.def("name", &isobarAmplitudeWrapper::name, &isobarAmplitudeWrapper::default_name)
 		.def("name", &isobarAmplitude::name)
 		.def("printParameters", &isobarAmplitudeWrapper::printParameters__, &isobarAmplitudeWrapper::default_printParameters__)


### PR DESCRIPTION
Export isobarAmplitude::enableBoseSymmetrization to python

Change isobarAmplitude::initSymTermMaps to handle unsymmetrized
amplitudes correctly. Had 0 syymetrizations terms instead of
one before

Add a setFromXdecay method. To quickly change the topology
to start from the X decay.