### PR TITLE
tests: Fix the pylint tests for the scripts.

### DIFF
--- a/pyInterface/package/_likelihood.py
+++ b/pyInterface/package/_likelihood.py
@@ -46,7 +46,7 @@ def initLikelihood(waveDescThres,
 		eventFile, eventMeta = pyRootPwa.utils.openEventFile(eventFileName)
 		if not eventFile or not eventMeta:
 			pyRootPwa.utils.printErr("could not open event file '" + eventFileName + "'. Aborting...")
-			return False
+			return None
 		eventMetas.append(eventMeta)
 	likelihood.setOnTheFlyBinning(multiBin.boundaries, eventMetas)
 	for waveName in eventAndAmpFileDict[eventAndAmpFileDict.keys()[0]]:

--- a/pyInterface/userInterface/eigenvectorLikelihoodSlices.py
+++ b/pyInterface/userInterface/eigenvectorLikelihoodSlices.py
@@ -18,12 +18,13 @@ if __name__ == "__main__":
 	parser.add_argument("inputFileName", type=str, metavar="inputFile", help="path to fit result")
 	parser.add_argument("outputFileName", type=str, metavar="outputFile", help="path to output file")
 	parser.add_argument("-c", type=str, metavar="configFileName", dest="configFileName", default="./rootpwa.config", help="path to config file (default: './rootpwa.config')")
-	parser.add_argument("-b", type=int, metavar="#", dest="binID", default=0, help="bin ID of fit (default: 0)")
+	parser.add_argument("-b", type=int, metavar="#", dest="integralBin", default=0, help="integral bin id of fit (default: 0)")
 	parser.add_argument("-s", action="store_true", dest="ranWithHesse", default=False, help="indicates that the fit result contains an analytically calculated covariance matrix")
 	parser.add_argument("-C", "--cauchyPriors", help="use half-Cauchy priors (default: false)", action="store_true")
 	parser.add_argument("-P", "--cauchyPriorWidth", type=float, metavar ="WIDTH", default=0.5, help="width of half-Cauchy prior (default: 0.5)")
 	parser.add_argument("-A", type=int, metavar="#", dest="accEventsOverride", default=0,
 	                    help="number of input events to normalize acceptance to (default: use number of events from normalization integral file)")
+	parser.add_argument("--noAcceptance", help="do not take acceptance into account (default: false)", action="store_true")
 	parser.add_argument("-v", "--verbose", help="verbose; print debug output (default: false)", action="store_true")
 	args = parser.parse_args()
 
@@ -37,14 +38,27 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
 		sys.exit(1)
 
-	ampFileList = fileManager.getAmplitudeFilePaths(args.binID, pyRootPwa.core.eventMetadata.REAL)
-	if not ampFileList:
+	multiBin = fileManager.binList[args.integralBin]
+	eventAndAmpFileDict = fileManager.getEventAndAmplitudeFilePathsInBin(multiBin, pyRootPwa.core.eventMetadata.REAL)
+	if not eventAndAmpFileDict:
 		pyRootPwa.utils.printErr("could not retrieve valid amplitude file list. Aborting...")
 		sys.exit(1)
-	binningMap = fileManager.getBinFromID(args.binID)
 
-	psIntegralPath  = fileManager.getIntegralFilePath(args.binID, pyRootPwa.core.eventMetadata.GENERATED)
-	accIntegralPath = fileManager.getIntegralFilePath(args.binID, pyRootPwa.core.eventMetadata.ACCEPTED)
+	psIntegralPath  = fileManager.getIntegralFilePath(multiBin, pyRootPwa.core.eventMetadata.GENERATED)
+	accIntegralPath = psIntegralPath
+	if not args.noAcceptance:
+		accIntegralPath = fileManager.getIntegralFilePath(multiBin, pyRootPwa.core.eventMetadata.ACCEPTED)
+	elif args.accEventsOverride != 0:
+		# for a fit without acceptance corrections the number of events
+		# the acceptance matrix is normalized to needs to be equal to
+		# the number of events in the normalization matrix
+		intFile = pyRootPwa.ROOT.TFile.Open(psIntegralPath, "READ")
+		intMeta = pyRootPwa.core.ampIntegralMatrixMetadata.readIntegralFile(intFile)
+		intMatrix = intMeta.getAmpIntegralMatrix()
+		if args.accEventsOverride != intMatrix.nmbEvents():
+			pyRootPwa.utils.printErr("incorrect number of events for normalization of integral matrix for "
+			                         "a fit without acceptance (got: {:d}, expected: {:d}). Aborting...".format(args.accEventsOverride, intMatrix.nmbEvents()))
+			sys.exit(1)
 
 	result = pyRootPwa.utils.getFitResultFromFile(fitResultFileName = args.inputFileName,
 	                                              fitResultTreeName = config.fitResultTreeName,
@@ -53,16 +67,17 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("could not get fit result from file '" + args.inputFileName + "'. Aborting...")
 		sys.exit(1)
 
-	waveDescThres = pyRootPwa.utils.getWaveDescThresFromFitResult(result, fileManager.getKeyFiles())
+	waveDescThres = pyRootPwa.utils.getWaveDescThresFromFitResult(result, fileManager.getWaveDescriptions())
 	if not waveDescThres:
 		pyRootPwa.utils.printErr("error while getting wave names, descriptions and thresholds. Aborting...")
 		sys.exit(1)
 
 	likelihood = pyRootPwa.initLikelihood(waveDescThres = waveDescThres,
 	                                      massBinCenter = result.massBinCenter(),
-	                                      ampFileList = ampFileList,
+	                                      eventAndAmpFileDict = eventAndAmpFileDict,
 	                                      normIntegralFileName = psIntegralPath,
 	                                      accIntegralFileName = accIntegralPath,
+	                                      multiBin = multiBin,
 	                                      accEventsOverride = args.accEventsOverride,
 	                                      cauchy = args.cauchyPriors,
 	                                      cauchyWidth = args.cauchyPriorWidth,

--- a/pyInterface/userInterface/likelihoodPointCalculator.py
+++ b/pyInterface/userInterface/likelihoodPointCalculator.py
@@ -16,11 +16,12 @@ if __name__ == "__main__":
 
 	parser.add_argument("inputFileName", type=str, metavar="inputFile", help="path to fit result")
 	parser.add_argument("-c", type=str, metavar="configFileName", dest="configFileName", default="./rootpwa.config", help="path to config file (default: './rootpwa.config')")
-	parser.add_argument("-b", type=int, metavar="#", dest="binID", default=0, help="bin ID of fit (default: 0)")
+	parser.add_argument("-b", type=int, metavar="#", dest="integralBin", default=0, help="integral bin id of fit (default: 0)")
 	parser.add_argument("-C", "--cauchyPriors", help="use half-Cauchy priors (default: false)", action="store_true")
 	parser.add_argument("-P", "--cauchyPriorWidth", type=float, metavar ="WIDTH", default=0.5, help="width of half-Cauchy prior (default: 0.5)")
 	parser.add_argument("-A", type=int, metavar="#", dest="accEventsOverride", default=0,
 	                    help="number of input events to normalize acceptance to (default: use number of events from normalization integral file)")
+	parser.add_argument("--noAcceptance", help="do not take acceptance into account (default: false)", action="store_true")
 	parser.add_argument("-v", "--verbose", help="verbose; print debug output (default: false)", action="store_true")
 	args = parser.parse_args()
 
@@ -34,14 +35,27 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
 		sys.exit(1)
 
-	ampFileList = fileManager.getAmplitudeFilePaths(args.binID, pyRootPwa.core.eventMetadata.REAL)
-	if not ampFileList:
+	multiBin = fileManager.binList[args.integralBin]
+	eventAndAmpFileDict = fileManager.getEventAndAmplitudeFilePathsInBin(multiBin, pyRootPwa.core.eventMetadata.REAL)
+	if not eventAndAmpFileDict:
 		pyRootPwa.utils.printErr("could not retrieve valid amplitude file list. Aborting...")
 		sys.exit(1)
-	binningMap = fileManager.getBinFromID(args.binID)
 
-	psIntegralPath  = fileManager.getIntegralFilePath(args.binID, pyRootPwa.core.eventMetadata.GENERATED)
-	accIntegralPath = fileManager.getIntegralFilePath(args.binID, pyRootPwa.core.eventMetadata.ACCEPTED)
+	psIntegralPath  = fileManager.getIntegralFilePath(multiBin, pyRootPwa.core.eventMetadata.GENERATED)
+	accIntegralPath = psIntegralPath
+	if not args.noAcceptance:
+		accIntegralPath = fileManager.getIntegralFilePath(multiBin, pyRootPwa.core.eventMetadata.ACCEPTED)
+	elif args.accEventsOverride != 0:
+		# for a fit without acceptance corrections the number of events
+		# the acceptance matrix is normalized to needs to be equal to
+		# the number of events in the normalization matrix
+		intFile = pyRootPwa.ROOT.TFile.Open(psIntegralPath, "READ")
+		intMeta = pyRootPwa.core.ampIntegralMatrixMetadata.readIntegralFile(intFile)
+		intMatrix = intMeta.getAmpIntegralMatrix()
+		if args.accEventsOverride != intMatrix.nmbEvents():
+			pyRootPwa.utils.printErr("incorrect number of events for normalization of integral matrix for "
+			                         "a fit without acceptance (got: {:d}, expected: {:d}). Aborting...".format(args.accEventsOverride, intMatrix.nmbEvents()))
+			sys.exit(1)
 
 	result = pyRootPwa.utils.getFitResultFromFile(fitResultFileName = args.inputFileName,
 	                                              fitResultTreeName = config.fitResultTreeName,
@@ -57,9 +71,10 @@ if __name__ == "__main__":
 
 	likelihood = pyRootPwa.initLikelihood(waveDescThres = waveDescThres,
 	                                      massBinCenter = result.massBinCenter(),
-	                                      ampFileList = ampFileList,
+	                                      eventAndAmpFileDict = eventAndAmpFileDict,
 	                                      normIntegralFileName = psIntegralPath,
 	                                      accIntegralFileName = accIntegralPath,
+	                                      multiBin = multiBin,
 	                                      accEventsOverride = args.accEventsOverride,
 	                                      cauchy = args.cauchyPriors,
 	                                      cauchyWidth = args.cauchyPriorWidth,


### PR DESCRIPTION
Fix the pylint tests for the three python scripts which have been broken by the
recent revision of the file manager and the on-the-fly binning. These fixes are
rather ugly and there is a significant amount of code duplication, but these
scripts need to be revisited and revised anyway when the automatic integral
merging for the fitting is implemented.