### PR TITLE
pyInterface: fix 'getWaveDescThresFromWaveList'

### DIFF
--- a/pyInterface/package/utils/_waveDescThresUtils.py
+++ b/pyInterface/package/utils/_waveDescThresUtils.py
@@ -35,7 +35,7 @@ def getWaveDescThresFromWaveList(waveListFileName, keyFiles):
 				continue
 			line = line.replace('\n', '')
 			lineArray = line.split(" ")
-			if lineArray in [1, 2]:
+			if len(lineArray) in [1, 2]:
 				waveName = lineArray[0]
 				if len(lineArray) == 1:
 					threshold = 0


### PR DESCRIPTION
The python function 'getWaveDescThresFromWaveList' should check whether
a line read from the wavelist can be split into either one or two parts,
not whether the split array is either '1' or '2'. This was broken by commit
71a39d39057ddc47868cbba46cb12868c9806cb5,