### PR TITLE
Fix calculation of intensity errors

### DIFF
--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -595,7 +595,7 @@ fitResult::intensityErr(const string& waveNamePattern) const
 		for (unsigned int j = 0; j < nmbAmps; ++j) {
 			if (rankOfProdAmp(prodAmpIndices[j]) != currentRank)
 				continue;
-			ampNorm += prodAmp(prodAmpIndices[j]) * normIntegralForProdAmp(j, i);  // order of indices is essential
+			ampNorm += prodAmp(prodAmpIndices[j]) * normIntegralForProdAmp(prodAmpIndices[j], prodAmpIndices[i]);  // order of indices is essential
 		}
 		jacobian[0][2 * i    ] = ampNorm.real();
 		jacobian[0][2 * i + 1] = ampNorm.imag();

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -569,14 +569,21 @@ double
 fitResult::intensityErr(const string& waveNamePattern) const
 {
 	// get amplitudes that correspond to wave name pattern
-	const vector<unsigned int> prodAmpIndices = prodAmpIndicesMatchingPattern(waveNamePattern);
-	const unsigned int         nmbAmps        = prodAmpIndices.size();
-	if (not _covMatrixValid or (nmbAmps == 0)) {
+	const vector<unsigned int> waveIndices    = waveIndicesMatchingPattern(waveNamePattern);
+	const unsigned int         nmbWaves       = waveIndices.size();
+	if (not _covMatrixValid or (nmbWaves == 0)) {
 		return 0.;
 	}
-	if(nmbAmps == 1) {
-		return intensityErr(prodAmpIndices[0]);
+	if(nmbWaves == 1) {
+		return intensityErr(waveIndices[0]);
 	}
+
+	vector<unsigned int> prodAmpIndices;
+	for (unsigned int i = 0; i < nmbWaves; ++i) {
+		const vector<unsigned int> prodAmpIndicesWave = prodAmpIndicesForWave(waveIndices[i]);
+		prodAmpIndices.insert(prodAmpIndices.end(), prodAmpIndicesWave.begin(), prodAmpIndicesWave.end());
+	}
+	const unsigned int nmbAmps = prodAmpIndices.size();
 	// build Jacobian for intensity, which is a 1 x 2n matrix composed of n sub-Jacobians:
 	// J = (JA_0, ..., JA_{n - 1}), where n is the number of production amplitudes
 	TMatrixT<double> jacobian(1, 2 * nmbAmps);


### PR DESCRIPTION
In addition to a crash while calculating the errors for a rank-2 fit (#149), there is a much more serious bug in `fitResult::intensityErr`. The function call to `normIntegralForProdAmp` should not use the indices of the `prodAmpIndices` array `i` and `j`, but the content of that array at the respective positions. Patterns that match a single wave should be fine. Patterns that match multiple waves probably return a wrong error for all patterns that did not result in a continuous sequences of production amplitude indices and were not starting from production amplitude index zero (realistically that is all except the '.*' pattern).

The actual impact of this bug is fortunately hardly visible in the plots I compared so far.

Replaces #149.
Fixes #140.
Fixes #60. 