### PR TITLE
isobarDecayTopology: Fix wrong isospin symmetrization with > 1 group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ html-doc
 .project
 *.d
 *.so
+.cproject
+.pydevproject
+.settings

--- a/decayAmplitude/isobarDecayTopology.cc
+++ b/decayAmplitude/isobarDecayTopology.cc
@@ -509,15 +509,15 @@ isobarDecayTopology::getIsospinSymmetrization()
 	// group are saved.
 	vector< vector<unsigned int> > groups;
 	for(unsigned int i = 0; i < fsParts.size(); ++i) {
-		const particlePtr& particle = fsParts.at(i);
+		const particlePtr& particle = fsParts[i];
 		bool inserted = false;
 		for(unsigned int j = 0; j < groups.size(); ++j) {
-			const particlePtr& compPart = fsParts.at(groups.at(j).at(0));
+			const particlePtr& compPart = fsParts.at(groups[j][0]);
 			if(particle->isospin() == compPart->isospin() &&
 			   particle->J() == compPart->J() &&
 			   particle->P() == compPart->P())
 			{
-				groups.at(j).push_back(i);
+				groups[j].push_back(i);
 				inserted = true;
 			}
 		}
@@ -530,9 +530,9 @@ isobarDecayTopology::getIsospinSymmetrization()
 		printDebug << "Found isospin symmetrization groups:" << endl;
 		for(unsigned int i = 0; i < groups.size(); ++i) {
 			printDebug << "Group " << i << endl;
-			for(unsigned int j = 0; j < groups.at(i).size(); ++j) {
-				printDebug << j << ": " << groups.at(i).at(j)
-				           << " (" << fsParts.at(groups.at(i).at(j))->name() << ")" << endl;
+			for(unsigned int j = 0; j < groups[i].size(); ++j) {
+				printDebug << j << ": " << groups[i][j]
+				           << " (" << fsParts.at(groups[i][j])->name() << ")" << endl;
 			}
 		}
 	}
@@ -542,7 +542,7 @@ isobarDecayTopology::getIsospinSymmetrization()
 	// Needed to reset everything as it was at the end.
 	vector<int> isospinProjs;
 	for(unsigned int j = 0; j < fsParts.size(); ++j) {
-		isospinProjs.push_back(fsParts.at(j)->isospinProj());
+		isospinProjs.push_back(fsParts[j]->isospinProj());
 	}
 
 	// A vector to save the found permutations and their Clebsch-Gordans
@@ -569,19 +569,19 @@ isobarDecayTopology::getIsospinSymmetrization()
 		bool breaking = false;
 		for(unsigned int j = 0; j < map.size(); ++j) {
 
-			if (j == map.at(j)) {
+			if (j == map[j]) {
 				continue; // particle j was not swapped -> go on with check of next particle
 			}
 
 			// Make sure we are not swapping two indistinguishable particles.
-			if(fsParts.at(j)->name() == fsParts.at(map.at(j))->name()) {
+			if(fsParts.at(j)->name() == fsParts.at(map[j])->name()) {
 				breaking = true;
 				break;
 			}
 
 			// Check if two particles from the same isobar are being swapped.
 			for(unsigned int k = 0; k < map.size(); ++k) {
-				if ((map.at(k) == k) or (j == k)) {
+				if ((map[k] == k) or (j == k)) {
 					continue;
 				}
 				if(fromVertex(fsParts.at(j)) == fromVertex(fsParts.at(k))) {
@@ -600,15 +600,15 @@ isobarDecayTopology::getIsospinSymmetrization()
 
 		// Set the isospin of the final-state particles as given by the permutation.
 		for(unsigned int j = 0; j < map.size(); ++j) {
-			fsParts.at(j)->setIsospinProj(isospinProjs.at(map.at(j)));
+			fsParts.at(j)->setIsospinProj(isospinProjs.at(map[j]));
 		}
 		calcIsobarCharges(false);
 
 		// Check for isospin consistency in all vertices.
 		for(unsigned int j = 0; j < _isobarVertices.size(); ++j) {
-			const particlePtr d1 = _isobarVertices.at(j)->daughter1();
-			const particlePtr d2 = _isobarVertices.at(j)->daughter2();
-			const particlePtr p  = _isobarVertices.at(j)->parent();
+			const particlePtr d1 = _isobarVertices[j]->daughter1();
+			const particlePtr d2 = _isobarVertices[j]->daughter2();
+			const particlePtr p  = _isobarVertices[j]->parent();
 			if(not spinStatesCanCouple(d1->isospin(), d1->isospinProj(),
 			       d2->isospin(), d2->isospinProj(),
 			       p->isospin(),  p->isospinProj())) {
@@ -619,7 +619,7 @@ isobarDecayTopology::getIsospinSymmetrization()
 		// If something is amiss, reset everything and proceed to the next permutation.
 		if(breaking) {
 			for(unsigned int j = 0; j < fsParts.size(); ++j) {
-				fsParts.at(j)->setIsospinProj(isospinProjs.at(j));
+				fsParts[j]->setIsospinProj(isospinProjs.at(j));
 			}
 			calcIsobarCharges();
 			continue;
@@ -634,7 +634,7 @@ isobarDecayTopology::getIsospinSymmetrization()
 		if(_debug) {
 			printDebug << "Found valid permutation: ";
 			for(unsigned int j = 0; j < map.size(); ++j) {
-				cout << map.at(j);
+				cout << map[j];
 			}
 			cout << " (";
 			for(unsigned int j = 0; j < map.size(); ++j) {
@@ -645,7 +645,7 @@ isobarDecayTopology::getIsospinSymmetrization()
 
 		// Resetting isospins for the next permutation
 		for(unsigned int j = 0; j < fsParts.size(); ++j) {
-			fsParts.at(j)->setIsospinProj(isospinProjs.at(j));
+			fsParts[j]->setIsospinProj(isospinProjs.at(j));
 		}
 		calcIsobarCharges();
 

--- a/decayAmplitude/isobarDecayTopology.cc
+++ b/decayAmplitude/isobarDecayTopology.cc
@@ -37,6 +37,13 @@
 #include "particleDataTable.h"
 #include "spinUtils.hpp"
 
+namespace {
+	// Returns a list with all possible permutations of all groups of particles
+	// groupsExt is a vector of groups where each group is a vector of particle ids that belong to that group ( [<group>][<particleInGroup>] )
+	// The return value is a list of all permutations where each permutation is a list of groups
+    // where each group is a vector of particle ids that belong to that group ( [<permutation>][<group>][<particleInGroup>] )
+	std::vector< std::vector< std::vector<unsigned int> > > getAllGroupPermutations(const std::vector< std::vector<unsigned int> >& groupsExt);
+}
 
 using namespace std;
 using namespace boost;
@@ -541,128 +548,108 @@ isobarDecayTopology::getIsospinSymmetrization()
 	// A vector to save the found permutations and their Clebsch-Gordans
 	vector<symTermMap> symAmplitudes;
 
-	// Permutating all the particles and checking if the permutation makes sense
+	// Permuting all the particles and checking if the permutation makes sense
 	//
-	// First, loop over all the groups.
-	for(unsigned int i = 0; i < groups.size(); ++i) {
-		vector<unsigned int> group = groups.at(i);
+	const std::vector< std::vector< std::vector<unsigned int> > > permutations = getAllGroupPermutations(groups);
+	for(unsigned int i_permutation = 0; i_permutation < permutations.size(); ++i_permutation){
+		const std::vector< std::vector<unsigned int> >& permutation = permutations[i_permutation];
+		std::vector<unsigned int> map(fsParts.size());
 
-		// Again debug output
+		for(unsigned int i_group = 0; i_group < groups.size(); ++i_group){
+			for(unsigned int i_group_entry = 0; i_group_entry < groups[i_group].size(); ++i_group_entry){
+				map[ groups[i_group][i_group_entry] ] = permutation[i_group][i_group_entry];
+			}
+		}
 		if(_debug) {
-			printDebug << "Group permutations " << i << endl;
+			printDebug << "Processing permutation '";
+			for(unsigned int i = 0; i < map.size(); ++i) cout << map[i];
+			cout << "'." << std::endl;
 		}
+		// Some first checks if the permutation makes sense.
+		bool breaking = false;
+		for(unsigned int j = 0; j < map.size(); ++j) {
 
-		// First we need a vector with the unity permutation, which will
-		// subsequently be permutated.
-		vector<unsigned int> permutations;
-		for(unsigned int j = 0; j < group.size(); ++j) {
-			permutations.push_back(j);
-		}
-
-		// Now loop over all permutations for the current group.
-		do {
-			// Create a unity map. The map has one entry per final-state particle
-			// (unlike the group, which only holds the indices of the final-state
-			// particles in the group).
-			vector<unsigned int> map;
-			for(unsigned int j = 0; j < fsParts.size(); ++j) {
-				map.push_back(j);
+			if (j == map.at(j)) {
+				continue; // particle j was not swapped -> go on with check of next particle
 			}
 
-			// Now apply the permutation to the map. We get the index of the particle
-			// we want to swap from the group vector and the index of the particle we
-			// want to swap it with from the permutations vector. The whole thing is
-			// applied to the map vector.
-			for(unsigned int j = 0; j < group.size(); ++j) {
-				map.at(group.at(j)) = group.at(permutations.at(j));
+			// Make sure we are not swapping two indistinguishable particles.
+			if(fsParts.at(j)->name() == fsParts.at(map.at(j))->name()) {
+				breaking = true;
+				break;
 			}
 
-			// Some first checks if the permutation makes sense.
-			bool breaking = false;
-			for(unsigned int j = 0; j < map.size(); ++j) {
-
-				if(j == map.at(j)) {
+			// Check if two particles from the same isobar are being swapped.
+			for(unsigned int k = 0; k < map.size(); ++k) {
+				if ((map.at(k) == k) or (j == k)) {
 					continue;
 				}
-
-				// Make sure we are not swapping two indistinguishable particles.
-				if(fsParts.at(j)->name() == fsParts.at(map.at(j))->name()) {
+				if(fromVertex(fsParts.at(j)) == fromVertex(fsParts.at(k))) {
 					breaking = true;
 					break;
 				}
-
-				// Check if two particles from the same isobar are being swapped.
-				for(unsigned int k = 0; k < map.size(); ++k) {
-					if((map.at(k) == k) || (j == k)) continue;
-					if(fromVertex(fsParts.at(j)) == fromVertex(fsParts.at(k))) {
-						breaking = true;
-						break;
-					}
-				}
-				if(breaking) {
-					break;
-				}
 			}
-
 			if(breaking) {
-				continue;
+				break;
 			}
+		}
 
-			// Set the isospin of the final-state particles as given by the premutation.
-			for(unsigned int j = 0; j < map.size(); ++j) {
-				fsParts.at(j)->setIsospinProj(isospinProjs.at(map.at(j)));
+		if(breaking) { // check next permutation
+			continue;
+		}
+
+		// Set the isospin of the final-state particles as given by the permutation.
+		for(unsigned int j = 0; j < map.size(); ++j) {
+			fsParts.at(j)->setIsospinProj(isospinProjs.at(map.at(j)));
+		}
+		calcIsobarCharges(false);
+
+		// Check for isospin consistency in all vertices.
+		for(unsigned int j = 0; j < _isobarVertices.size(); ++j) {
+			const particlePtr d1 = _isobarVertices.at(j)->daughter1();
+			const particlePtr d2 = _isobarVertices.at(j)->daughter2();
+			const particlePtr p  = _isobarVertices.at(j)->parent();
+			if(not spinStatesCanCouple(d1->isospin(), d1->isospinProj(),
+			       d2->isospin(), d2->isospinProj(),
+			       p->isospin(),  p->isospinProj())) {
+				breaking = true;
 			}
-			calcIsobarCharges(false);
+		}
 
-			// Check for isospin consistency in all vertices.
-			for(unsigned int j = 0; j < _isobarVertices.size(); ++j) {
-				const particlePtr d1 = _isobarVertices.at(j)->daughter1();
-				const particlePtr d2 = _isobarVertices.at(j)->daughter2();
-				const particlePtr p  = _isobarVertices.at(j)->parent();
-				if(!spinStatesCanCouple(d1->isospin(), d1->isospinProj(),
-				                        d2->isospin(), d2->isospinProj(),
-				                        p->isospin(),  p->isospinProj())) {
-					breaking = true;
-				}
-			}
-
-			// If something is amiss, reset everything and proceed to the next permutation.
-			if(breaking) {
-				for(unsigned int j = 0; j < fsParts.size(); ++j) {
-					fsParts.at(j)->setIsospinProj(isospinProjs.at(j));
-				}
-				calcIsobarCharges();
-				continue;
-			}
-
-			double clebsch = getIsospinClebschGordanProduct();
-
-			// Survived all the criteria, saving to be returned
-			symTermMap symTerm(getIsospinClebschGordanProduct(), map);
-			symAmplitudes.push_back(symTerm);
-
-			if(_debug) {
-				printDebug << "Found valid permutation: ";
-				for(unsigned int j = 0; j < map.size(); ++j) {
-					cout << map.at(j);
-				}
-				cout << " (";
-				for(unsigned int j = 0; j < map.size(); ++j) {
-					cout << fsParts.at(j)->name();
-				}
-				cout << "), clebsch-gordan=" << clebsch << endl;
-			}
-
-			// Resetting isospins for the next permutation
+		// If something is amiss, reset everything and proceed to the next permutation.
+		if(breaking) {
 			for(unsigned int j = 0; j < fsParts.size(); ++j) {
 				fsParts.at(j)->setIsospinProj(isospinProjs.at(j));
 			}
 			calcIsobarCharges();
+			continue;
+		}
 
-		} while(next_permutation(permutations.begin(), permutations.end()));
-		// End of the loop over permutations.
+		double clebsch = getIsospinClebschGordanProduct();
 
-	} // End of the loop over the groups.
+		// Survived all the criteria, saving to be returned
+		symTermMap symTerm(getIsospinClebschGordanProduct(), map);
+		symAmplitudes.push_back(symTerm);
+
+		if(_debug) {
+			printDebug << "Found valid permutation: ";
+			for(unsigned int j = 0; j < map.size(); ++j) {
+				cout << map.at(j);
+			}
+			cout << " (";
+			for(unsigned int j = 0; j < map.size(); ++j) {
+				cout << fsParts.at(j)->name();
+			}
+			cout << "), clebsch-gordan=" << clebsch << endl;
+		}
+
+		// Resetting isospins for the next permutation
+		for(unsigned int j = 0; j < fsParts.size(); ++j) {
+			fsParts.at(j)->setIsospinProj(isospinProjs.at(j));
+		}
+		calcIsobarCharges();
+
+	} // End of the loop over the permutations
 
 	for(unsigned int i = 0; i < symAmplitudes.size(); ++i) {
 		symAmplitudes[i].factor = signum(symAmplitudes[i].factor.real()) / sqrt(symAmplitudes.size());
@@ -874,4 +861,48 @@ isobarDecayTopology::findIsobarBoseSymVertices() const
 		}
 	}
 	return boseSymVertices;
+}
+
+
+namespace {
+	// Returns a list with all possible permutations of all groups of particles
+	// groupsExt is a vector of groups where each group is a vector of particle ids that belong to that group ( [<group>][<particleInGroup>] )
+	// The return value is a list of all permutations where each permutation is a list of groups
+    // where each group is a vector of particle ids that belong to that group ( [<permutation>][<group>][<particleInGroup>] )
+	std::vector< std::vector< std::vector<unsigned int> > > getAllGroupPermutations(const std::vector< std::vector<unsigned int> >& groupsExt){
+
+		std::vector< std::vector< std::vector<unsigned int> > > permutations;
+
+		std::vector< std::vector<unsigned int> > subGroups(groupsExt.size() - 1);
+		for (size_t i = 0; i < groupsExt.size() - 1; ++i) {
+			subGroups[i] = groupsExt[i];
+		}
+
+		std::vector<unsigned int> curGroup = groupsExt[groupsExt.size()-1];
+		// make sure that the cur_group is sorted such that next_permutation works
+		std::sort(curGroup.begin(), curGroup.end());
+
+		if(subGroups.empty()){ // this is the lowest group
+			do{
+				std::vector< std::vector<unsigned int> > lastElement(1, curGroup);
+				permutations.push_back(lastElement);
+			} while(next_permutation(curGroup.begin(), curGroup.end()));
+
+		} else { // build all permutation, take into account all permutations of all subgroups
+
+			// get all permutations of all subgroups
+			const std::vector< std::vector< std::vector<unsigned int> > > subPermutations = getAllGroupPermutations(subGroups);
+
+			do{
+				for(unsigned int i_subPermutation = 0; i_subPermutation < subPermutations.size(); ++i_subPermutation){
+					std::vector< std::vector< unsigned int> > permutation(subPermutations[i_subPermutation]);
+					permutation.push_back(curGroup);
+					permutations.push_back(permutation);
+				}
+			} while(next_permutation(curGroup.begin(), curGroup.end()));
+		}
+
+		return permutations;
+
+	}
 }


### PR DESCRIPTION
Partial waves with more than one isospin group (e.g. K- pi- pi+) lead to too much
isospin terms in the isospin symmetrization due to a wrong handling of groups.