### PR TITLE
ampIntegralMatrixMetadata: small patch

### DIFF
--- a/decayAmplitude/rootPwaAmpLinkDef.h
+++ b/decayAmplitude/rootPwaAmpLinkDef.h
@@ -58,8 +58,15 @@
 
 #pragma link C++ class std::map<std::string, std::pair<double, double> >+;
 #pragma link C++ class pair<string,pair<double,double> >+;
-#pragma link C++ class std::vector<std::pair<rpwa::eventMetadata, std::vector<std::pair<size_t, size_t> > > >+;
 
+#pragma link C++ class vector<pair<rpwa::eventMetadata, vector<pair<size_t, size_t> > > >+;
+#pragma link C++ class vector<pair<rpwa::eventMetadata, vector<pair<unsigned long, unsigned long> > > >+;
+#pragma link C++ class pair<rpwa::eventMetadata, vector<pair<size_t, size_t> > >+;
+#pragma link C++ class pair<rpwa::eventMetadata, vector<pair<unsigned long, unsigned long> > >+;
+#pragma link C++ class vector<pair<size_t, size_t> >+;
+#pragma link C++ class vector<pair<unsigned long, unsigned long> >+;
+#pragma link C++ class pair<size_t, size_t>+;
+#pragma link C++ class pair<unsigned long, unsigned long>+;
 
 
 #endif

--- a/pyInterface/package/_integrals.py
+++ b/pyInterface/package/_integrals.py
@@ -55,8 +55,11 @@ def calcIntegrals(integralFileName, ampFileNameList, maxNmbEvents=0, weightFileN
 				pyRootPwa.utils.printErr("amplitude files with non-matching event metadatas. Aborting...")
 				return False
 		if not integralMetaData.addAmplitudeHash(ampMeta.contentHash()):
-			pyRootPwa.utils.printWarn("could not add the amplitude hash. Aborting...")
-			return False
+			pyRootPwa.utils.printWarn("could not add the amplitude hash.")
+			# This error is not fatal, since in special cases the same hash can appear twice:
+			# e.g. in freed-isobar analyses with spin zero, the angular dependences are constant
+			# and the shape is either 0 or 1. If two such waves accidentally have the same number
+			# of events, both will also have the same hash.
 	if not integralMetaData.setAmpIntegralMatrix(integralMatrix):
 		pyRootPwa.utils.printErr("could not add the integral matrix to the metadata object. Aborting...")
 		return False

--- a/pyInterface/package/_integralsOnTheFly.py
+++ b/pyInterface/package/_integralsOnTheFly.py
@@ -111,8 +111,11 @@ def calcIntegralsOnTheFly(integralFileName, eventFileName, keyFileNameList, binn
 		return False
 	for hasher in hashers:
 		if not metadataObject.addAmplitudeHash(hasher.hash()):
-			pyRootPwa.utils.printWarn("could not add the amplitude hash. Aborting...")
-			return False
+			pyRootPwa.utils.printWarn("could not add the amplitude hash.")
+			# This error is not fatal, since in special cases the same hash can appear twice:
+			# e.g. in freed-isobar analyses with spin zero, the angular dependences are constant
+			# and the shape is either 0 or 1. If two such waves accidentally have the same number
+			# of events, both will also have the same hash.
 	if not metadataObject.writeToFile(outFile):
 		pyRootPwa.utils.printErr("could not write integral objects to file. Aborting...")
 		return False


### PR DESCRIPTION
add dictionaries for all subclasses.
existing amplitudeHash not fatal, since in special cases
the same hases can appear several times.