### PR TITLE
buildSystem: linker flags and new version for BAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ endif()
 message(STATUS "")
 message(STATUS ">>> Setting up BAT.")
 option(USE_BAT "En/Disables usage of BAT" OFF)
-find_package(BAT 0.9)
+find_package(BAT 1.0)
 set_package_properties(BAT
 	PROPERTIES
 	DESCRIPTION "Bayesian Analysis Toolkit"

--- a/cmakeModules/FindBAT.cmake
+++ b/cmakeModules/FindBAT.cmake
@@ -164,10 +164,15 @@ if(BAT_ROOT_DIR)
 endif()
 
 
+# remove leading and trailing whitespaces
+string(STRIP "${BAT_LINKER_FLAGS}" BAT_LINKER_FLAGS)
+
+
 # make variables changeable
 mark_as_advanced(
 	BAT_INCLUDE_DIR
 	BAT_LIBRARIES
+	BAT_LINKER_FLAGS
 	)
 
 


### PR DESCRIPTION
Require at least BAT version 1.0. There was a massive interface change
with this version so we cannot support earlier and later versions at the
same time, so we will only support the new versions.

Remove leading and trailing whitespaces from BAT's special linker flags.