### PR TITLE
Update fit result

### DIFF
--- a/highLevelInterface/pwaFit.cc
+++ b/highLevelInterface/pwaFit.cc
@@ -206,7 +206,7 @@ rpwa::hli::pwaFit(const pwaLikelihood<complex<double> >& L,
 	unsigned int maxParNameLength = 0;       // maximum length of parameter names
 	{
 		for (unsigned int i = 0; i < nmbPar; ++i) {
-			const string& parName = L.parName(i);
+			const string parName = L.parameter(i).parName();
 			if (parName.length() > maxParNameLength)
 				maxParNameLength = parName.length();
 		}
@@ -217,7 +217,7 @@ rpwa::hli::pwaFit(const pwaLikelihood<complex<double> >& L,
 		const double sqrtNmbEvts = sqrt((double)nmbEvts);
 		bool         success     = true;
 		for (unsigned int i = 0; i < nmbPar; ++i) {
-			const string& parName = L.parName(i);
+			const string parName = L.parameter(i).parName();
 
 			double startVal;
 			if (startValValid) {
@@ -232,7 +232,7 @@ rpwa::hli::pwaFit(const pwaLikelihood<complex<double> >& L,
 			}
 
 			// check if parameter needs to be fixed
-			if (not L.parFixed(i)) {
+			if (not L.parameter(i).fixed()) {
 				if (startVal == 0) {
 					cout << "    read start value 0 for parameter " << parName << ". "
 					     << "using default start value." << endl;
@@ -344,8 +344,8 @@ rpwa::hli::pwaFit(const pwaLikelihood<complex<double> >& L,
 	printInfo << "minimization result:" << endl;
 	for (unsigned int i = 0; i < nmbPar; ++i) {
 		cout << "    parameter [" << setw(3) << i << "] "
-		     << setw(maxParNameLength) << L.parName(i) << " = ";
-		if (L.parFixed(i))
+		     << setw(maxParNameLength) << L.parameter(i).parName() << " = ";
+		if (L.parameter(i).fixed())
 			cout << correctParams[i] << " (fixed)";
 		else {
 			cout << setw(12) << maxPrecisionAlign(correctParams[i]) << " +- ";

--- a/highLevelInterface/pwaFit.cc
+++ b/highLevelInterface/pwaFit.cc
@@ -381,9 +381,7 @@ rpwa::hli::pwaFit(const pwaLikelihood<complex<double> >& L,
 	complexMatrix accIntegral (0, 0);                 // normalization integral over full phase space with acceptance
 	vector<double> phaseSpaceIntegral;
 	if (not saveSpace) {
-		normIntegral.resizeTo(nmbWaves, nmbWaves);
-		accIntegral.resizeTo(nmbWaves, nmbWaves);
-		L.getIntegralMatrices(normIntegral, accIntegral, phaseSpaceIntegral);
+		L.getIntegralMatrices(normIntegral, accIntegral, phaseSpaceIntegral, true);
 	}
 	const int normNmbEvents = 1;  // number of events to normalize to
 

--- a/highLevelInterface/pwaNloptFit.cc
+++ b/highLevelInterface/pwaNloptFit.cc
@@ -136,7 +136,7 @@ rpwa::hli::pwaNloptFit(const pwaLikelihood<complex<double> >& L,
 	vector<double>params(nmbPar);
 	{
 		for (unsigned int i = 0; i < nmbPar; ++i) {
-			const string& parName = L.parName(i);
+			const string parName = L.parameter(i).parName();
 			if (parName.length() > maxParNameLength)
 				maxParNameLength = parName.length();
 		}
@@ -146,7 +146,7 @@ rpwa::hli::pwaNloptFit(const pwaLikelihood<complex<double> >& L,
 		TRandom3     random(seed);
 		const double sqrtNmbEvts = sqrt((double)nmbEvts);
 		for (unsigned int i = 0; i < nmbPar; ++i) {
-			const string& parName = L.parName(i);
+			const string parName = L.parameter(i).parName();
 
 			double startVal;
 			{
@@ -157,7 +157,7 @@ rpwa::hli::pwaNloptFit(const pwaLikelihood<complex<double> >& L,
 			}
 
 			// check if parameter needs to be fixed
-			if (not L.parFixed(i)) {
+			if (not L.parameter(i).fixed()) {
 				cout << "    setting parameter [" << setw(3) << i << "] "
 				     << setw(maxParNameLength) << parName << " = " << maxPrecisionAlign(startVal) << endl;
 				params[i] = startVal;
@@ -268,7 +268,7 @@ rpwa::hli::pwaNloptFit(const pwaLikelihood<complex<double> >& L,
 	printInfo << "minimization result:" << endl;
 	for (unsigned int i = 0; i < nmbPar; ++i) {
 		cout << "    parameter [" << setw(3) << i << "] "
-		     << setw(maxParNameLength) << L.parName(i) << " = "
+		     << setw(maxParNameLength) << L.parameter(i).parName() << " = "
 		     << setw(12) << maxPrecisionAlign(correctParams[i]) << " +- ";
 		if(not saveSpace) {
 			cout << setw(12) << maxPrecisionAlign(sqrt(fitParCovMatrix(i, i)));

--- a/highLevelInterface/pwaNloptFit.cc
+++ b/highLevelInterface/pwaNloptFit.cc
@@ -294,9 +294,7 @@ rpwa::hli::pwaNloptFit(const pwaLikelihood<complex<double> >& L,
 	complexMatrix accIntegral (0, 0);                 // normalization integral over full phase space with acceptance
 	vector<double> phaseSpaceIntegral;
 	if (not saveSpace) {
-		normIntegral.resizeTo(nmbWaves, nmbWaves);
-		accIntegral.resizeTo(nmbWaves, nmbWaves);
-		L.getIntegralMatrices(normIntegral, accIntegral, phaseSpaceIntegral);
+		L.getIntegralMatrices(normIntegral, accIntegral, phaseSpaceIntegral, true);
 	}
 	const int normNmbEvents = 1;  // number of events to normalize to
 

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -240,15 +240,55 @@ fitResult::fill(const unsigned int              nmbEvents,               // numb
 		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
 		          << "does not match number of production amplitude names "
 		          << "(" << _prodAmpNames.size() << ")." << endl;
+	if (_waveNames.size() > _prodAmpNames.size())
+		printWarn << "number of wave names (" << _waveNames.size() << ") "
+		          << "larger than number of production amplitude names "
+		          << "(" << _prodAmpNames.size() << ")." << endl;
+	if (_fitParCovMatrix.GetNrows() != _fitParCovMatrix.GetNcols())
+		printWarn << "covariance matrix is not a square matrix "
+		          << "(" << _fitParCovMatrix.GetNrows() << ", " << _fitParCovMatrix.GetNcols() << ")." << endl;
 	if (_prodAmps.size() != _fitParCovMatrixIndices.size())
 		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
 		          << "does not match number of covariance matrix indices "
 		          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+	for (unsigned int i=0; i<_fitParCovMatrixIndices.size(); ++i) {
+		if (_fitParCovMatrixIndices[i].first < 0)
+			printWarn << "entry in covariance matrix for real part of production "
+			          << "amplitude " << i << " does not exist." << endl;
+		if (_fitParCovMatrixIndices[i].first >= _fitParCovMatrix.GetNrows())
+			printWarn << "real part of production amplitude " << i << " is mapped to "
+			          << "entry in covariance matrix outside covariance matrix size "
+			          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+		if (_fitParCovMatrixIndices[i].second >= _fitParCovMatrix.GetNrows())
+			printWarn << "imaginary part of production amplitude " << i << " is mapped to "
+			          << "entry in covariance matrix outside covariance matrix size "
+			          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+	}
 	if (   (_waveNames.size() != _normIntegral.nRows())
 	    or (_waveNames.size() != _normIntegral.nCols()))
 		printWarn << "number of waves (" << _waveNames.size() << ") "
 		          << "does not match size of normalization integral "
 		          << "(" << _normIntegral.nRows() << ", " << _normIntegral.nCols() << ")." << endl;
+	if (   (_waveNames.size() != _acceptedNormIntegral.nRows())
+	    or (_waveNames.size() != _acceptedNormIntegral.nCols()))
+		printWarn << "number of waves (" << _waveNames.size() << ") "
+		          << "does not match size of acceptance integral "
+		          << "(" << _acceptedNormIntegral.nRows() << ", " << _acceptedNormIntegral.nCols() << ")." << endl;
+	if (_waveNames.size() != _phaseSpaceIntegral.size())
+		printWarn << "number of waves (" << _waveNames.size() << ") "
+		          << "does not match size of phase-space integral "
+		          << "(" << _phaseSpaceIntegral.size() << ")." << endl;
+	if (_prodAmps.size() != _normIntIndexMap.size())
+		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
+		          << "does not match number of mappings from production amplitudes to indices in integrals "
+		          << "(" << _normIntIndexMap.size() << ")." << endl;
+	for (unsigned int i=0; i<_prodAmps.size(); ++i) {
+		if (_normIntIndexMap.count(i) != 1)
+			printWarn << "production amplitude at index " << i << " is not mapped to any index in integrals." << endl;
+		if (_normIntIndexMap[i] < 0 or _normIntIndexMap[i] >= (int)_waveNames.size())
+			printWarn << "production amplitude at index " << i << " is mapped to integrals "
+			             "at index " << _normIntIndexMap[i] <<", which does not exist." << endl;
+	}
 }
 
 

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -33,7 +33,6 @@
 //-----------------------------------------------------------
 
 
-#include <assert.h>
 #include <algorithm>
 #include <set>
 
@@ -96,7 +95,8 @@ fitResult::~fitResult()
 
 
 fitResult*
-fitResult::variedProdAmps() const {
+fitResult::variedProdAmps() const
+{
 	// copy complete info
 	fitResult* result = new fitResult(*this);
 
@@ -105,10 +105,10 @@ fitResult::variedProdAmps() const {
 	printDebug << "starting Cholesky decomposition... " << endl;
 	TDecompChol decomp(_fitParCovMatrix);
 	decomp.Decompose();
-	TMatrixT<Double_t> C(decomp.GetU());
+	const TMatrixT<Double_t> C(decomp.GetU());
 	printDebug << "... done." << endl;
 
-	unsigned int npar = C.GetNrows();
+	const unsigned int npar = C.GetNrows();
 	TMatrixD x(npar, 1);
 	// generate npar independent random numbers
 	for (unsigned int ipar = 0; ipar < npar; ++ipar)
@@ -116,16 +116,16 @@ fitResult::variedProdAmps() const {
 
 	// this tells us how to permute the parameters taking into account all
 	// correlations in the covariance matrix
-	TMatrixD y(C, TMatrixD::kMult, x);
+	const TMatrixD y(C, TMatrixD::kMult, x);
 
 	// now we need mapping from parameters to production amp re and im
 	// loop over production amps
-	unsigned int nt = _prodAmps.size();
+	const unsigned int nt = _prodAmps.size();
 	for (unsigned int it = 0; it < nt; ++it) {
-		Int_t  jre = _fitParCovMatrixIndices[it].first;
-		Int_t  jim = _fitParCovMatrixIndices[it].second;
-		double re  = result->_prodAmps[it].Re();
-		double im  = result->_prodAmps[it].Im();
+		const Int_t jre = _fitParCovMatrixIndices[it].first;
+		const Int_t jim = _fitParCovMatrixIndices[it].second;
+		double      re  = result->_prodAmps[it].Re();
+		double      im  = result->_prodAmps[it].Im();
 		if(jre > -1)
 			re += y(jre, 0);
 		if(jim > -1)
@@ -139,6 +139,124 @@ fitResult::variedProdAmps() const {
 }
 
 
+void
+fitResult::reset()
+{
+	_nmbEvents     = 0;
+	_normNmbEvents = 0;
+	_massBinCenter = 0;
+	_logLikelihood = 0;
+	_rank          = 0;
+	_prodAmps.clear();
+	_prodAmpNames.clear();
+	_waveNames.clear();
+	_covMatrixValid = false;
+	_fitParCovMatrix.ResizeTo(0, 0);
+	_fitParCovMatrixIndices.clear();
+	_normIntegral.resizeTo(0, 0);
+	_acceptedNormIntegral.resizeTo(0, 0);
+	_normIntIndexMap.clear();
+	_phaseSpaceIntegral.clear();
+	_converged  = false;
+	_hasHessian = false;
+}
+
+
+void
+fitResult::fill(const unsigned int              nmbEvents,               // number of events in bin
+                const unsigned int              normNmbEvents,           // number of events to normalize to
+                const double                    massBinCenter,           // center value of mass bin
+                const double                    logLikelihood,           // log(likelihood) at maximum
+                const int                       rank,                    // rank of fit
+                const vector<complex<double> >& prodAmps,                // production amplitudes
+                const vector<string>&           prodAmpNames,            // names of production amplitudes used in fit
+                const TMatrixT<double>&         fitParCovMatrix,         // covariance matrix of fit parameters
+                const vector<pair<int, int> >&  fitParCovMatrixIndices,  // indices of fit parameters for real and imaginary part in covariance matrix matrix
+                const complexMatrix&            normIntegral,            // normalization integral matrix
+                const complexMatrix&            acceptedNormIntegral,    // normalization integral matrix with acceptance
+                const vector<double>&           phaseSpaceIntegral,      // normalization integral over full phase space without acceptance
+                const bool                      converged,
+                const bool                      hasHessian)
+{
+	_converged     = converged;
+	_hasHessian    = hasHessian;
+	_nmbEvents     = nmbEvents;
+	_normNmbEvents = normNmbEvents;
+	_massBinCenter = massBinCenter;
+	_logLikelihood = logLikelihood;
+	_rank          = rank;
+	_prodAmps.resize(prodAmps.size());
+	for (unsigned int i = 0; i < prodAmps.size(); ++i)
+		_prodAmps[i] = TComplex(prodAmps[i].real(), prodAmps[i].imag());
+	_prodAmpNames  = prodAmpNames;
+	_fitParCovMatrix.ResizeTo(fitParCovMatrix.GetNrows(), fitParCovMatrix.GetNcols());
+	_fitParCovMatrix        = fitParCovMatrix;
+	_fitParCovMatrixIndices = fitParCovMatrixIndices;
+	// check whether there really is an error matrix
+	if (not (fitParCovMatrix.GetNrows() == 0) and not (fitParCovMatrix.GetNcols() == 0))
+		_covMatrixValid = true;
+	else
+		_covMatrixValid = false;
+	_normIntegral.resizeTo(normIntegral.nRows(), normIntegral.nCols());
+	_normIntegral         = normIntegral;
+	_acceptedNormIntegral.resizeTo(acceptedNormIntegral.nRows(), acceptedNormIntegral.nCols());
+	_acceptedNormIntegral = acceptedNormIntegral;
+	_phaseSpaceIntegral   = phaseSpaceIntegral;
+
+	// get wave list from production amplitudes and fill map for
+	// production-amplitude indices to indices in normalization integral
+	for (unsigned int i = 0; i < _prodAmpNames.size(); ++i) {
+		const string waveName = waveNameForProdAmp(i);
+		const size_t waveIdx  = find(_waveNames.begin(), _waveNames.end(), waveName) - _waveNames.begin();
+		if (waveIdx == _waveNames.size())
+			_waveNames.push_back(waveName);
+		_normIntIndexMap[i] = waveIdx;
+	}
+
+	// check consistency
+	if (_prodAmps.size() != _prodAmpNames.size())
+		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
+		          << "does not match number of production amplitude names "
+		          << "(" << _prodAmpNames.size() << ")." << endl;
+	if (_prodAmps.size() != _fitParCovMatrixIndices.size())
+		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
+		          << "does not match number of covariance matrix indices "
+		          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+	if (   (_waveNames.size() != _normIntegral.nRows())
+	    or (_waveNames.size() != _normIntegral.nCols()))
+		printWarn << "number of waves (" << _waveNames.size() << ") "
+		          << "does not match size of normalization integral "
+		          << "(" << _normIntegral.nRows() << ", " << _normIntegral.nCols() << ")." << endl;
+}
+
+
+void
+fitResult::fill(const fitResult& result)
+{
+	_nmbEvents              = result.nmbEvents();
+	_normNmbEvents          = result.normNmbEvents();
+	_massBinCenter          = result.massBinCenter();
+	_logLikelihood          = result.logLikelihood();
+	_rank                   = result.rank();
+	_prodAmps               = result.prodAmps();
+	_prodAmpNames           = result.prodAmpNames();
+	_waveNames              = result.waveNames();
+	_covMatrixValid         = result.covMatrixValid();
+
+	const TMatrixT<double>& fitParCovMatrix = result.fitParCovMatrix();
+	_fitParCovMatrix.ResizeTo(fitParCovMatrix.GetNrows(), fitParCovMatrix.GetNcols());
+	_fitParCovMatrix        = fitParCovMatrix;
+
+	_fitParCovMatrixIndices = result.fitParCovIndices();
+	_normIntegral           = result.normIntegralMatrix();
+	_acceptedNormIntegral   = result.acceptedNormIntegralMatrix();
+	_normIntIndexMap        = result.normIntIndexMap();
+	_phaseSpaceIntegral     = result.phaseSpaceIntegralVector();
+	_converged              = result.converged();
+	_hasHessian             = result.hasHessian();
+}
+
+
 /// \brief calculates the model evidence using Rafters occam factor method
 ///
 /// \f[ \ln P(\mathrm{Data}|M_k)\approx \ln P(\mathrm{Data}|A_{\mathrm{ML}}^k,M_k) + \ln{\frac{\sqrt{(2\pi)^d|\mathbf{C}_{A|D}|}}{\sum_i\frac{\pi}{\Psi_{ii}}}} \f]
@@ -148,12 +266,13 @@ double
 fitResult::evidence() const
 {
 	double retval = 0.;
-	std::vector<double> summands = evidenceComponents();
+	const std::vector<double> summands = evidenceComponents();
 	for(unsigned int i = 0; i < summands.size(); ++i) {
 		retval += summands[i];
 	}
 	return retval;
 }
+
 
 std::vector<double>
 fitResult::evidenceComponents() const
@@ -161,8 +280,17 @@ fitResult::evidenceComponents() const
 	// make sure evidence can be calculated, i.e.:
 	// - covariance matrix exists
 	// - accepted normalisation integral exists
-	if (fitParCovMatrix().GetNcols() == 0 || fitParCovMatrix().GetNrows() == 0
-	    || acceptedNormIntegralMatrix().nCols() == 0 || acceptedNormIntegralMatrix().nRows() == 0) {
+	if (not covMatrixValid()) {
+		printWarn << "fitResult does not have a valid error matrix. Returning negative infinity for components of evidence." << endl;
+		std::vector<double> retval;
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		retval.push_back(-numeric_limits<double>::infinity());
+		return retval;
+	}
+	if (acceptedNormIntegralMatrix().nCols() == 0 || acceptedNormIntegralMatrix().nRows() == 0) {
+		printWarn << "fitResult does not have a acceptance integral matrix. Returning negative infinity for components of evidence." << endl;
 		std::vector<double> retval;
 		retval.push_back(-numeric_limits<double>::infinity());
 		retval.push_back(-numeric_limits<double>::infinity());
@@ -175,10 +303,7 @@ fitResult::evidenceComponents() const
 	// ones with imaginary and real part equal to zero
 	set<unsigned int> thrProdAmpIndices;
 	for (unsigned int i = 0; i < nmbProdAmps(); ++i) {
-		// printDebug << "production amplitude[" << i << "] = '" << _prodAmpNames[i]
-		//            << "' = " << prodAmp(i) << endl;
 		if (prodAmp(i) == 0.) {
-			// printDebug << "IS ZERO!!!" << endl;
 			thrProdAmpIndices.insert(i);
 		}
 	}
@@ -190,9 +315,6 @@ fitResult::evidenceComponents() const
 	for (set<unsigned int>::const_iterator it = thrProdAmpIndices.begin();
 	     it != thrProdAmpIndices.end(); ++it) {
 		const int index = waveIndex(waveNameForProdAmp(*it));
-		// printDebug << " wave[" << index << "] = '" << waveNameForProdAmp(*it).Data()
-		//            << "' has zero production amp[" << *it << "] = '"
-		//            << _prodAmpNames[*it] << "'" << endl;
 		assert(index > 0);
 		thrWaveIndices.insert(index);
 	}
@@ -213,7 +335,6 @@ fitResult::evidenceComponents() const
 	Int_t row = -1;
 	for (Int_t i = 0; i < fitParCovMatrix().GetNrows(); ++i) {
 		if (thrColAndRowIndices.count(i) > 0) {
-			// printDebug << "disregarding covariance row " << i << endl;
 			continue;
 		}
 		row++;
@@ -221,7 +342,6 @@ fitResult::evidenceComponents() const
 		Int_t col = -1;
 		for (Int_t j = 0; j < fitParCovMatrix().GetNcols(); ++j) {
 			if (thrColAndRowIndices.count(j) > 0) {
-				// printDebug << "disregarding covariance column " << j << endl;
 				continue;
 			}
 			col++;
@@ -259,7 +379,7 @@ fitResult::evidenceComponents() const
 	double logDetAcc = 0;
 	{
 		// keep list of required waves for each reflectivity and rank
-		boost::multi_array<vector<int>, 2> waves(boost::extents[2][_rank]);
+		boost::multi_array<vector<int>, 2> waves(boost::extents[2][rank()]);
 
 		// loop over production amplitudes and extract combinations of
 		// rank and reflectivity
@@ -278,7 +398,7 @@ fitResult::evidenceComponents() const
 				continue;
 
 			const int rank = rankOfProdAmp(i);
-			assert(rank >= 0 && rank < _rank);
+			assert(rank >= 0 && (unsigned int)rank < this->rank());
 
 			const int refl = partialWaveFitHelper::getReflectivity(waveName);
 			assert(refl == -1 || refl == +1);
@@ -290,7 +410,7 @@ fitResult::evidenceComponents() const
 		}
 
 		for (unsigned int iRefl = 0; iRefl < 2; ++iRefl) {
-			for (int iRank = 0; iRank < _rank; ++iRank) {
+			for (unsigned int iRank = 0; iRank < rank(); ++iRank) {
 				const unsigned int dim = waves[iRefl][iRank].size();
 				complexMatrix sub(dim, dim);
 
@@ -308,7 +428,7 @@ fitResult::evidenceComponents() const
 		logDetAcc += TMath::Log(acceptedNormIntegral(idxFlat, idxFlat).real());
 	}
 	// n-Sphere:
-	const double lva = TMath::Log(d) + 0.5 * (d * 1.144729886 + (d - 1) * TMath::Log(_nmbEvents))
+	const double lva = TMath::Log(d) + 0.5 * (d * 1.144729886 + (d - 1) * TMath::Log(nmbEvents()))
 	                   - ROOT::Math::lgamma(0.5 * d + 1) - 0.5 * logDetAcc;
 
 	// finally we calculate the probability of single waves being negligible and
@@ -338,34 +458,36 @@ fitResult::evidenceComponents() const
 	retval.push_back(-lva);
 	retval.push_back(logprob);
 	return retval;
-
 }
 
 
-/// \brief calculates spin density matrix element for waves A and B
-///
-/// \f[ \rho_{AB} = \sum_r V_{Ar} V_{Br}^* \f]
-complex<double>
-fitResult::spinDensityMatrixElem(const unsigned int waveIndexA,
-                                 const unsigned int waveIndexB) const
+int
+fitResult::waveIndex(const string& waveName) const
 {
-	// spin density matrix element is 0 if the two waves have different
-	// reflectivities
-	if (partialWaveFitHelper::getReflectivity(_waveNames[waveIndexA])
-	    != partialWaveFitHelper::getReflectivity(_waveNames[waveIndexB])) {
-		return 0;
-	}
+	int index = -1;
+	for (unsigned int i = 0; i < nmbWaves(); ++i)
+		if (waveName == this->waveName(i)) {
+			index = i;
+			break;  // assumes that waves have unique names
+		}
+	if (index == -1)
+		printWarn << "could not find any wave named '" << waveName << "'." << endl;
+	return index;
+}
 
-	// get pairs of amplitude indices with the same rank for waves A and B
-	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
-		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);
-	if (prodAmpIndexPairs.size() == 0)
-		return 0;
-	// sum up amplitude products
-	complex<double> spinDens = 0;
-	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i)
-		spinDens += prodAmp(prodAmpIndexPairs[i].first) * conj(prodAmp(prodAmpIndexPairs[i].second));
-	return spinDens;
+
+int
+fitResult::prodAmpIndex(const string& prodAmpName) const
+{
+	int index = -1;
+	for (unsigned int i = 0; i < nmbProdAmps(); ++i)
+		if (prodAmpName == _prodAmpNames[i]) {
+			index = i;
+			break;  // assumes that production amplitudes have unique names
+		}
+	if (index == -1)
+		printWarn << "could not find any production amplitude named '" << prodAmpName << "'." << endl;
+	return index;
 }
 
 
@@ -431,16 +553,18 @@ fitResult::prodAmpCov(const vector<unsigned int>& prodAmpIndices) const
 {
 	const unsigned int dim = 2 * prodAmpIndices.size();
 	TMatrixT<double>   prodAmpCov(dim, dim);
-	if (not _covMatrixValid) {
+	if (not covMatrixValid()) {
 		printWarn << "fitResult does not have a valid error matrix. Returning zero covariance matrix." << endl;
 		return prodAmpCov;
 	}
+
 	// get corresponding indices for parameter covariances
 	vector<int> parCovIndices;
 	for (unsigned int i = 0; i < prodAmpIndices.size(); ++i) {
 		parCovIndices.push_back(_fitParCovMatrixIndices[prodAmpIndices[i]].first);   // real part
 		parCovIndices.push_back(_fitParCovMatrixIndices[prodAmpIndices[i]].second);  // imaginary part
 	}
+
 	// build covariance matrix
 	for (unsigned int row = 0; row < dim; ++row)
 		for (unsigned int col = 0; col < dim; ++col) {
@@ -450,90 +574,6 @@ fitResult::prodAmpCov(const vector<unsigned int>& prodAmpIndices) const
 				prodAmpCov[row][col] = fitParameterCov(i, j);
 		}
 	return prodAmpCov;
-}
-
-
-/// \brief calculates covariance matrix of spin density matrix element for waves A and B
-///
-/// rho_AB = sum_r V_Ar V_Br^*
-// !!! possible optimization: make special case for waveIndexA == waveIndexB
-TMatrixT<double>
-fitResult::spinDensityMatrixElemCov(const unsigned int waveIndexA,
-                                    const unsigned int waveIndexB) const
-{
-	// spin density matrix element is 0 if the two waves have different
-	// reflectivities
-	if (partialWaveFitHelper::getReflectivity(_waveNames[waveIndexA])
-	    != partialWaveFitHelper::getReflectivity(_waveNames[waveIndexB])) {
-		TMatrixT<double> spinDensCov(2, 2);
-		return spinDensCov;
-	}
-
-	// get pairs of amplitude indices with the same rank for waves A and B
-	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
-		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);
-	if (not _covMatrixValid or (prodAmpIndexPairs.size() == 0)) {
-		TMatrixT<double> spinDensCov(2, 2);
-		return spinDensCov;
-	}
-	// build covariance matrix for amplitudes
-	const TMatrixT<double> prodAmpCov = this->prodAmpCov(prodAmpIndexPairs);
-	// build Jacobian for rho_AB, which is a 2 x 4m matrix composed of 2m sub-Jacobians:
-	// J = (JA0, ..., JA(m - 1), JB0, ..., JB(m - 1))
-	// m is the number of production amplitudes for waves A and B that have the same rank
-	const unsigned int dim = prodAmpCov.GetNcols();
-	TMatrixT<double>   jacobian(2, dim);
-	// build m sub-Jacobians for d rho_AB / d V_Ar = M(V_Br^*)
-	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i) {
-		const unsigned int     ampIndexB    = prodAmpIndexPairs[i].second;
-		const TMatrixT<double> subJacobianA = matrixRepr(conj(prodAmp(ampIndexB)));
-		jacobian.SetSub(0, 2 * i, subJacobianA);
-	}
-	// build m sub-Jacobian for d rho_AB / d V_Br = M(V_Ar) {{1,  0},
-	//                                                       {0, -1}}
-	TMatrixT<double> M(2, 2);  // complex conjugation of V_Br is non-analytic operation
-	M[0][0] =  1;
-	M[1][1] = -1;
-	const unsigned int colOffset = 2 * prodAmpIndexPairs.size();
-	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i) {
-		const unsigned int ampIndexA    = prodAmpIndexPairs[i].first;
-		TMatrixT<double>   subJacobianB = matrixRepr(prodAmp(ampIndexA));
-		subJacobianB *= M;
-		jacobian.SetSub(0, colOffset + 2 * i, subJacobianB);
-	}
-	// calculate spin density covariance matrix
-	// cov(rho_AB) = J cov(V_A0, ..., V_A(m - 1), V_B0, ..., V_B(m - 1)) J^T
-	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);
-	// binary operations are unavoidable, since matrices are not squared
-	// !!! possible optimaztion: use special TMatrixT constructors to perform the multiplication
-	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;
-	const TMatrixT<double> spinDensCov  = jacobian   * prodAmpCovJT;
-	return spinDensCov;
-}
-
-
-/// \brief calculates intensity for set of waves matching name pattern
-///
-/// int = sum_i int(i) + sum_i sum_{j < i} overlap(i, j)
-double
-fitResult::intensity(const string& waveNamePattern) const
-{
-	vector<unsigned int> waveIndices = waveIndicesMatchingPattern(waveNamePattern);
-	if(waveIndices.size() == 1) {
-		return intensity(waveIndices[0]);
-	}
-	double intensity = 0;
-	for (unsigned int i = 0; i < waveIndices.size(); ++i) {
-		intensity += this->intensity(waveIndices[i]);
-		// cout << "    contribution from " << _waveNames[waveIndices[i]]
-		//      << " = " << this->intensity(waveIndices[i]) << endl;
-		for (unsigned int j = 0; j < i; ++j) {
-			intensity += overlap(waveIndices[i], waveIndices[j]);
-			// cout << "        overlap with " << _waveNames[waveIndices[j]]
-			//      << " = " << overlap(waveIndices[i], waveIndices[j]) << endl;
-		}
-	}
-	return intensity;
 }
 
 
@@ -562,53 +602,93 @@ fitResult::normIntegralForProdAmp(const unsigned int prodAmpIndexA,
 }
 
 
-/// \brief calculates error of intensity of a set of waves matching name pattern
+/// \brief calculates spin density matrix element for waves A and B
 ///
-/// error calculation is performed on amplitude level using: int = sum_ij Norm_ij sum_r A_ir A_jr*
-double
-fitResult::intensityErr(const string& waveNamePattern) const
+/// \f[ \rho_{AB} = \sum_r V_{Ar} V_{Br}^* \f]
+complex<double>
+fitResult::spinDensityMatrixElem(const unsigned int waveIndexA,
+                                 const unsigned int waveIndexB) const
 {
-	// get amplitudes that correspond to wave name pattern
-	const vector<unsigned int> waveIndices    = waveIndicesMatchingPattern(waveNamePattern);
-	const unsigned int         nmbWaves       = waveIndices.size();
-	if (not _covMatrixValid or (nmbWaves == 0)) {
-		return 0.;
-	}
-	if(nmbWaves == 1) {
-		return intensityErr(waveIndices[0]);
+	// spin density matrix element is 0 if the two waves have different
+	// reflectivities
+	if (partialWaveFitHelper::getReflectivity(waveName(waveIndexA))
+	    != partialWaveFitHelper::getReflectivity(waveName(waveIndexB))) {
+		return 0;
 	}
 
-	vector<unsigned int> prodAmpIndices;
-	for (unsigned int i = 0; i < nmbWaves; ++i) {
-		const vector<unsigned int> prodAmpIndicesWave = prodAmpIndicesForWave(waveIndices[i]);
-		prodAmpIndices.insert(prodAmpIndices.end(), prodAmpIndicesWave.begin(), prodAmpIndicesWave.end());
+	// get pairs of amplitude indices with the same rank for waves A and B
+	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
+		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);
+	if (prodAmpIndexPairs.size() == 0)
+		return 0;
+
+	// sum up amplitude products
+	complex<double> spinDens = 0;
+	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i)
+		spinDens += prodAmp(prodAmpIndexPairs[i].first) * conj(prodAmp(prodAmpIndexPairs[i].second));
+	return spinDens;
+}
+
+
+/// \brief calculates covariance matrix of spin density matrix element for waves A and B
+///
+/// \f[ \rho_{AB} = \sum_r V_{Ar} V_{Br}^* \f]
+// !!! possible optimization: make special case for waveIndexA == waveIndexB
+TMatrixT<double>
+fitResult::spinDensityMatrixElemCov(const unsigned int waveIndexA,
+                                    const unsigned int waveIndexB) const
+{
+	// spin density matrix element is 0 if the two waves have different
+	// reflectivities
+	if (partialWaveFitHelper::getReflectivity(waveName(waveIndexA))
+	    != partialWaveFitHelper::getReflectivity(waveName(waveIndexB))) {
+		const TMatrixT<double> spinDensCov(2, 2);
+		return spinDensCov;
 	}
-	const unsigned int nmbAmps = prodAmpIndices.size();
-	// build Jacobian for intensity, which is a 1 x 2n matrix composed of n sub-Jacobians:
-	// J = (JA_0, ..., JA_{n - 1}), where n is the number of production amplitudes
-	TMatrixT<double> jacobian(1, 2 * nmbAmps);
-	for (unsigned int i = 0; i < nmbAmps; ++i) {
-		// build sub-Jacobian for each amplitude; intensity is real valued function, so J has only one row
-		// JA_ir = 2 * sum_j (A_jr Norm_ji)
-		complex<double>  ampNorm     = 0;  // sum_j (A_jr Norm_ji)
-		const int        currentRefl = partialWaveFitHelper::getReflectivity(waveNameForProdAmp(prodAmpIndices[i]));
-		const int        currentRank = rankOfProdAmp(prodAmpIndices[i]);
-		for (unsigned int j = 0; j < nmbAmps; ++j) {
-			if (partialWaveFitHelper::getReflectivity(waveNameForProdAmp(prodAmpIndices[j])) != currentRefl)
-				continue;
-			if (rankOfProdAmp(prodAmpIndices[j]) != currentRank)
-				continue;
-			ampNorm += prodAmp(prodAmpIndices[j]) * normIntegralForProdAmp(prodAmpIndices[j], prodAmpIndices[i]);  // order of indices is essential
-		}
-		jacobian[0][2 * i    ] = ampNorm.real();
-		jacobian[0][2 * i + 1] = ampNorm.imag();
+
+	// get pairs of amplitude indices with the same rank for waves A and B
+	const vector<pair<unsigned int, unsigned int> > prodAmpIndexPairs
+		= prodAmpIndexPairsForWaves(waveIndexA, waveIndexB);
+	if (not covMatrixValid() or (prodAmpIndexPairs.size() == 0)) {
+		const TMatrixT<double> spinDensCov(2, 2);
+		return spinDensCov;
 	}
-	jacobian *= 2;
-	const TMatrixT<double> prodAmpCov   = this->prodAmpCov(prodAmpIndices);     // 2n x 2n matrix
-	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);  // 2n x  1 matrix
-	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;               // 2n x  1 matrix
-	const TMatrixT<double> intensityCov = jacobian * prodAmpCovJT;              //  1 x  1 matrix
-	return sqrt(intensityCov[0][0]);
+
+	// build covariance matrix for amplitudes
+	const TMatrixT<double> prodAmpCov = this->prodAmpCov(prodAmpIndexPairs);
+
+	// build Jacobian for rho_AB, which is a 2 x 4m matrix composed of 2m sub-Jacobians:
+	// J = (JA0, ..., JA(m - 1), JB0, ..., JB(m - 1))
+	// m is the number of production amplitudes for waves A and B that have the same rank
+	const unsigned int dim = prodAmpCov.GetNcols();
+	TMatrixT<double>   jacobian(2, dim);
+	// build m sub-Jacobians for d rho_AB / d V_Ar = M(V_Br^*)
+	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i) {
+		const unsigned int     ampIndexB    = prodAmpIndexPairs[i].second;
+		const TMatrixT<double> subJacobianA = matrixRepr(conj(prodAmp(ampIndexB)));
+		jacobian.SetSub(0, 2 * i, subJacobianA);
+	}
+	// build m sub-Jacobians for d rho_AB / d V_Br = M(V_Ar) {{1,  0},
+	//                                                        {0, -1}}
+	TMatrixT<double> M(2, 2);  // complex conjugation of V_Br is non-analytic operation
+	M[0][0] =  1;
+	M[1][1] = -1;
+	const unsigned int colOffset = 2 * prodAmpIndexPairs.size();
+	for (unsigned int i = 0; i < prodAmpIndexPairs.size(); ++i) {
+		const unsigned int ampIndexA    = prodAmpIndexPairs[i].first;
+		TMatrixT<double>   subJacobianB = matrixRepr(prodAmp(ampIndexA));
+		subJacobianB *= M;
+		jacobian.SetSub(0, colOffset + 2 * i, subJacobianB);
+	}
+
+	// calculate spin density covariance matrix
+	// cov(rho_AB) = J cov(V_A0, ..., V_A(m - 1), V_B0, ..., V_B(m - 1)) J^T
+	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);
+	// binary operations are unavoidable, since matrices are not squared
+	// !!! possible optimaztion: use special TMatrixT constructors to perform the multiplication
+	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;
+	const TMatrixT<double> spinDensCov  = jacobian   * prodAmpCovJT;
+	return spinDensCov;
 }
 
 
@@ -628,8 +708,9 @@ double
 fitResult::phaseErr(const unsigned int waveIndexA,
                     const unsigned int waveIndexB) const
 {
-	if (not _covMatrixValid or (waveIndexA == waveIndexB))
+	if (not covMatrixValid() or (waveIndexA == waveIndexB))
 		return 0;
+
 	// construct Jacobian for phi_AB = +- arctan(Im[rho_AB] / Re[rho_AB])
 	const complex<double> spinDens = spinDensityMatrixElem(waveIndexA, waveIndexB);
 	TMatrixT<double>      jacobian(1, 2);  // phase is real valued function, so J has only one row
@@ -662,13 +743,14 @@ fitResult::coherenceErr(const unsigned int waveIndexA,
                         const unsigned int waveIndexB) const
 {
 	// get amplitude indices for waves A and B
-	const vector<unsigned int> prodAmpIndices[2] = {prodAmpIndicesForWave(waveIndexA),
-	                                                prodAmpIndicesForWave(waveIndexB)};
-	if (not _covMatrixValid or (prodAmpIndices[0].size() == 0) or (prodAmpIndices[1].size() == 0))
+	const vector<unsigned int> prodAmpIndicesA = prodAmpIndicesForWave(waveIndexA);
+	const vector<unsigned int> prodAmpIndicesB = prodAmpIndicesForWave(waveIndexB);
+	if (not covMatrixValid() or (prodAmpIndicesA.size() == 0) or (prodAmpIndicesB.size() == 0))
 		return 0;
+
 	// build Jacobian for coherence, which is a 1 x 2(n + m) matrix composed of (n + m) sub-Jacobians:
 	// J = (JA_0, ..., JA_{n - 1}, JB_0, ..., JB_{m - 1})
-	const unsigned int nmbAmps = prodAmpIndices[0].size() + prodAmpIndices[1].size();
+	const unsigned int nmbAmps = prodAmpIndicesA.size() + prodAmpIndicesB.size();
 	TMatrixT<double>   jacobian(1, 2 * nmbAmps);
 	// precalculate some variables
 	const double          rhoAA     = spinDensityMatrixElem(waveIndexA, waveIndexA).real();  // rho_AA is real by definition
@@ -681,14 +763,14 @@ fitResult::coherenceErr(const unsigned int waveIndexA,
 	if (coh == 0)
 		return 0;
 	// build m sub-Jacobians for JA_r = coh_AB / d V_Ar
-	for (unsigned int i = 0; i < prodAmpIndices[0].size(); ++i) {
-		const unsigned int    prodAmpIndexA = prodAmpIndices[0][i];
+	for (unsigned int i = 0; i < prodAmpIndicesA.size(); ++i) {
+		const unsigned int    prodAmpIndexA = prodAmpIndicesA[i];
 		const complex<double> prodAmpA      = prodAmp(prodAmpIndexA);
 		const int             prodAmpRankA  = rankOfProdAmp(prodAmpIndexA);
 		// find production amplitude of wave B with same rank
 		complex<double> prodAmpB = 0;
-		for (unsigned int j = 0; j < prodAmpIndices[1].size(); ++j) {
-			const unsigned int prodAmpIndexB = prodAmpIndices[1][j];
+		for (unsigned int j = 0; j < prodAmpIndicesB.size(); ++j) {
+			const unsigned int prodAmpIndexB = prodAmpIndicesB[j];
 			if (rankOfProdAmp(prodAmpIndexB) == prodAmpRankA) {
 				prodAmpB = prodAmp(prodAmpIndexB);
 				break;
@@ -698,16 +780,16 @@ fitResult::coherenceErr(const unsigned int waveIndexA,
 		jacobian[0][2 * i + 1] = rhoABRe * prodAmpB.imag() + rhoABIm * prodAmpB.real() - (rhoABNorm / rhoAA) * prodAmpA.imag();
 	}
 	// !!! possible optimization: join the loops for JA_r and JB_r
-	// build m sub-Jacobian for JB_r = d coh_AB / d V_Br
-	const unsigned int colOffset = 2 * prodAmpIndices[0].size();
-	for (unsigned int i = 0; i < prodAmpIndices[1].size(); ++i) {
-		const unsigned int    prodAmpIndexB = prodAmpIndices[1][i];
+	// build m sub-Jacobians for JB_r = d coh_AB / d V_Br
+	const unsigned int colOffset = 2 * prodAmpIndicesA.size();
+	for (unsigned int i = 0; i < prodAmpIndicesB.size(); ++i) {
+		const unsigned int    prodAmpIndexB = prodAmpIndicesB[i];
 		const complex<double> prodAmpB      = prodAmp(prodAmpIndexB);
 		const int             prodAmpRankB  = rankOfProdAmp(prodAmpIndexB);
 		// find production amplitude of wave A with same rank
 		complex<double> prodAmpA = 0;
-		for (unsigned int j = 0; j < prodAmpIndices[0].size(); ++j) {
-			const unsigned int prodAmpIndexA = prodAmpIndices[0][j];
+		for (unsigned int j = 0; j < prodAmpIndicesA.size(); ++j) {
+			const unsigned int prodAmpIndexA = prodAmpIndicesA[j];
 			if (rankOfProdAmp(prodAmpIndexA) == prodAmpRankB) {
 				prodAmpA = prodAmp(prodAmpIndexA);
 				break;
@@ -717,11 +799,12 @@ fitResult::coherenceErr(const unsigned int waveIndexA,
 		jacobian[0][colOffset + 2 * i + 1] = rhoABRe * prodAmpA.imag() - rhoABIm * prodAmpA.real() - (rhoABNorm / rhoBB) * prodAmpB.imag();
 	}
 	jacobian *= 1 / (coh * rhoAA * rhoBB);
+
 	// build covariance matrix for amplitudes and calculate coherence covariance matrix
-	const TMatrixT<double> prodAmpCov   = this->prodAmpCov(prodAmpIndices[0], prodAmpIndices[1]);  // 2(n + m) x 2(n + m) matrix
-	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);                     // 2(n + m) x        1 matrix
-	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;                                  // 2(n + m) x        1 matrix
-	const TMatrixT<double> cohCov       = jacobian   * prodAmpCovJT;                               //        1 x        1 matrix
+	const TMatrixT<double> prodAmpCov   = this->prodAmpCov(prodAmpIndicesA, prodAmpIndicesB);  // 2(n + m) x 2(n + m) matrix
+	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);                 // 2(n + m) x        1 matrix
+	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;                              // 2(n + m) x        1 matrix
+	const TMatrixT<double> cohCov       = jacobian   * prodAmpCovJT;                           //        1 x        1 matrix
 	return sqrt(cohCov[0][0]);
 }
 
@@ -742,8 +825,9 @@ double
 fitResult::overlapErr(const unsigned int waveIndexA,
                       const unsigned int waveIndexB) const
 {
-	if (not _covMatrixValid)
+	if (not covMatrixValid())
 		return 0;
+
 	const complex<double> normInt = normIntegral(waveIndexA, waveIndexB);
 	TMatrixT<double> jacobian(1, 2);  // overlap is real valued function, so J has only one row
 	jacobian[0][0] =  2 * normInt.real();
@@ -753,199 +837,79 @@ fitResult::overlapErr(const unsigned int waveIndexA,
 }
 
 
-void
-fitResult::reset()
+/// \brief calculates intensity for set of waves matching name pattern
+///
+/// int = sum_i int(i) + sum_i sum_{j < i} overlap(i, j)
+double
+fitResult::intensity(const string& waveNamePattern) const
 {
-	_nmbEvents     = 0;
-	_normNmbEvents = 0;
-	_massBinCenter = 0;
-	_logLikelihood = 0;
-	_rank          = 0;
-	_prodAmps.clear();
-	_prodAmpNames.clear();
-	_waveNames.clear();
-	_covMatrixValid = false;
-	_fitParCovMatrix.ResizeTo(0, 0);
-	_fitParCovMatrixIndices.clear();
-	_normIntegral.resizeTo(0, 0);
-	_acceptedNormIntegral.resizeTo(0, 0);
-	_normIntIndexMap.clear();
-	_phaseSpaceIntegral.clear();
-	_converged  = false;
-	_hasHessian = false;
-}
-
-
-void
-fitResult::fill
-(const unsigned int              nmbEvents,               // number of events in bin
- const unsigned int              normNmbEvents,           // number of events to normalize to
- const double                    massBinCenter,           // center value of mass bin
- const double                    logLikelihood,           // log(likelihood) at maximum
- const int                       rank,                    // rank of fit
- const vector<complex<double> >& prodAmps,                // production amplitudes
- const vector<string>&           prodAmpNames,            // names of production amplitudes used in fit
- const TMatrixT<double>&         fitParCovMatrix,         // covariance matrix of fit parameters
- const vector<pair<int, int> >&  fitParCovMatrixIndices,  // indices of fit parameters for real and imaginary part in covariance matrix matrix
- const complexMatrix&            normIntegral,            // normalization integral matrix
- const complexMatrix&            acceptedNormIntegral,    // normalization integral matrix with acceptance
- const vector<double>&           phaseSpaceIntegral,      // normalization integral over full phase space without acceptance
- const bool                      converged,
- const bool                      hasHessian)
-{
-	_converged     = converged;
-	_hasHessian    = hasHessian;
-	_nmbEvents     = nmbEvents;
-	_normNmbEvents = normNmbEvents;
-	_massBinCenter = massBinCenter;
-	_logLikelihood = logLikelihood;
-	_rank          = rank;
-	_prodAmps.resize(prodAmps.size());
-	for (unsigned int i = 0; i < prodAmps.size(); ++i)
-		_prodAmps[i] = TComplex(prodAmps[i].real(), prodAmps[i].imag());
-	_prodAmpNames  = prodAmpNames;
-	_fitParCovMatrix.ResizeTo(fitParCovMatrix.GetNrows(), fitParCovMatrix.GetNcols());
-	_fitParCovMatrix        = fitParCovMatrix;
-	_fitParCovMatrixIndices = fitParCovMatrixIndices;
-	// check whether there really is an error matrix
-	if (not (fitParCovMatrix.GetNrows() == 0) and not (fitParCovMatrix.GetNcols() == 0))
-		_covMatrixValid = true;
-	else
-		_covMatrixValid = false;
-	_normIntegral.resizeTo(normIntegral.nRows(), normIntegral.nCols());
-	_normIntegral         = normIntegral;
-	_acceptedNormIntegral.resizeTo(acceptedNormIntegral.nRows(), acceptedNormIntegral.nCols());
-	_acceptedNormIntegral = acceptedNormIntegral;
-	_phaseSpaceIntegral   = phaseSpaceIntegral;
-
-	// get wave list from production amplitudes and fill map for
-	// production-amplitude indices to indices in normalization integral
-	for (unsigned int i = 0; i < _prodAmpNames.size(); ++i) {
-		const string waveName = waveNameForProdAmp(i);
-		const size_t waveIdx  = find(_waveNames.begin(), _waveNames.end(), waveName) - _waveNames.begin();
-		if (waveIdx == _waveNames.size())
-			_waveNames.push_back(waveName);
-		_normIntIndexMap[i] = waveIdx;
+	const vector<unsigned int> waveIndices = waveIndicesMatchingPattern(waveNamePattern);
+	const unsigned int         nmbWaves    = waveIndices.size();
+	if (nmbWaves == 0) {
+		return 0;
+	}
+	if (nmbWaves == 1) {
+		return intensity(waveIndices[0]);
 	}
 
-	// check consistency
-	if (_prodAmps.size() != _prodAmpNames.size())
-		cout << "fitResult::fill(): warning: number of production amplitudes "
-		     << "(" << _prodAmps.size() << ") does not match number of "
-		     << "production amplitude names (" << _prodAmpNames.size() << ")." << endl;
-	if (_prodAmps.size() != _fitParCovMatrixIndices.size())
-		cout << "fitResult::fill(): warning: number of production amplitudes "
-		     << "(" << _prodAmps.size() << ") does not match number of "
-		     << "covariance matrix indices (" << _fitParCovMatrixIndices.size() << ")." << endl;
-	if (   (_waveNames.size() != _normIntegral.nRows())
-	    or (_waveNames.size() != _normIntegral.nCols()))
-		cout << "fitResult::fill(): warning: number of waves (" << _waveNames.size()
-		     << ") does not match size of normalization integral "
-		     << "(" << _normIntegral.nRows() << ", " << _normIntegral.nCols() << ")." << endl;
-
-	if (0) {
-		// print debug information that allows to check ordering of arrays
-		map<TString, complex<double> > V;
-		for (unsigned int i = 0; i < nmbProdAmps(); ++i)
-			V[prodAmpName(i)] = prodAmp(i);
-		printInfo << "production amplitudes:" << endl;
-		for (map<TString, complex<double> >::const_iterator i = V.begin(); i != V.end(); ++i)
-			cout << "     " << i->first << " = " << i->second << endl;
-		printInfo << "normalization integral matrix:" << endl;
-		map<TString, unsigned int> waveIndexMap;
-		for (unsigned int i = 0; i < nmbWaves(); ++i)
-			waveIndexMap[waveName(i)] = i;
-		for (map<TString, unsigned int>::const_iterator i = waveIndexMap.begin();
-		     i != waveIndexMap.end(); ++i)
-			for (map<TString, unsigned int>::const_iterator j = waveIndexMap.begin();
-			     j != waveIndexMap.end(); ++j) {
-				cout << "    [" << i->first << "][" << j->first << "] = "
-				     << this->normIntegral(i->second, j->second) << endl;
-			}
-		printInfo << "covariance matrix:" << endl;
-		map<TString, unsigned int> prodAmpIndexMap;
-		for (unsigned int i = 0; i < nmbProdAmps(); ++i)
-			prodAmpIndexMap[prodAmpName(i)] = i;
-		for (map<TString, unsigned int>::const_iterator i = prodAmpIndexMap.begin();
-		     i != prodAmpIndexMap.end(); ++i) {
-			const int iIndex[2] = { _fitParCovMatrixIndices[i->second].first,    // real part index
-			                        _fitParCovMatrixIndices[i->second].second};  // imaginary part index
-			for (map<TString, unsigned int>::const_iterator j = prodAmpIndexMap.begin();
-			     j != prodAmpIndexMap.end(); ++j) {
-				const int jIndex[2] = { _fitParCovMatrixIndices[j->second].first,    // real part index
-				                        _fitParCovMatrixIndices[j->second].second};  // imaginary part index
-				cout << "    [" << i->first << "][" << j->first << "]: " << flush;
-				if (iIndex[0] >= 0) {
-					if (jIndex[0] >= 0)
-						cout << "ReRe = " << fitParameterCov(iIndex[0], jIndex[0]) << ", " << flush;
-					if (jIndex[1] >= 0)
-						cout << "ReIm = " << fitParameterCov(iIndex[0], jIndex[1]) << ", " << flush;
-				}
-				if (iIndex[1] >= 0) {
-					if (jIndex[0] >= 0)
-						cout << "ImRe = " << fitParameterCov(iIndex[1], jIndex[0]) << ", " << flush;
-					if (jIndex[1] >= 0)
-						cout << "ImIm = " << fitParameterCov(iIndex[1], jIndex[1]) << flush;
-				}
-				cout << endl;
-			}
+	double intensity = 0;
+	for (unsigned int i = 0; i < nmbWaves; ++i) {
+		intensity += this->intensity(waveIndices[i]);
+		for (unsigned int j = 0; j < i; ++j) {
+			intensity += overlap(waveIndices[i], waveIndices[j]);
 		}
 	}
+	return intensity;
 }
 
 
-void
-fitResult::fill(const fitResult& result)
+/// \brief calculates error of intensity of a set of waves matching name pattern
+///
+/// error calculation is performed on amplitude level using: int = sum_ij Norm_ij sum_r A_ir A_jr*
+double
+fitResult::intensityErr(const string& waveNamePattern) const
 {
-	_nmbEvents              = result.nmbEvents();
-	_normNmbEvents          = result.normNmbEvents();
-	_massBinCenter          = result.massBinCenter();
-	_logLikelihood          = result.logLikelihood();
-	_rank                   = result.rank();
-	_prodAmps               = result.prodAmps();
-	_prodAmpNames           = result.prodAmpNames();
-	_waveNames              = result.waveNames();
-	_covMatrixValid         = result.covMatrixValid();
+	// get amplitudes that correspond to wave name pattern
+	const vector<unsigned int> waveIndices = waveIndicesMatchingPattern(waveNamePattern);
+	const unsigned int         nmbWaves    = waveIndices.size();
+	if (not covMatrixValid() or (nmbWaves == 0)) {
+		return 0;
+	}
+	if (nmbWaves == 1) {
+		return intensityErr(waveIndices[0]);
+	}
 
-	const TMatrixT<double>& fitParCovMatrix = result.fitParCovMatrix();
-	_fitParCovMatrix.ResizeTo(fitParCovMatrix.GetNrows(), fitParCovMatrix.GetNcols());
-	_fitParCovMatrix        = fitParCovMatrix;
+	vector<unsigned int> prodAmpIndices;
+	for (unsigned int i = 0; i < nmbWaves; ++i) {
+		const vector<unsigned int> prodAmpIndicesWave = prodAmpIndicesForWave(waveIndices[i]);
+		prodAmpIndices.insert(prodAmpIndices.end(), prodAmpIndicesWave.begin(), prodAmpIndicesWave.end());
+	}
+	const unsigned int nmbAmps = prodAmpIndices.size();
 
-	_fitParCovMatrixIndices = result.fitParCovIndices();
-	_normIntegral           = result.normIntegralMatrix();
-	_acceptedNormIntegral   = result.acceptedNormIntegralMatrix();
-	_normIntIndexMap        = result.normIntIndexMap();
-	_phaseSpaceIntegral     = result.phaseSpaceIntegralVector();
-	_converged              = result.converged();
-	_hasHessian             = result.hasHessian();
-}
-
-
-int
-fitResult::waveIndex(const string& waveName) const
-{
-	int index = -1;
-	for (unsigned int i = 0; i < nmbWaves(); ++i)
-		if (waveName == _waveNames[i]) {
-			index = i;
-			break;  // assumes that waves have unique names
+	// build Jacobian for intensity, which is a 1 x 2n matrix composed of n sub-Jacobians:
+	// J = (JA_0, ..., JA_{n - 1}), where n is the number of production amplitudes
+	TMatrixT<double> jacobian(1, 2 * nmbAmps);
+	for (unsigned int i = 0; i < nmbAmps; ++i) {
+		// build sub-Jacobian for each amplitude; intensity is real valued function, so J has only one row
+		// JA_ir = 2 * sum_j (A_jr Norm_ji)
+		complex<double>  ampNorm     = 0;  // sum_j (A_jr Norm_ji)
+		const int        currentRefl = partialWaveFitHelper::getReflectivity(waveNameForProdAmp(prodAmpIndices[i]));
+		const int        currentRank = rankOfProdAmp(prodAmpIndices[i]);
+		for (unsigned int j = 0; j < nmbAmps; ++j) {
+			if (partialWaveFitHelper::getReflectivity(waveNameForProdAmp(prodAmpIndices[j])) != currentRefl)
+				continue;
+			if (rankOfProdAmp(prodAmpIndices[j]) != currentRank)
+				continue;
+			ampNorm += prodAmp(prodAmpIndices[j]) * normIntegralForProdAmp(prodAmpIndices[j], prodAmpIndices[i]);  // order of indices is essential
 		}
-	if (index == -1)
-		printWarn << "could not find any wave named '" << waveName << "'." << endl;
-	return index;
-}
+		jacobian[0][2 * i    ] = ampNorm.real();
+		jacobian[0][2 * i + 1] = ampNorm.imag();
+	}
+	jacobian *= 2;
 
-
-int
-fitResult::prodAmpIndex(const string& prodAmpName) const
-{
-	int index = -1;
-	for (unsigned int i = 0; i < nmbProdAmps(); ++i)
-		if (prodAmpName == _prodAmpNames[i]) {
-			index = i;
-			break;  // assumes that production amplitudes have unique names
-		}
-	if (index == -1)
-		printWarn << "could not find any production amplitude named '" << prodAmpName << "'." << endl;
-	return index;
+	const TMatrixT<double> prodAmpCov   = this->prodAmpCov(prodAmpIndices);     // 2n x 2n matrix
+	const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);  // 2n x  1 matrix
+	const TMatrixT<double> prodAmpCovJT = prodAmpCov * jacobianT;               // 2n x  1 matrix
+	const TMatrixT<double> intensityCov = jacobian * prodAmpCovJT;              //  1 x  1 matrix
+	return sqrt(intensityCov[0][0]);
 }

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -46,7 +46,6 @@
 #include "TRandom3.h"
 
 #include "fitResult.h"
-#include "partialWaveFitHelper.h"
 
 
 using namespace std;

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -56,6 +56,29 @@ using namespace rpwa;
 ClassImp(fitResult);
 
 
+namespace {
+
+
+	/// \brief returns matrix representation of complex number
+	///
+	///   c.re  -c.im
+	///   c.im   c.re
+	// !!! possible optimization: return TMatrixTLazy
+	inline
+	TMatrixT<double>
+	matrixRepr(const std::complex<double>& c)
+	{
+		TMatrixT<double> m(2, 2);
+		m[0][0] = m[1][1] = c.real();
+		m[0][1] = -c.imag();
+		m[1][0] =  c.imag();
+		return m;
+	}
+
+
+}
+
+
 fitResult::fitResult()
 	: _nmbEvents     (0),
 	  _normNmbEvents (0),

--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -536,33 +536,6 @@ fitResult::fitParameter(const string& parName) const
 }
 
 
-/// returns fit parameter error by parameter name
-double
-fitResult::fitParameterErr(const string& parName) const
-{
-	if (not covMatrixValid()) {
-		printWarn << "fitResult does not have a valid error matrix. Returning zero error for fit parameter." << endl;
-		return 0;
-	}
-	// check if parameter corresponds to real or imaginary part of production amplitude
-	TString    name(parName);
-	const bool realPart = (name.Contains("RE") or name.Contains("flat"));
-	// find corresponding production amplitude
-	if (realPart)
-		name.ReplaceAll("_RE", "");
-	else
-		name.ReplaceAll("_IM", "");
-	const int index = prodAmpIndex(name.Data());
-	if (index >= 0) {
-		if (realPart)
-			return sqrt(prodAmpCov(index)[0][0]);
-		else
-			return sqrt(prodAmpCov(index)[1][1]);
-	}
-	return 0;  // not found
-}
-
-
 /// \brief constructs 2n x 2n covariance matrix of production amplitudes specified by index list
 // where n is the number of amplitudes
 // layout:
@@ -597,7 +570,7 @@ fitResult::prodAmpCov(const vector<unsigned int>& prodAmpIndices) const
 			const int i = parCovIndices[row];
 			const int j = parCovIndices[col];
 			if ((i >= 0) and (j >= 0))
-				prodAmpCov[row][col] = fitParameterCov(i, j);
+				prodAmpCov[row][col] = _fitParCovMatrix(i, j);
 		}
 	return prodAmpCov;
 }

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -283,7 +283,6 @@ namespace rpwa {
 		inline std::ostream& printWaveNames   (std::ostream& out = std::cout) const;  ///< prints all wave names
 		inline std::ostream& printProdAmps    (std::ostream& out = std::cout) const;  ///< prints all production amplitudes and their covariance matrix
 		inline std::ostream& printWaves       (std::ostream& out = std::cout) const;  ///< prints all wave intensities and their errors
-		inline std::ostream& printAmpsGenPW   (std::ostream& out = std::cout) const;  ///< prints all amplitudes in format used for genpw (rank 1 only at the moment)
 
 		virtual inline std::ostream& print(std::ostream& out = std::cout) const;
 		friend std::ostream& operator << (std::ostream&    out,
@@ -458,20 +457,6 @@ namespace rpwa {
 			    << " +- " << intensityErr(i) << std::endl;
 		}
 		return out;
-	}
-
-
-	// prints all amplitudes in format used for genpw
-	// only supports rank 1 at the moment!!!
-	inline
-	std::ostream&
-	fitResult::printAmpsGenPW(std::ostream& s) const {
-		for(unsigned int i=0;i<nmbWaves();++i){
-			s << waveName(i) << " "
-			  << prodAmp(i).real() << " "
-			  << prodAmp(i).imag() << std::endl;
-		}
-		return s;
 	}
 
 

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -280,8 +280,6 @@ namespace rpwa {
 		const std::map<Int_t, Int_t>&                normIntIndexMap           () const { return _normIntIndexMap;        }
 
 
-		inline std::ostream& printProdAmpNames(std::ostream& out = std::cout) const;  ///< prints all production amplitude names
-		inline std::ostream& printWaveNames   (std::ostream& out = std::cout) const;  ///< prints all wave names
 		inline std::ostream& printProdAmps    (std::ostream& out = std::cout) const;  ///< prints all production amplitudes and their covariance matrix
 		inline std::ostream& printWaves       (std::ostream& out = std::cout) const;  ///< prints all wave intensities and their errors
 
@@ -407,30 +405,6 @@ namespace rpwa {
 	}
 
 
-	// prints all production amplitude names
-	inline
-	std::ostream&
-	fitResult::printProdAmpNames(std::ostream& out) const
-	{
-		out << "    Production amplitude names:" << std::endl;
-		for (unsigned int i = 0; i < nmbProdAmps(); ++i)
-			out << "        " << std::setw(3) << i << " " << _prodAmpNames[i] << std::endl;
-		return out;
-	}
-
-
-	// prints all wave names
-	inline
-	std::ostream&
-	fitResult::printWaveNames(std::ostream& out) const
-	{
-		out << "    Wave names:" << std::endl;
-		for (unsigned int i = 0; i < nmbWaves(); ++i)
-			out << "        " << std::setw(3) << i << " " << waveName(i) << std::endl;
-		return out;
-	}
-
-
 	// prints all production amplitudes and their covariance matrix
 	inline
 	std::ostream&
@@ -474,7 +448,7 @@ namespace rpwa {
 		    << "    fit has converged .................... " << rpwa::yesNo(converged())      << std::endl
 		    << "    Hessian matrix has been calculated ... " << rpwa::yesNo(hasHessian())     << std::endl;
 		printProdAmps(out);
-		printWaveNames(out);
+		printWaves(out);
 		out << "    covariance matrix:" << std::endl << _fitParCovMatrix << std::endl;
 		out << "    covariance matrix indices:" << std::endl;
 		for (unsigned int i = 0; i < _fitParCovMatrixIndices.size(); ++i)

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -292,8 +292,6 @@ namespace rpwa {
 
 		// helper functions
 
-		inline static TMatrixT<double> matrixRepr(const std::complex<double>& c);
-
 		std::complex<double> normIntegralForProdAmp(const unsigned int prodAmpIndexA,
 		                                            const unsigned int prodAmpIndexB) const;
 
@@ -488,23 +486,6 @@ namespace rpwa {
 			out << "        prod. amp [" << std::setw(3) << i->first << "] "
 			    << "-> norm. int. [" << std::setw(3) << i->second << "]" << std::endl;
 		return out;
-	}
-
-
-	/// \brief returns matrix representation of complex number
-	///
-	///   c.re  -c.im
-	///   c.im   c.re
-	// !!! possible optimization: return TMatrixTLazy
-	inline
-	TMatrixT<double>
-	fitResult::matrixRepr(const std::complex<double>& c)
-	{
-		TMatrixT<double> m(2, 2);
-		m[0][0] = m[1][1] = c.real();
-		m[0][1] = -c.imag();
-		m[1][0] =  c.imag();
-		return m;
 	}
 
 

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -56,6 +56,7 @@
 
 #include "complexMatrix.h"
 #include "conversionUtils.hpp"
+#include "partialWaveFitHelper.h"
 #include "reportingUtils.hpp"
 #include "reportingUtilsRoot.hpp"
 
@@ -541,20 +542,26 @@ namespace rpwa {
 	                                     const unsigned int waveIndexB) const
 	{
 		std::vector<std::pair<unsigned int, unsigned int> > prodAmpIndexPairs;
+		// return empty vector if the two waves have different reflectivities
+		if (rpwa::partialWaveFitHelper::getReflectivity(waveName(waveIndexA))
+		    != rpwa::partialWaveFitHelper::getReflectivity(waveName(waveIndexB))) {
+			return prodAmpIndexPairs;
+		}
+
 		const std::vector<unsigned int> prodAmpIndicesA = prodAmpIndicesForWave(waveIndexA);
 		const std::vector<unsigned int> prodAmpIndicesB = prodAmpIndicesForWave(waveIndexB);
 		for (unsigned int countAmpA = 0; countAmpA < prodAmpIndicesA.size(); ++countAmpA) {
 			const unsigned int ampIndexA = prodAmpIndicesA[countAmpA];
 			const int          ampRankA  = rankOfProdAmp(ampIndexA);
 			// find production amplitude of wave B with same rank
-			int ampIndexB = -1;
-			for (unsigned int countAmpB = 0; countAmpB < prodAmpIndicesB.size(); ++countAmpB)
-				if (rankOfProdAmp(prodAmpIndicesB[countAmpB]) == ampRankA) {
-					ampIndexB = prodAmpIndicesB[countAmpB];
+			for (unsigned int countAmpB = 0; countAmpB < prodAmpIndicesB.size(); ++countAmpB) {
+				const unsigned int ampIndexB = prodAmpIndicesB[countAmpB];
+				const int          ampRankB  = rankOfProdAmp(ampIndexB);
+				if (ampRankA == ampRankB) {
+					prodAmpIndexPairs.push_back(std::make_pair(ampIndexA, ampIndexB));
 					break;
 				}
-			if (ampIndexB >=0)
-				prodAmpIndexPairs.push_back(std::make_pair(ampIndexA, (unsigned int)ampIndexB));
+			}
 		}
 		return prodAmpIndexPairs;
 	}

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -350,9 +350,9 @@ namespace rpwa {
 		TMatrixT<double> cov(2, 2);
 		if(not covMatrixValid()) {
 			printWarn << "no valid covariance matrix to return, return 0-matrix." << std::endl;
-			cov = 0.;
 			return cov;
 		}
+
 		// get parameter indices
 		const int i = _fitParCovMatrixIndices[prodAmpIndex].first;
 		const int j = _fitParCovMatrixIndices[prodAmpIndex].second;
@@ -548,8 +548,10 @@ namespace rpwa {
 	                           const unsigned int      waveIndexB,
 	                           const TMatrixT<double>& jacobian) const  // Jacobian of real valued function (d f/ d Re[rho]   d f / d Im[rho])
 	{
-		if (!covMatrixValid())
+		if (!covMatrixValid()) {
+			printWarn << "fitResult does not have a valid error matrix. Returning zero error for real-valued function." << std::endl;
 			return 0;
+		}
 
 		const TMatrixT<double> spinDensCov = spinDensityMatrixElemCov(waveIndexA, waveIndexB);  // 2 x 2 matrix
 		const TMatrixT<double> jacobianT(TMatrixT<double>::kTransposed, jacobian);              // 2 x 1 matrix

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -155,11 +155,7 @@ namespace rpwa {
 		int waveIndex   (const std::string& waveName   ) const;  ///< returns wave index corresponding to wave name
 		int prodAmpIndex(const std::string& prodAmpName) const;  ///< returns production amplitude index corresponding to production amplitude name
 
-		double fitParameter   (const std::string& parName  ) const;  ///< returns value of fit parameter with name
-		double fitParameterErr(const std::string& parName  ) const;  ///< returns error of fit parameter with name
-		/// returns covariance of fit parameters at index A and B
-		double fitParameterCov(const unsigned int parIndexA,
-		                       const unsigned int parIndexB) const { return _fitParCovMatrix[parIndexA][parIndexB]; }
+		double fitParameter(const std::string& parName) const;  ///< returns value of fit parameter with name
 
 		/// returns production amplitude value at index
 		std::complex<double>    prodAmp   (const unsigned int prodAmpIndex) const { return std::complex<double>(_prodAmps[prodAmpIndex].Re(), _prodAmps[prodAmpIndex].Im()); }

--- a/partialWaveFit/partialWaveFitHelper.cc
+++ b/partialWaveFit/partialWaveFitHelper.cc
@@ -26,32 +26,11 @@
 //-------------------------------------------------------------------------
 
 
+#include <iostream>
+#include <string>
+
 #include "partialWaveFitHelper.h"
-
-#include "fitResult.h"
-
-void
-rpwa::partialWaveFitHelper::extractWaveList(const rpwa::fitResult& result,
-                                            std::ostream& waveList)
-{
-	for(unsigned int i = 0; i < result.nmbWaves(); ++i) {
-		const std::string waveName(result.waveName(i));
-		if(waveName != "flat") {
-			waveList << waveName;
-
-			// test whether this wave is thresholded
-			bool thresholded = true;
-			for (unsigned int prodAmpIndex = 0; prodAmpIndex < result.nmbProdAmps(); ++prodAmpIndex)
-				if (result.waveNameForProdAmp(prodAmpIndex) == waveName)
-					thresholded &= (result.prodAmp(prodAmpIndex) == 0.);
-			// set the threshold to something higher than the current mass bin
-			if (thresholded)
-				waveList << " " << 1.1 * result.massBinCenter();
-
-			waveList << std::endl;
-		}
-	}
-}
+#include "reportingUtils.hpp"
 
 
 int

--- a/partialWaveFit/partialWaveFitHelper.h
+++ b/partialWaveFit/partialWaveFitHelper.h
@@ -30,24 +30,11 @@
 #define PARTIALWAVEFITHELPER_HH
 
 
-#include <iostream>
-
-
-template<typename T> class TMatrixT;
-template<typename T> class TVectorT;
-
-
 namespace rpwa {
-
-
-	class fitResult;
-	template<typename T> class pwaLikelihood;
 
 
 	namespace partialWaveFitHelper {
 
-
-		void extractWaveList(const rpwa::fitResult& fitResult, std::ostream& waveList);
 
 		int getReflectivity(const std::string& name);
 

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -1502,10 +1502,13 @@ template<typename complexT>
 void
 pwaLikelihood<complexT>::getIntegralMatrices(complexMatrix&  normMatrix,
                                              complexMatrix&  accMatrix,
-                                             vector<double>& phaseSpaceIntegral) const
+                                             vector<double>& phaseSpaceIntegral,
+                                             const bool      withFlat) const
 {
-	phaseSpaceIntegral.clear();
-	phaseSpaceIntegral.resize(_nmbWaves + 1, 0);
+	const unsigned int size = _nmbWaves + (withFlat ? 1 : 0);
+	normMatrix.resizeTo(size, size);
+	accMatrix.resizeTo(size, size);
+	phaseSpaceIntegral.resize(size, 0);
 	unsigned int iIndex = 0;
 	for (unsigned int iRefl = 0; iRefl < 2; ++iRefl) {
 		for (unsigned int iWave = 0; iWave < _nmbWavesRefl[iRefl]; ++iWave) {
@@ -1523,17 +1526,19 @@ pwaLikelihood<complexT>::getIntegralMatrices(complexMatrix&  normMatrix,
 			++iIndex;
 		}
 	}
-	// set unused entries to 0
-	for (unsigned int i = 0; i < normMatrix.nCols(); ++i) {
-		normMatrix.set(_nmbWaves, i, 0);
-		normMatrix.set(i, _nmbWaves, 0);
-		accMatrix.set (_nmbWaves, i, 0);
-		accMatrix.set (i, _nmbWaves, 0);
+	if (withFlat) {
+		// set unused entries to 0
+		for (unsigned int i = 0; i < normMatrix.nCols(); ++i) {
+			normMatrix.set(_nmbWaves, i, 0);
+			normMatrix.set(i, _nmbWaves, 0);
+			accMatrix.set (_nmbWaves, i, 0);
+			accMatrix.set (i, _nmbWaves, 0);
+		}
+		// add flat
+		normMatrix.set(_nmbWaves, _nmbWaves, 1.);
+		accMatrix.set (_nmbWaves, _nmbWaves, _totAcc);
+		phaseSpaceIntegral[_nmbWaves] = 1.;
 	}
-	// add flat
-	normMatrix.set(_nmbWaves, _nmbWaves, 1.);
-	accMatrix.set (_nmbWaves, _nmbWaves, _totAcc);
-	phaseSpaceIntegral[_nmbWaves] = 1.;
 }
 
 

--- a/partialWaveFit/pwaLikelihood.cc
+++ b/partialWaveFit/pwaLikelihood.cc
@@ -35,22 +35,22 @@
 
 #include "pwaLikelihood.h"
 
-#include <iomanip>
-#include <fstream>
-#include <complex>
 #include <cassert>
+#include <complex>
+#include <fstream>
+#include <iomanip>
 #include <limits>
 
+#include "TStopwatch.h"
 #include "TString.h"
 #include "TSystem.h"
-#include "TStopwatch.h"
 #include "TTree.h"
 
 #include "amplitudeMetadata.h"
-#include "eventMetadata.h"
 #include "amplitudeTreeLeaf.h"
 #include "complexMatrix.h"
 #include "conversionUtils.hpp"
+#include "eventMetadata.h"
 #include "fileUtils.hpp"
 #include "reportingUtils.hpp"
 #ifdef USE_CUDA

--- a/partialWaveFit/pwaLikelihood.h
+++ b/partialWaveFit/pwaLikelihood.h
@@ -189,7 +189,8 @@ namespace rpwa {
 
 		void getIntegralMatrices(rpwa::complexMatrix&       normMatrix,
 		                         rpwa::complexMatrix&       accMatrix,
-		                         std::vector<double>&       phaseSpaceIntegral) const;
+		                         std::vector<double>&       phaseSpaceIntegral,
+		                         const bool                 withFlat = false) const;
 
 		// note: amplitudes which do not exist in higher ranks are NOT built!
 		void buildProdAmpArrays(const double*                       inPar,

--- a/partialWaveFit/pwaLikelihood.h
+++ b/partialWaveFit/pwaLikelihood.h
@@ -109,6 +109,43 @@ namespace rpwa {
 			HALF_CAUCHY
 		};
 
+		// class to store fit parameter information
+		class fitParameter {
+
+		public:
+
+			fitParameter()
+				: _waveName(""), _rank(0), _threshold(0.), _fixed(true), _realPart(true) {}
+			fitParameter(const std::string& waveName,
+			             const unsigned int rank,
+			             const double       threshold,
+			             const bool         fixed,
+			             const bool         realPart)
+				: _waveName(waveName), _rank(rank), _threshold(threshold), _fixed(fixed), _realPart(realPart) {}
+
+			bool operator==(const fitParameter& rhs) const {
+				return (_waveName == rhs.waveName() and _rank == rhs.rank() and _threshold == rhs.threshold()
+				        and _fixed == rhs.fixed() and _realPart == rhs.realPart());
+			}
+
+			const std::string& waveName () const { return _waveName;  }
+			unsigned int       rank     () const { return _rank;      }
+			double             threshold() const { return _threshold; }
+			bool               fixed    () const { return _fixed;     }
+			bool               realPart () const { return _realPart;  }
+
+			std::string        parName  () const;
+
+                private:
+
+			std::string  _waveName;
+			unsigned int _rank;
+			double       _threshold;
+			bool         _fixed;
+			bool         _realPart;
+
+		};
+
 		pwaLikelihood();
 		~pwaLikelihood();
 
@@ -143,14 +180,13 @@ namespace rpwa {
 		/// flips the signs of the paramaters according to conventions (amplitudes of each anchor wave and the flat wave are real and positive)
 		std::vector<double> CorrectParamSigns(const double* par) const;
 
-		unsigned int             nmbEvents   ()                                    const { return _nmbEvents;               }  ///< returns number of events that enter in the likelihood
-		unsigned int             rank        ()                                    const { return _rank;                    }  ///< returns rank of spin density matrix
-		unsigned int             nmbWaves    (const int          reflectivity = 0) const;                                      ///< returns total number of waves (reflectivity == 0) or number or number of waves with positive/negative reflectivity; flat wave is not counted!
-		unsigned int             nmbPars     ()                                    const { return _nmbPars;                 }  ///< returns total number of parameters
-		unsigned int             nmbParsFixed()                                    const { return _nmbParsFixed;            }  ///< returns number of fixed parameters
-		const std::string&       parName     (const unsigned int parIndex)         const { return _parNames[parIndex];      }  ///< returns name of likelihood parameter at parIndex
-		double                   parThreshold(const unsigned int parIndex)         const { return _parThresholds[parIndex]; }  ///< returns threshold in GeV/c^2 above which likelihood parameter at parIndex becomes free
-		bool                     parFixed    (const unsigned int parIndex)         const { return _parFixed[parIndex];      }  ///< returns whether likelihood parameter at parIndex is fixed due to mass threshold
+		unsigned int                     nmbEvents   ()                                    const { return _nmbEvents;               }  ///< returns number of events that enter in the likelihood
+		unsigned int                     rank        ()                                    const { return _rank;                    }  ///< returns rank of spin density matrix
+		unsigned int                     nmbWaves    (const int          reflectivity = 0) const;                                      ///< returns total number of waves (reflectivity == 0) or number or number of waves with positive/negative reflectivity; flat wave is not counted!
+		unsigned int                     nmbPars     ()                                    const { return _nmbPars;                 }  ///< returns total number of parameters
+		unsigned int                     nmbParsFixed()                                    const { return _nmbParsFixed;            }  ///< returns number of fixed parameters
+		const fitParameter&              parameter   (const unsigned int parIndex)         const { return _parameters[parIndex];    }  ///< returns information about likelihood parameter at parIndex
+		const std::vector<fitParameter>& parameters  ()                                    const { return _parameters;              }  ///< returns information about likelihood parameters
 
 		double dLcache(const unsigned int i) const { return _derivCache[i]; }
 		unsigned int ncalls(const functionCallEnum func = FDF) const
@@ -253,15 +289,13 @@ namespace rpwa {
 		unsigned int _numbAccEvents; // number of input events used for acceptance integrals (accepted + rejected!)
 		double       _totAcc;        // total acceptance in this bin
 
-		waveNameArrayType        _waveNames;            // wave names [reflectivity][wave index]
-		waveThrArrayType         _waveThresholds;       // mass thresholds of waves
-		waveAmpAddedArrayType    _waveAmpAdded;         // amplitude read for waves
-		std::vector<std::string> _parNames;             // function parameter names
-		std::vector<double>      _parThresholds;        // mass thresholds of parameters
-		std::vector<bool>        _parFixed;             // parameter fixed due to mass thresholds
-		waveParamsType           _waveParams;           // map wave name to reflectivity and index in
-		                                                // reflectivity
-		ampToParMapType          _prodAmpToFuncParMap;  // maps each production amplitude to the indices
+		waveNameArrayType         _waveNames;            // wave names [reflectivity][wave index]
+		waveThrArrayType          _waveThresholds;       // mass thresholds of waves
+		waveAmpAddedArrayType     _waveAmpAdded;         // amplitude read for waves
+		std::vector<fitParameter> _parameters;           // information about function parameters
+		waveParamsType            _waveParams;           // map wave name to reflectivity and index in
+		                                                 // reflectivity
+		ampToParMapType           _prodAmpToFuncParMap;  // maps each production amplitude to the indices
 		                                                // of its real and imginary part in the parameter
 		                                                // array; negative indices mean that the parameter
 		                                                // is not existing due to rank restrictions

--- a/partialWaveFit/pwaLikelihood.h
+++ b/partialWaveFit/pwaLikelihood.h
@@ -35,10 +35,10 @@
 #define PWALIKELIHOOD_H
 
 
-#include <vector>
-#include <string>
 #include <iostream>
 #include <map>
+#include <string>
+#include <vector>
 
 #define BOOST_DISABLE_ASSERTS
 #include "boost/multi_array.hpp"
@@ -48,8 +48,8 @@
 #include "TMatrixT.h"
 #include "TVectorT.h"
 
-#include "sumAccumulators.hpp"
 #include "ampIntegralMatrix.h"
+#include "sumAccumulators.hpp"
 
 
 class TString;
@@ -148,7 +148,7 @@ namespace rpwa {
 		unsigned int             nmbWaves    (const int          reflectivity = 0) const;                                      ///< returns total number of waves (reflectivity == 0) or number or number of waves with positive/negative reflectivity; flat wave is not counted!
 		unsigned int             nmbPars     ()                                    const { return _nmbPars;                 }  ///< returns total number of parameters
 		unsigned int             nmbParsFixed()                                    const { return _nmbParsFixed;            }  ///< returns number of fixed parameters
-		std::string              parName     (const unsigned int parIndex)         const { return _parNames[parIndex];      }  ///< returns name of likelihood parameter at parIndex
+		const std::string&       parName     (const unsigned int parIndex)         const { return _parNames[parIndex];      }  ///< returns name of likelihood parameter at parIndex
 		double                   parThreshold(const unsigned int parIndex)         const { return _parThresholds[parIndex]; }  ///< returns threshold in GeV/c^2 above which likelihood parameter at parIndex becomes free
 		bool                     parFixed    (const unsigned int parIndex)         const { return _parFixed[parIndex];      }  ///< returns whether likelihood parameter at parIndex is fixed due to mass threshold
 
@@ -168,7 +168,7 @@ namespace rpwa {
 		void          setPriorType     (const priorEnum priorType  = FLAT) { _priorType         = priorType; }
 		priorEnum     priorType        () const                            { return _priorType;              }
 		void          setCauchyWidth   (const double    cauchyWidth)       { _cauchyWidth = cauchyWidth;     }
-		const double& cauchyWidth      () const                            { return _cauchyWidth;            }
+		double        cauchyWidth      () const                            { return _cauchyWidth;            }
 		static void   setQuiet         (const bool      flag       = true) { _debug             = !flag;     }
 
 		// operations

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -341,8 +341,6 @@ void rpwa::py::exportFitResult() {
 		.def("waveIndex", &rpwa::fitResult::waveIndex)
 		.def("prodAmpIndex", &rpwa::fitResult::prodAmpIndex)
 		.def("fitParameter", &rpwa::fitResult::fitParameter)
-		.def("fitParameterErr", &rpwa::fitResult::fitParameterErr)
-		.def("fitParameterCov", &rpwa::fitResult::fitParameterCov)
 		.def("prodAmp", &fitResult::prodAmp)
 		.def("prodAmpCov", &fitResult_prodAmpCov_2)
 		.def("prodAmpCov", &fitResult_prodAmpCov_1)

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -82,25 +82,6 @@ namespace {
 		return rpwa::py::convertToPy<TMatrixT<double> >(self.prodAmpCov(prodAmpIndices));
 	}
 
-	PyObject* fitResult_prodAmpCov_3(const rpwa::fitResult& self, const bp::object& pyProdAmpIndexPairs)
-	{
-		bp::list pyListProdAmpIndexPairs = bp::extract<bp::list>(pyProdAmpIndexPairs);
-		std::vector<std::pair<unsigned int, unsigned int> > prodAmpIndexPairs(bp::len(pyListProdAmpIndexPairs));
-		for(int i = 0; i < bp::len(pyListProdAmpIndexPairs); ++i) {
-			bp::tuple tuple = bp::extract<bp::tuple>(pyListProdAmpIndexPairs[i]);
-			prodAmpIndexPairs[i].first  = bp::extract<unsigned int>(tuple[0]);
-			prodAmpIndexPairs[i].second = bp::extract<unsigned int>(tuple[1]);
-		}
-		return rpwa::py::convertToPy<TMatrixT<double> >(self.prodAmpCov(prodAmpIndexPairs));
-	}
-
-	PyObject* fitResult_prodAmpCov_4(const rpwa::fitResult& self,
-	                                 const std::vector<unsigned int>& prodAmpIndicesA,
-	                                 const std::vector<unsigned int>& prodAmpIndicesB)
-	{
-		return rpwa::py::convertToPy<TMatrixT<double> >(self.prodAmpCov(prodAmpIndicesA, prodAmpIndicesB));
-	}
-
 	double fitResult_phaseSpaceIntegral_1(const rpwa::fitResult& self, const unsigned int waveIndex)
 	{
 		return self.phaseSpaceIntegral(waveIndex);
@@ -111,35 +92,18 @@ namespace {
 		return self.phaseSpaceIntegral(waveName);
 	}
 
-	PyObject* fitResult_spinDensityMatrixElemCov(const rpwa::fitResult& self,
-	                                             const unsigned int waveIndexA,
-	                                             const unsigned int waveIndexB)
+	std::complex<double> fitResult_spinDensityMatrixElem_1(const rpwa::fitResult& self,
+	                                                       const unsigned int waveIndexA,
+	                                                       const unsigned int waveIndexB)
+	{
+		return self.spinDensityMatrixElem(waveIndexA, waveIndexB);
+	}
+
+	PyObject* fitResult_spinDensityMatrixElemCov_1(const rpwa::fitResult& self,
+	                                               const unsigned int waveIndexA,
+	                                               const unsigned int waveIndexB)
 	{
 		return rpwa::py::convertToPy<TMatrixT<double> >(self.spinDensityMatrixElemCov(waveIndexA, waveIndexB));
-	}
-
-	double fitResult_intensity_1(const rpwa::fitResult& self, const unsigned int waveIndex) {
-		return self.intensity(waveIndex);
-	}
-
-	double fitResult_intensityErr_1(const rpwa::fitResult& self, const unsigned int waveIndex) {
-			return self.intensityErr(waveIndex);
-	}
-
-	double fitResult_intensity_2(const rpwa::fitResult& self, const char* waveNamePattern) {
-		return self.intensity(waveNamePattern);
-	}
-
-	double fitResult_intensityErr_2(const rpwa::fitResult& self, const char* waveNamePattern) {
-			return self.intensityErr(waveNamePattern);
-	}
-
-	double fitResult_intensity_3(const rpwa::fitResult& self) {
-		return self.intensity();
-	}
-
-	double fitResult_intensityErr_3(const rpwa::fitResult& self) {
-			return self.intensityErr();
 	}
 
 	double fitResult_phase_1(const rpwa::fitResult& self,
@@ -156,6 +120,48 @@ namespace {
 		return self.phaseErr(waveIndexA, waveIndexB);
 	}
 
+	double fitResult_coherence_1(const rpwa::fitResult& self,
+	                             const unsigned int waveIndexA,
+	                             const unsigned int waveIndexB)
+	{
+		return self.coherence(waveIndexA, waveIndexB);
+	}
+
+	double fitResult_coherenceErr_1(const rpwa::fitResult& self,
+	                                const unsigned int waveIndexA,
+	                                const unsigned int waveIndexB)
+	{
+		return self.coherenceErr(waveIndexA, waveIndexB);
+	}
+
+	double fitResult_overlap_1(const rpwa::fitResult& self,
+	                           const unsigned int waveIndexA,
+	                           const unsigned int waveIndexB)
+	{
+		return self.overlap(waveIndexA, waveIndexB);
+	}
+
+	double fitResult_overlapErr_1(const rpwa::fitResult& self,
+	                              const unsigned int waveIndexA,
+	                              const unsigned int waveIndexB)
+	{
+		return self.overlapErr(waveIndexA, waveIndexB);
+	}
+
+	std::complex<double> fitResult_spinDensityMatrixElem_2(const rpwa::fitResult& self,
+	                                                       const std::string& waveNameA,
+	                                                       const std::string& waveNameB)
+	{
+		return self.spinDensityMatrixElem(waveNameA, waveNameB);
+	}
+
+	PyObject* fitResult_spinDensityMatrixElemCov_2(const rpwa::fitResult& self,
+	                                               const std::string& waveNameA,
+	                                               const std::string& waveNameB)
+	{
+		return rpwa::py::convertToPy<TMatrixT<double> >(self.spinDensityMatrixElemCov(waveNameA, waveNameB));
+	}
+
 	double fitResult_phase_2(const rpwa::fitResult& self,
 	                         const std::string waveNameA,
 	                         const std::string waveNameB)
@@ -168,6 +174,58 @@ namespace {
 	                            const std::string waveNameB)
 	{
 		return self.phaseErr(waveNameA, waveNameB);
+	}
+
+	double fitResult_coherence_2(const rpwa::fitResult& self,
+	                             const std::string waveNameA,
+	                             const std::string waveNameB)
+	{
+		return self.coherence(waveNameA, waveNameB);
+	}
+
+	double fitResult_coherenceErr_2(const rpwa::fitResult& self,
+	                                const std::string waveNameA,
+	                                const std::string waveNameB)
+	{
+		return self.coherenceErr(waveNameA, waveNameB);
+	}
+
+	double fitResult_overlap_2(const rpwa::fitResult& self,
+	                           const std::string waveNameA,
+	                           const std::string waveNameB)
+	{
+		return self.overlap(waveNameA, waveNameB);
+	}
+
+	double fitResult_overlapErr_2(const rpwa::fitResult& self,
+	                              const std::string waveNameA,
+	                              const std::string waveNameB)
+	{
+		return self.overlapErr(waveNameA, waveNameB);
+	}
+
+	double fitResult_intensity_1(const rpwa::fitResult& self, const unsigned int waveIndex) {
+		return self.intensity(waveIndex);
+	}
+
+	double fitResult_intensityErr_1(const rpwa::fitResult& self, const unsigned int waveIndex) {
+		return self.intensityErr(waveIndex);
+	}
+
+	double fitResult_intensity_2(const rpwa::fitResult& self, const char* waveNamePattern) {
+		return self.intensity(waveNamePattern);
+	}
+
+	double fitResult_intensityErr_2(const rpwa::fitResult& self, const char* waveNamePattern) {
+		return self.intensityErr(waveNamePattern);
+	}
+
+	double fitResult_intensity_3(const rpwa::fitResult& self) {
+		return self.intensity();
+	}
+
+	double fitResult_intensityErr_3(const rpwa::fitResult& self) {
+		return self.intensityErr();
 	}
 
 	bp::list fitResult_prodAmps(const rpwa::fitResult& self)
@@ -275,52 +333,70 @@ void rpwa::py::exportFitResult() {
 		.def("reset", &rpwa::fitResult::reset)
 		.def("fill", &fitResult_fill_1)
 		.def("fill", &fitResult_fill_2)
+		.def("nmbEvents", &rpwa::fitResult::nmbEvents)
+		.def("normNmbEvents", &rpwa::fitResult::normNmbEvents)
 		.def("massBinCenter", &rpwa::fitResult::massBinCenter)
 		.def("logLikelihood", &rpwa::fitResult::logLikelihood)
 		.def("evidence", &rpwa::fitResult::evidence)
 		.def("evidenceComponents", &fitResult_evidenceComponents)
+		.def("rank", &rpwa::fitResult::rank)
+		.def("covMatrixValid", &rpwa::fitResult::covMatrixValid)
 		.def("converged", &rpwa::fitResult::converged)
 		.def("hasHessian", &rpwa::fitResult::hasHessian)
-		.def("rank", &rpwa::fitResult::rank)
-		.def("nmbEvents", &rpwa::fitResult::nmbEvents)
-		.def("normNmbEvents", &rpwa::fitResult::normNmbEvents)
 		.def("nmbWaves", &rpwa::fitResult::nmbWaves)
 		.def("nmbProdAmps", &rpwa::fitResult::nmbProdAmps)
-		.def("waveName", &rpwa::fitResult::waveName)
+		.def(
+			"waveName"
+			, &rpwa::fitResult::waveName
+			, bp::return_value_policy<bp::copy_const_reference>()
+		)
 		.def("waveNameEsc", &rpwa::fitResult::waveNameEsc)
-		.def("prodAmpName", &rpwa::fitResult::prodAmpName)
+		.def(
+			"prodAmpName"
+			, &rpwa::fitResult::prodAmpName
+			, bp::return_value_policy<bp::copy_const_reference>()
+		)
 		.def("prodAmpNameEsc", &rpwa::fitResult::prodAmpNameEsc)
 		.def("waveNameForProdAmp", &rpwa::fitResult::waveNameForProdAmp)
+		.def("rankOfProdAmp", &rpwa::fitResult::rankOfProdAmp)
 		.def("waveIndex", &rpwa::fitResult::waveIndex)
 		.def("prodAmpIndex", &rpwa::fitResult::prodAmpIndex)
 		.def("fitParameter", &rpwa::fitResult::fitParameter)
+		.def("fitParameterErr", &rpwa::fitResult::fitParameterErr)
 		.def("fitParameterCov", &rpwa::fitResult::fitParameterCov)
 		.def("prodAmp", &fitResult::prodAmp)
-		.def("prodAmpCov", &fitResult_prodAmpCov_3)
-		.def("prodAmpCov", &fitResult_prodAmpCov_4)
 		.def("prodAmpCov", &fitResult_prodAmpCov_2)
 		.def("prodAmpCov", &fitResult_prodAmpCov_1)
-		.def("covMatrixValid", &rpwa::fitResult::covMatrixValid)
 		.def("normIntegral", &rpwa::fitResult::normIntegral)
 		.def("acceptedNormIntegral", &rpwa::fitResult::acceptedNormIntegral)
 		.def("phaseSpaceIntegral", &fitResult_phaseSpaceIntegral_1)
 		.def("phaseSpaceIntegral", &fitResult_phaseSpaceIntegral_2)
-		.def("spinDensityMatrixElem", &rpwa::fitResult::spinDensityMatrixElem)
-		.def("spinDensityMatrixElemCov", &fitResult_spinDensityMatrixElemCov)
+
+		.def("spinDensityMatrixElem", &fitResult_spinDensityMatrixElem_1)
+		.def("spinDensityMatrixElemCov", &fitResult_spinDensityMatrixElemCov_1)
+		.def("phase", &fitResult_phase_1)
+		.def("phaseErr", &fitResult_phaseErr_1)
+		.def("coherence", &fitResult_coherence_1)
+		.def("coherenceErr", &fitResult_coherenceErr_1)
+		.def("overlap", &fitResult_overlap_1)
+		.def("overlapErr", &fitResult_overlapErr_1)
+
+		.def("spinDensityMatrixElem", &fitResult_spinDensityMatrixElem_2)
+		.def("spinDensityMatrixElemCov", &fitResult_spinDensityMatrixElemCov_2)
+		.def("phase", &fitResult_phase_2)
+		.def("phaseErr", &fitResult_phaseErr_2)
+		.def("coherence", &fitResult_coherence_2)
+		.def("coherenceErr", &fitResult_coherenceErr_2)
+		.def("overlap", &fitResult_overlap_2)
+		.def("overlapErr", &fitResult_overlapErr_2)
+
 		.def("intensity", &fitResult_intensity_1)
 		.def("intensityErr", &fitResult_intensityErr_1)
 		.def("intensity", &fitResult_intensity_2)
 		.def("intensityErr", &fitResult_intensityErr_2)
 		.def("intensity", &fitResult_intensity_3)
 		.def("intensityErr", &fitResult_intensityErr_3)
-		.def("phase", &fitResult_phase_1)
-		.def("phaseErr", &fitResult_phaseErr_1)
-		.def("phase", &fitResult_phase_2)
-		.def("phaseErr", &fitResult_phaseErr_2)
-		.def("coherence", &rpwa::fitResult::coherence)
-		.def("coherenceErr", &rpwa::fitResult::coherenceErr)
-		.def("overlap", &rpwa::fitResult::overlap)
-		.def("overlapErr", &rpwa::fitResult::overlapErr)
+
 		.def("prodAmps", &fitResult_prodAmps)
 		.def("prodAmpNames", &fitResult_prodAmpNames)
 		.def("waveNames", &fitResult_waveNames)

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -280,20 +280,6 @@ namespace {
 		return retval;
 	}
 
-	std::string fitResult_printProdAmpNames(const rpwa::fitResult self)
-	{
-		std::stringstream sstr;
-		self.printProdAmpNames(sstr);
-		return sstr.str();
-	}
-
-	std::string fitResult_printWaveNames(const rpwa::fitResult self)
-	{
-		std::stringstream sstr;
-		self.printWaveNames(sstr);
-		return sstr.str();
-	}
-
 	std::string fitResult_printProdAmps(const rpwa::fitResult self)
 	{
 		std::stringstream sstr;
@@ -407,8 +393,6 @@ void rpwa::py::exportFitResult() {
 		)
 		.def("phaseSpaceIntegralVector", &fitResult_phaseSpaceIntegralVector)
 		.def("normIntIndexMap", &fitResult_normIntIndexMap)
-		.def("printProdAmpNames", &fitResult_printProdAmpNames)
-		.def("printWaveNames", &fitResult_printWaveNames)
 		.def("printProdAmps", &fitResult_printProdAmps)
 		.def("printWaves", &fitResult_printWaves)
 

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -308,13 +308,6 @@ namespace {
 		return sstr.str();
 	}
 
-	std::string fitResult_printAmpsGenPW(const rpwa::fitResult self)
-	{
-		std::stringstream sstr;
-		self.printAmpsGenPW(sstr);
-		return sstr.str();
-	}
-
 	int fitResult_Write(const rpwa::fitResult& self, const char* name = 0)
 	{
 		return self.Write(name);
@@ -418,7 +411,6 @@ void rpwa::py::exportFitResult() {
 		.def("printWaveNames", &fitResult_printWaveNames)
 		.def("printProdAmps", &fitResult_printProdAmps)
 		.def("printWaves", &fitResult_printWaves)
-		.def("printAmpsGenPW", &fitResult_printAmpsGenPW)
 
 		.def("Write", &fitResult_Write, bp::arg("name")=0)
 		.def("setBranchAddress", &rpwa::py::setBranchAddress<rpwa::fitResult*>)

--- a/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
+++ b/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
@@ -279,12 +279,15 @@ void rpwa::py::exportPwaLikelihood() {
 		.def("nmbPars", &rpwa::pwaLikelihood<std::complex<double> >::nmbPars)
 		.def("nmbParsFixed", &rpwa::pwaLikelihood<std::complex<double> >::nmbParsFixed)
 		.def(
-			"parName"
-			, &rpwa::pwaLikelihood<std::complex<double> >::parName
-			, bp::return_value_policy<bp::copy_const_reference>()
+			"parameter"
+			, &rpwa::pwaLikelihood<std::complex<double> >::parameter
+			, bp::return_internal_reference<>()
 		)
-		.def("parThreshold", &rpwa::pwaLikelihood<std::complex<double> >::parThreshold)
-		.def("parFixed", &rpwa::pwaLikelihood<std::complex<double> >::parFixed)
+		.def(
+			"parameters"
+			, &rpwa::pwaLikelihood<std::complex<double> >::parameters
+			, bp::return_internal_reference<>()
+		)
 		.def("useNormalizedAmps", &rpwa::pwaLikelihood<std::complex<double> >::useNormalizedAmps)
 		.def("setPriorType", &rpwa::pwaLikelihood<std::complex<double> >::setPriorType)
 		.def("priorType", &rpwa::pwaLikelihood<std::complex<double> >::priorType)
@@ -297,6 +300,20 @@ void rpwa::py::exportPwaLikelihood() {
 		)
 		.staticmethod("setQuiet")
 		.def(bp::self_ns::str(bp::self))
+		;
+
+
+	bp::class_<rpwa::pwaLikelihood<std::complex<double> >::fitParameter>("fitParameter", bp::no_init)
+		.def(
+			"waveName"
+			, &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::waveName
+			, bp::return_value_policy<bp::copy_const_reference>()
+		)
+		.def("rank", &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::rank)
+		.def("threshold", &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::threshold)
+		.def("fixed", &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::fixed)
+		.def("realPart", &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::realPart)
+		.def("parName", &rpwa::pwaLikelihood<std::complex<double> >::fitParameter::parName)
 		;
 
 

--- a/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
+++ b/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
@@ -235,7 +235,7 @@ namespace {
 
 void rpwa::py::exportPwaLikelihood() {
 
-	bp::class_<rpwa::pwaLikelihood<std::complex<double> > >("pwaLikelihood")
+	bp::scope theScope = bp::class_<rpwa::pwaLikelihood<std::complex<double> > >("pwaLikelihood")
 		.def(
 			"init"
 			, ::pwaLikelihood_init

--- a/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
+++ b/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
@@ -278,18 +278,18 @@ void rpwa::py::exportPwaLikelihood() {
 		)
 		.def("nmbPars", &rpwa::pwaLikelihood<std::complex<double> >::nmbPars)
 		.def("nmbParsFixed", &rpwa::pwaLikelihood<std::complex<double> >::nmbParsFixed)
-		.def("parName", &rpwa::pwaLikelihood<std::complex<double> >::parName)
+		.def(
+			"parName"
+			, &rpwa::pwaLikelihood<std::complex<double> >::parName
+			, bp::return_value_policy<bp::copy_const_reference>()
+		)
 		.def("parThreshold", &rpwa::pwaLikelihood<std::complex<double> >::parThreshold)
 		.def("parFixed", &rpwa::pwaLikelihood<std::complex<double> >::parFixed)
 		.def("useNormalizedAmps", &rpwa::pwaLikelihood<std::complex<double> >::useNormalizedAmps)
 		.def("setPriorType", &rpwa::pwaLikelihood<std::complex<double> >::setPriorType)
 		.def("priorType", &rpwa::pwaLikelihood<std::complex<double> >::priorType)
 		.def("setCauchyWidth", &rpwa::pwaLikelihood<std::complex<double> >::setCauchyWidth)
-		.def(
-			"cauchyWidth"
-			, &rpwa::pwaLikelihood<std::complex<double> >::cauchyWidth
-			, bp::return_value_policy<bp::copy_const_reference>()
-		)
+		.def("cauchyWidth", &rpwa::pwaLikelihood<std::complex<double> >::cauchyWidth)
 		.def(
 			"setQuiet"
 			, &rpwa::pwaLikelihood<std::complex<double> >::setQuiet

--- a/pyInterface/bindings/pyUtils/stlContainers_py.cc
+++ b/pyInterface/bindings/pyUtils/stlContainers_py.cc
@@ -8,6 +8,7 @@
 #include<isobarDecayVertex.h>
 #include<particle.h>
 #include<particleProperties.h>
+#include<pwaLikelihood.h>
 #include<waveDescription.h>
 
 namespace bp = boost::python;
@@ -63,5 +64,9 @@ void rpwa::py::exportStlContainers() {
 	// std::vector<rpwa::waveDescriptionPtr>
 	bp::class_<std::vector<rpwa::waveDescriptionPtr> >("__vector_waveDescription")
 		.def(bp::vector_indexing_suite<std::vector<rpwa::waveDescriptionPtr>, true>());
+
+	// std::vector<rpwa::pwaLikelihood<double>::fitParameter>
+	bp::class_<std::vector<rpwa::pwaLikelihood<std::complex<double> >::fitParameter> >("__vector_pwaLikelihood_fitParameter")
+		.def(bp::vector_indexing_suite<std::vector<rpwa::pwaLikelihood<std::complex<double> >::fitParameter>, true>());
 
 }

--- a/pyInterface/bindings/pyUtils/stlContainers_py.cc
+++ b/pyInterface/bindings/pyUtils/stlContainers_py.cc
@@ -4,10 +4,10 @@
 #include "boost/python/suite/indexing/map_indexing_suite.hpp"
 
 #include<amplitudeMetadata.h>
-#include<particle.h>
-#include<particleProperties.h>
 #include<interactionVertex.h>
 #include<isobarDecayVertex.h>
+#include<particle.h>
+#include<particleProperties.h>
 #include<waveDescription.h>
 
 namespace bp = boost::python;

--- a/pyInterface/module/_likelihood.py
+++ b/pyInterface/module/_likelihood.py
@@ -18,7 +18,7 @@ def initLikelihood(waveDescThres,
 	if not verbose:
 		likelihood.setQuiet()
 	if cauchy:
-		likelihood.setPriorType(pyRootPwa.core.HALF_CAUCHY)
+		likelihood.setPriorType(pyRootPwa.core.pwaLikelihood.HALF_CAUCHY)
 		likelihood.setCauchyWidth(cauchyWidth)
 	if (not likelihood.init(waveDescThres,
 	                        rank,

--- a/pyInterface/scripts/calcCovMatrixForFitResult.py
+++ b/pyInterface/scripts/calcCovMatrixForFitResult.py
@@ -92,9 +92,8 @@ if __name__ == "__main__":
 		sys.exit(1)
 
 	pars = []
-	for i in range(likelihood.nmbPars()):
-		parName = likelihood.parName(i)
-		pars.append(result.fitParameter(parName))
+	for parameter in likelihood.parameters():
+		pars.append(result.fitParameter(parameter.parName()))
 
 	# analytically calculate Hessian
 	hessian = likelihood.Hessian(pars)

--- a/pyInterface/scripts/eigenvectorLikelihoodSlices.py
+++ b/pyInterface/scripts/eigenvectorLikelihoodSlices.py
@@ -94,9 +94,8 @@ if __name__ == "__main__":
 		sys.exit(1)
 
 	minimum = ROOT.TVectorD(likelihood.nmbPars())
-	for i in range(likelihood.nmbPars()):
-		parName = likelihood.parName(i)
-		minimum[i] = result.fitParameter(parName)
+	for i, parameter in enumerate(likelihood.parameters()):
+		minimum[i] = result.fitParameter(parameter.parName())
 
 	minimumLikelihood = likelihood.DoEval( [ minimum[i] for i in xrange(minimum.GetNrows()) ] )
 	pyRootPwa.utils.printInfo("likelihood at minimum is {: .15e}.".format(minimumLikelihood))

--- a/pyInterface/scripts/likelihoodPointCalculator.py
+++ b/pyInterface/scripts/likelihoodPointCalculator.py
@@ -91,8 +91,7 @@ if __name__ == "__main__":
 		sys.exit(1)
 
 	pars = []
-	for i in range(likelihood.nmbPars()):
-		parName = likelihood.parName(i)
-		pars.append(result.fitParameter(parName))
+	for parameter in likelihood.parameters():
+		pars.append(result.fitParameter(parameter.parName()))
 
 	pyRootPwa.utils.printSucc("likelihood is {: .15e}.".format(likelihood.DoEval(pars)))


### PR DESCRIPTION
* no longer store the names of production amplitudes in the fit result, instead store a wave index and a rank for each production amplitude, unfortunately this broke `boost::python` as there were too many arguments to the `fitResult::fill` method, so now do not pass individual vectors, but tuples of vectors
* add a new `spinDensityMatrixTimesAmplitudeMatrix` method to calculate the weights for a subset of waves in one central place, and not have to implement this over and over again
* some cleaning of the code

For my test cases old fit results are still read correctly (after changes to the ROOT I/O rules).