### PR TITLE
pyInterface: fix pylint test

### DIFF
--- a/pyInterface/module/utils/_waveDescThresUtils.py
+++ b/pyInterface/module/utils/_waveDescThresUtils.py
@@ -1,5 +1,4 @@
 
-import pyRootPwa.core
 from _printingUtils import printInfo, printWarn
 
 def getWaveDescThresFromFitResult(fitResult, waveDescriptions):


### PR DESCRIPTION
Remove a no longer required import statement from the '_waveDescThresUtils.py' file.

Broken after merging #172.