### PR TITLE
decayAmplitude: Add phase space options.

### DIFF
--- a/decayAmplitude/phaseSpaceIntegral.h
+++ b/decayAmplitude/phaseSpaceIntegral.h
@@ -42,6 +42,12 @@ namespace rpwa {
 		                                            isobarDecayVertexPtr& vertexPtr,
 		                                            isobarDecayTopologyPtr& subDecay);
 
+		static const std::string& directory() { return _directory; }
+		static void setDirectory(const std::string& directory) { _directory = directory; }
+
+		static const double& upperMassBound() { return _upperBound; }
+		static void setUpperMassBound(const double& upperBound) { _upperBound = upperBound; }
+
 	  private:
 
 		double dyn(double M, double M0);
@@ -66,15 +72,16 @@ namespace rpwa {
 
 		bool _init;
 
+		static std::string _directory;
+		static double _upperBound;
+
 		const static int N_POINTS;
 		const static int N_MC_EVENTS;
 		const static int N_MC_EVENTS_FOR_M0;
 		const static int MC_SEED;
-		const static double UPPER_BOUND;
 		const static bool NEW_FILENAME_CONVENTION;
 		const static bool CALCULATE_ERRORS;
 
-		const static std::string DIRECTORY;
 		const static std::string TREE_NAME;
 
 	};

--- a/pyInterface/decayAmplitude/phaseSpaceIntegral_py.cc
+++ b/pyInterface/decayAmplitude/phaseSpaceIntegral_py.cc
@@ -37,6 +37,15 @@ void rpwa::py::exportPhaseSpaceIntegral() {
 
 		.def("__call__", &rpwa::integralTableContainer::operator())
 
+		.def("directory", &rpwa::integralTableContainer::directory, bp::return_value_policy<bp::copy_const_reference>())
+		.def("setDirectory", &rpwa::integralTableContainer::setDirectory)
+		.def("upperMassBound", &rpwa::integralTableContainer::upperMassBound, bp::return_value_policy<bp::copy_const_reference>())
+		.def("setUpperMassBound", &rpwa::integralTableContainer::setUpperMassBound)
+		.staticmethod("directory")
+		.staticmethod("setDirectory")
+		.staticmethod("upperMassBound")
+		.staticmethod("setUpperMassBound")
+
 		.def("getSubWaveNameFromVertex", &integralTableContainer_getSubWaveNameFromVertex)
 		.staticmethod("getSubWaveNameFromVertex");
 

--- a/pyInterface/genPseudoData.py
+++ b/pyInterface/genPseudoData.py
@@ -54,6 +54,9 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
 		sys.exit(1)
 
+	pyRootPwa.core.integralTableContainer.setDirectory(config.phaseSpaceIntegralDirectory)
+	pyRootPwa.core.integralTableContainer.setUpperMassBound(config.phaseSpaceUpperMassBound)
+
 	# read integral matrix from ROOT file
 	integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile)
 	integral = pyRootPwa.core.ampIntegralMatrix.getFromTDirectory(integralFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)

--- a/pyInterface/package/_config.py
+++ b/pyInterface/package/_config.py
@@ -18,6 +18,10 @@ class rootPwaConfig(object):
 	intDirectory                           = ""
 	limitFilesPerDir                       = -1
 
+	# amplitude section
+	phaseSpaceIntegralDirectory            = ""
+	phaseSpaceUpperMassBound               = 0.
+
 	# fit section
 	fitResultTreeName                      = ""
 	fitResultBranchName                    = ""
@@ -64,9 +68,12 @@ class rootPwaConfig(object):
 			self.intDirectory    = self.getPathFromConfig("general", "intFileDirectory" , configDir + "/ints")
 
 			if self.config.has_option('general', 'limitFilesPerDir'):
-				self.limitFilesPerDir                   = self.config.get('general', 'limitFilesPerDir')
+				self.limitFilesPerDir                   = int(self.config.get('general', 'limitFilesPerDir'))
 			else:
 				self.limitFilesPerDir                   = -1
+
+			self.phaseSpaceIntegralDirectory = self.config.get("amplitude", "phaseSpaceIntegralDirectory")
+			self.phaseSpaceUpperMassBound    = float(self.config.get("amplitude", "phaseSpaceUpperMassBound"))
 
 			self.fitResultTreeName = self.config.get('fit', 'treeName')
 			self.fitResultBranchName = self.config.get('fit', 'fitResultBranch')
@@ -77,6 +84,9 @@ class rootPwaConfig(object):
 			self.accCorrPSAmpDirectoryName              = self.config.get('other', 'accCorrPSAmpDirectoryName')
 			self.weightTreeName                         = self.config.get('other', 'weightTreeName')
 
+		except ValueError as exc:
+			pyRootPwa.utils.printErr("a variable had the wrong type ('" + str(exc) + "').")
+			return False
 		except ConfigParser.Error as exc:
 			pyRootPwa.utils.printErr("a required entry was missing from the config file ('" + str(exc) + "').")
 			return False

--- a/pyInterface/rootpwa.config
+++ b/pyInterface/rootpwa.config
@@ -11,6 +11,14 @@ intFileDirectory                       = ints
 limitFilesPerDir                       = -1
 
 
+[amplitude]
+
+; These two values only need to be set if a relativistic
+; Breit-Wigner is used for a decay where one of the daughter
+; particles is not stable. Otherwise they can be left as is.
+phaseSpaceIntegralDirectory            = ""
+phaseSpaceUpperMassBound               = 0.
+
 [fit]
 
 treeName                   = pwa

--- a/pyInterface/userInterface/calcAmplitudes.py
+++ b/pyInterface/userInterface/calcAmplitudes.py
@@ -37,6 +37,9 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
 		sys.exit(1)
 
+	pyRootPwa.core.integralTableContainer.setDirectory(config.phaseSpaceIntegralDirectory)
+	pyRootPwa.core.integralTableContainer.setUpperMassBound(config.phaseSpaceUpperMassBound)
+
 	if not args.wavelistFileName == "" and not args.keyfileIndex == -1:
 		pyRootPwa.utils.printErr("Setting both options -k and -w is conflicting. Aborting...")
 		sys.exit(1)


### PR DESCRIPTION
Finally add the possibility to customize the phase space integral functionality
(which enables the relativistic Breit-Wigner mass dependence functions if the
daughters of the decay are not stable themselves) in the rootpwa.config file.