### PR TITLE
Importance sampling

### DIFF
--- a/cmakeModules/FindBAT.cmake
+++ b/cmakeModules/FindBAT.cmake
@@ -11,6 +11,7 @@
 #//      BAT_ROOT_DIR       - BAT installation directory
 #//      BAT_INCLUDE_DIR    - BAT header directory
 #//      BAT_LIBRARIES      - BAT libraries
+#//      BAT_CXX_FLAGS      - extra compiler flags when using BAT
 #//      BAT_LINKER_FLAGS   - extra linker flags required to link against
 #//                           BAT
 #//
@@ -27,6 +28,7 @@ set(BAT_VERSION      )
 set(BAT_ROOT_DIR     "")
 set(BAT_INCLUDE_DIR  "")
 set(BAT_LIBRARIES    )
+set(BAT_CXX_FLAGS    "")
 set(BAT_LINKER_FLAGS "")
 
 
@@ -89,6 +91,16 @@ if(BAT_ROOT_DIR)
 			OUTPUT_VARIABLE BAT_VERSION
 			OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+		execute_process(COMMAND ${_BAT_CONFIG_EXECUTABLE} --cflags
+			OUTPUT_VARIABLE _BAT_CFLAGS
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		string(FIND ${_BAT_CFLAGS} "-fopenmp" _BAT_OPENMP)
+		if(NOT _BAT_OPENMP EQUAL -1)
+			set(BAT_CXX_FLAGS "${BAT_CXX_FLAGS} -fopenmp")
+		endif()
+		unset(_BAT_CFLAGS)
+		unset(_BAT_OPENMP)
+
 		execute_process(COMMAND ${_BAT_CONFIG_EXECUTABLE} --libs
 			OUTPUT_VARIABLE _BAT_LDFLAGS
 			OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -139,6 +151,7 @@ if(BAT_ROOT_DIR)
 				set(BAT_ERROR_REASON "${BAT_ERROR_REASON} Could not extract whether BAT was build with threading support from string '${_BAT_OPENMP}'.")
 			endif()
 			if(_BAT_OPENMP_STATUS)
+				set(BAT_CXX_FLAGS "${BAT_CXX_FLAGS} -fopenmp")
 				set(BAT_LINKER_FLAGS "${BAT_LINKER_FLAGS} -fopenmp")
 			endif()
 			unset(_BAT_OPENMP)
@@ -165,6 +178,7 @@ endif()
 
 
 # remove leading and trailing whitespaces
+string(STRIP "${BAT_CXX_FLAGS}" BAT_CXX_FLAGS)
 string(STRIP "${BAT_LINKER_FLAGS}" BAT_LINKER_FLAGS)
 
 
@@ -172,6 +186,7 @@ string(STRIP "${BAT_LINKER_FLAGS}" BAT_LINKER_FLAGS)
 mark_as_advanced(
 	BAT_INCLUDE_DIR
 	BAT_LIBRARIES
+	BAT_CXX_FLAGS
 	BAT_LINKER_FLAGS
 	)
 
@@ -181,6 +196,7 @@ if(BAT_FOUND)
 	message(STATUS "Found BAT version ${BAT_VERSION} in '${BAT_ROOT_DIR}'.")
 	message(STATUS "Using BAT include directory '${BAT_INCLUDE_DIR}'.")
 	message(STATUS "Using BAT libraries '${BAT_LIBRARIES}'.")
+	message(STATUS "Using extra CXX_FLAGS for BAT '${BAT_CXX_FLAGS}'.")
 	message(STATUS "Using extra LINKER_FLAGS for BAT '${BAT_LINKER_FLAGS}'.")
 else()
 	if(BAT_FIND_REQUIRED)

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -48,6 +48,12 @@ include_directories(
 	${Libconfig_INCLUDE_DIR}
 	${ROOT_INCLUDE_DIR}
 	)
+if(USE_BAT)
+	include_directories(
+		SYSTEM
+		${BAT_INCLUDE_DIR}
+	)
+endif()
 
 
 # source files that are compiled into library
@@ -59,6 +65,9 @@ set(SOURCES
 	generatorPickerFunctions.cc
 	modelIntensity.cc
 	)
+if(USE_BAT)
+	LIST(APPEND SOURCES importanceSampler.cc)
+endif()
 
 
 # library
@@ -72,6 +81,9 @@ make_shared_library(
 	"${RPWA_PARTIALWAVEFIT_LIB}"
 	"${RPWA_STORAGEFORMATS_LIB}"
 	)
+if(USE_BAT)
+	target_link_libraries(${THIS_LIB} "${BAT_LIBRARIES}" "${BAT_LINKER_FLAGS}")
+endif()
 
 
 # executables

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SOURCES
 	)
 if(USE_BAT)
 	LIST(APPEND SOURCES importanceSampler.cc)
+	set_source_files_properties(importanceSampler.cc PROPERTIES COMPILE_FLAGS "${BAT_CXX_FLAGS}")
 endif()
 
 

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCES
 	diffractivePhaseSpace.cc
 	beamAndVertexGenerator.cc
 	generatorPickerFunctions.cc
+	modelIntensity.cc
 	)
 
 

--- a/generators/diffractivePhaseSpace.cc
+++ b/generators/diffractivePhaseSpace.cc
@@ -86,7 +86,7 @@ diffractivePhaseSpace::buildDaughterList()
 		}
 		const double xMassMin = _pickerFunction->massRange().first;
 		const double xMassMax = _pickerFunction->massRange().second;
-		if((xMassMax < xMassMin) || (xMassMax <= 0.)) {
+		if((xMassMax < xMassMin) or (xMassMax <= 0.)) {
 			printErr << "mass range [" << xMassMin << ", " << xMassMax << "] GeV/c^2 "
 			         << "does mot make sense. Aborting..." << endl;
 			throw;

--- a/generators/diffractivePhaseSpace.h
+++ b/generators/diffractivePhaseSpace.h
@@ -58,6 +58,19 @@ namespace rpwa {
 		void setDecayProducts(const std::vector<rpwa::particle>& particles);
 		void addDecayProduct(const rpwa::particle& particle);
 
+		/** @brief calculate kinematics of X system in lab frame (= target RF)
+		 *
+		 * calculate the Lorentz vector of the X system in the laboratory frame
+		 * (target rest frame) using the Lorentz vector of the beam particle,
+		 * the masses of target, recoil and X, and the Mandelstam variables
+		 */
+		static TLorentzVector calculateXSystemLab(const TLorentzVector& beamLorentzVector,
+		                                          const double          targetMass,
+		                                          const double          xMass,
+		                                          const double          recoilMass,
+		                                          const double          s,
+		                                          const double          tPrime);
+
 		/** @brief generates one event
 		 *
 		 * returns number of attempts to generate this event and beam

--- a/generators/generatorManager.cc
+++ b/generators/generatorManager.cc
@@ -336,11 +336,11 @@ void generatorManager::readBeamfileSequentially(bool readBeamfileSequentially) {
 void generatorManager::randomizeBeamfileStartingPosition() {
 
 	if(not _reactionFileRead) {
-		printErr << "reaction file has to have been read to set this option (readBeamfileSequentially)." << endl;
+		printErr << "reaction file has to have been read to set this option (randomizeBeamfileStartingPosition)." << endl;
 		throw;
 	}
 	if(not _beamAndVertexGenerator) {
-		printErr << "beam and vertex package seems to be disabled, unable to read beamfile sequentially." << endl;
+		printErr << "beam and vertex package seems to be disabled, unable to randomize beamfile starting position." << endl;
 		throw;
 	}
 	_beamAndVertexGenerator->randomizeBeamfileStartingPosition();

--- a/generators/generatorManager.cc
+++ b/generators/generatorManager.cc
@@ -154,7 +154,7 @@ bool generatorManager::readReactionFile(const string& fileName) {
 		configTarget->lookupValue("recoilParticleName", recoilParticleName);
 		const particleProperties* targetParticle = particleDataTable::entry(targetParticleName);
 		const particleProperties* recoilParticle = particleDataTable::entry(recoilParticleName);
-		if(not (targetParticle && recoilParticle)) {
+		if(not (targetParticle and recoilParticle)) {
 			printErr << "invalid target or recoil particle" << endl;
 			return false;
 		}

--- a/generators/generatorManager.cc
+++ b/generators/generatorManager.cc
@@ -37,13 +37,22 @@ generatorManager::~generatorManager() {
 
 
 #ifdef USE_BAT
-rpwa::importanceSampler generatorManager::getImportanceSampler(rpwa::modelIntensityPtr model) {
-	std::pair<double, double> massRange = _pickerFunction->massRange();
-	rpwa::importanceSampler sampler(massRange.first, massRange.second, model);
-	if (!sampler.initializeProductionGenerator(_beam, _target, _beamAndVertexGenerator, _pickerFunction)) {
-		printErr << "could not initializeProductionGenerator() for the importance sampler" << std::endl;
+rpwa::importanceSamplerPtr generatorManager::getImportanceSampler(rpwa::modelIntensityPtr model) {
+
+	if(not _reactionFileRead) {
+		printErr << "trying to initialize importance sampler before reading reaction file." << endl;
+		return rpwa::importanceSamplerPtr();
 	}
+
+	rpwa::importanceSamplerPtr sampler(new importanceSampler(model,
+	                                                         _beamAndVertexGenerator,
+	                                                         _pickerFunction,
+	                                                         _beam,
+	                                                         _target,
+	                                                         _finalState));
+
 	return sampler;
+
 }
 #endif
 

--- a/generators/generatorManager.cc
+++ b/generators/generatorManager.cc
@@ -33,7 +33,19 @@ generatorManager::generatorManager()
 
 generatorManager::~generatorManager() {
 	delete _generator;
-};
+}
+
+
+#ifdef USE_BAT
+rpwa::importanceSampler generatorManager::getImportanceSampler(rpwa::modelIntensityPtr model) {
+	std::pair<double, double> massRange = _pickerFunction->massRange();
+	rpwa::importanceSampler sampler(massRange.first, massRange.second, model);
+	if (!sampler.initializeProductionGenerator(_beam, _target, _beamAndVertexGenerator, _pickerFunction)) {
+		printErr << "could not initializeProductionGenerator() for the importance sampler" << std::endl;
+	}
+	return sampler;
+}
+#endif
 
 
 unsigned int generatorManager::event() {

--- a/generators/generatorManager.h
+++ b/generators/generatorManager.h
@@ -30,7 +30,7 @@ namespace rpwa {
 		const rpwa::generator& getGenerator() const { return *_generator; }
 
 #ifdef USE_BAT
-		rpwa::importanceSampler getImportanceSampler(rpwa::modelIntensityPtr model);
+		rpwa::importanceSamplerPtr getImportanceSampler(rpwa::modelIntensityPtr model);
 #endif
 
 		bool readReactionFile(const std::string& fileName);

--- a/generators/generatorManager.h
+++ b/generators/generatorManager.h
@@ -7,6 +7,9 @@
 #include "generatorParameters.hpp"
 #include "generatorPickerFunctions.h"
 #include "beamAndVertexGenerator.h"
+#ifdef USE_BAT
+#include "importanceSampler.h"
+#endif
 
 
 class TVector3;
@@ -25,6 +28,10 @@ namespace rpwa {
 		unsigned int event();
 
 		const rpwa::generator& getGenerator() const { return *_generator; }
+
+#ifdef USE_BAT
+		rpwa::importanceSampler getImportanceSampler(rpwa::modelIntensityPtr model);
+#endif
 
 		bool readReactionFile(const std::string& fileName);
 

--- a/generators/generatorPickerFunctions.cc
+++ b/generators/generatorPickerFunctions.cc
@@ -17,7 +17,7 @@ using namespace rpwa;
 
 void massAndTPrimePicker::overrideMassRange(double lowerLimit, double upperLimit) {
 	if(not _initialized) {
-		printErr << "cannot override massRange on uninitialized massAndTPrimePicker." << endl;
+		printErr << "cannot call overrideMassRange() on uninitialized massAndTPrimePicker." << endl;
 		throw;
 	}
 	_massRange.first = lowerLimit;
@@ -28,7 +28,7 @@ void massAndTPrimePicker::overrideMassRange(double lowerLimit, double upperLimit
 
 const std::pair<double, double>& massAndTPrimePicker::massRange() const {
 	if(not _initialized) {
-		printErr << "cannot call massRange on uninitialized massAndTPrimePicker." << endl;
+		printErr << "cannot call massRange() on uninitialized massAndTPrimePicker." << endl;
 		throw;
 	}
 	return _massRange;
@@ -37,7 +37,7 @@ const std::pair<double, double>& massAndTPrimePicker::massRange() const {
 
 const std::pair<double, double>& massAndTPrimePicker::tPrimeRange() const {
 	if(not _initialized) {
-		printErr << "cannot call tPrimeRange on uninitialized massAndTPrimePicker." << endl;
+		printErr << "cannot call tPrimeRange() on uninitialized massAndTPrimePicker." << endl;
 		throw;
 	}
 	return _tPrimeRange;
@@ -123,7 +123,7 @@ bool uniformMassExponentialTPicker::init(const Setting& setting) {
 		return false;
 	}
 	if(not (setting["tSlopes"][0].isNumber()
-			|| (setting["tSlopes"][0].isArray() && setting["tSlopes"][0][0].isNumber()))) {
+			or (setting["tSlopes"][0].isArray() and setting["tSlopes"][0][0].isNumber()))) {
 		printErr << "'tSlopes' has to be number or array of numbers." << endl;
 		return false;
 	}
@@ -140,7 +140,7 @@ bool uniformMassExponentialTPicker::init(const Setting& setting) {
 	}
 	for(int i = 0; i < setting["invariantMasses"].getLength(); ++i) {
 		vector<double> param;
-		if(tArray && not setting["tSlopes"][i].isArray()) {
+		if(tArray and not setting["tSlopes"][i].isArray()) {
 			printErr << "all entries of 'tSlopes' have to be either numbers or arrays of numbers." << endl;
 			return false;
 		}
@@ -316,7 +316,7 @@ bool uniformMassExponentialTPicker::pickTPrimeForMass(const double invariantMass
 			steps++;
 		}
 		restarts++;
-		if(restarts >= 5 && not done) {
+		if(restarts >= 5 and not done) {
 			printErr << restarts << " attempts to generate t' failed." << endl;
 			return false;
 		}
@@ -458,7 +458,7 @@ bool polynomialMassAndTPrimeSlopePicker::pickTPrimeForMass(const double invarian
 	double tPrimeSlope = _tPrimeSlopePolynomial.Eval(invariantMass);
 	do {
 		tPrime = randomNumbers->Exp(1. / tPrimeSlope);
-	} while(tPrime < _tPrimeRange.first || tPrime > _tPrimeRange.second);
+	} while(tPrime < _tPrimeRange.first or tPrime > _tPrimeRange.second);
 	return true;
 }
 

--- a/generators/generatorPickerFunctions.h
+++ b/generators/generatorPickerFunctions.h
@@ -41,8 +41,10 @@ namespace rpwa {
 
 		virtual void overrideMassRange(double lowerLimit, double upperLimit);
 		virtual const std::pair<double, double>& massRange() const;
+		virtual const std::pair<double, double>& tPrimeRange() const;
 
 		virtual bool operator() (double& invariantMass, double& tPrime) = 0;
+		virtual bool pickTPrimeForMass(const double invariantMass, double& tPrime) = 0;
 
 		virtual std::ostream& print(std::ostream& out) const = 0;
 
@@ -72,6 +74,7 @@ namespace rpwa {
 		virtual bool init(const libconfig::Setting& setting);
 
 		virtual bool operator() (double& invariantMass, double& tPrime);
+		virtual bool pickTPrimeForMass(const double invariantMass, double& tPrime);
 
 		virtual std::ostream& print(std::ostream& out) const;
 
@@ -97,6 +100,7 @@ namespace rpwa {
 		virtual bool init(const libconfig::Setting& setting);
 
 		virtual bool operator() (double& invariantMass, double& tPrime);
+		virtual bool pickTPrimeForMass(const double invariantMass, double& tPrime);
 
 		virtual std::ostream& print(std::ostream& out) const;
 

--- a/generators/importanceSampler.cc
+++ b/generators/importanceSampler.cc
@@ -43,6 +43,7 @@
 
 #include<BAT/BCMath.h>
 
+#include"diffractivePhaseSpace.h"
 #include"importanceSampler.h"
 #include"nBodyPhaseSpaceKinematics.h"
 #include"randomNumberGenerator.h"
@@ -384,42 +385,14 @@ rpwa::importanceSampler::getProductionKinematics(const double xMass) const
 		printWarn << "t' pick failed." << std::endl;
 		return boost::tuples::make_tuple(false, 0., TLorentzVector(), TLorentzVector());
 	}
-	TRandom3* random = randomNumberGenerator::instance()->getGenerator();
 
-	const double s            = overallCm.Mag2();
-	const double sqrtS        = sqrt(s);
-	const double recoilMass2  = _target.recoilParticle.mass2();
-	const double xMass2       = xMass * xMass;
-	const double xEnergyCM    = (s - recoilMass2 + xMass2) / (2 * sqrtS);  // breakup energy
-	const double xMomCM       = sqrt(xEnergyCM * xEnergyCM - xMass2);      // breakup momentum
-	const double beamMass2    = _beam.particle.mass2();
-	const double targetMass2  = _target.targetParticle.mass2();
-	const double beamEnergyCM = (s - targetMass2 + beamMass2) / (2 * sqrtS);    // breakup energy
-	const double beamMomCM    = sqrt(beamEnergyCM * beamEnergyCM - beamMass2);  // breakup momentum
-	const double t0           = (xEnergyCM - beamEnergyCM) * (xEnergyCM - beamEnergyCM) -
-	                            (xMomCM - beamMomCM) * (xMomCM - beamMomCM);
-	const double t            = t0 - tPrime;
+	// get Lorentz vector of X in lab system
+	const TLorentzVector xSystemLab = rpwa::diffractivePhaseSpace::calculateXSystemLab(beamLorentzVector,
+	                                                                                   _target.targetParticle.mass(),
+	                                                                                   xMass,
+	                                                                                   _target.recoilParticle.mass(),
+	                                                                                   overallCm.M2(), tPrime);
 
-	// construct X Lorentz-vector in lab frame (= target RF)
-	// convention used here: Reggeon = X - beam = target - recoil (momentum transfer from target to beam vertex)
-	const double beamEnergy       = beamLorentzVector.E();
-	const double beamMomentum     = beamLorentzVector.P();
-	const double reggeonEnergyLab = (targetMass2 - recoilMass2 + t) / (2 * _target.targetParticle.mass());  // breakup energy
-	const double xEnergyLab       = beamEnergy + reggeonEnergyLab;
-	const double xMomLab          = sqrt(xEnergyLab * xEnergyLab - xMass2);
-	const double xCosThetaLab     = (t - xMass2 - beamMass2 + 2 * beamEnergy * xEnergyLab) / (2 * beamMomentum * xMomLab);
-	const double xSinThetaLab     = sqrt(1 - xCosThetaLab * xCosThetaLab);
-	const double xPtLab           = xMomLab * xSinThetaLab;
-	const double xPhiLab          = random->Uniform(0., TMath::TwoPi());
-
-	// xSystemLab is defined w.r.t. beam direction
-	TLorentzVector xSystemLab = TLorentzVector(xPtLab  * cos(xPhiLab),
-	                                           xPtLab  * sin(xPhiLab),
-	                                           xMomLab * xCosThetaLab,
-	                                           xEnergyLab);
-
-	TVector3 beamDir = beamLorentzVector.Vect().Unit();
-	xSystemLab.RotateUz(beamDir);
 	return boost::tuples::make_tuple(true, tPrime, beamLorentzVector, xSystemLab);
 }
 

--- a/generators/importanceSampler.cc
+++ b/generators/importanceSampler.cc
@@ -7,6 +7,7 @@
 #include<BAT/BCMath.h>
 
 #include"importanceSampler.h"
+#include"nBodyPhaseSpaceKinematics.h"
 #include"physUtils.hpp"
 #include"randomNumberGenerator.h"
 
@@ -20,12 +21,11 @@ rpwa::importanceSampler::importanceSampler(const double            mMin,
 	: BCModel("phaseSpaceImportanceSampling"),
 	  _phaseSpaceOnly(false),
 	  _productionGeneratorInitialized(false),
-	  _zeroBinWidth(false),
 	  _nPart(0),
 	  _mMin(mMin),
 	  _mMax(mMax),
 	  _masses(model->finalStateMasses()),
-	  _massPrior(0),
+	  _mSum(0.),
 	  _model(model),
 	  _fileWriter(),
 	  _beamAndVertexGenerator(beamAndVertexGeneratorPtr(new beamAndVertexGenerator())),
@@ -36,44 +36,50 @@ rpwa::importanceSampler::importanceSampler(const double            mMin,
 		printErr << "less than two particles to sample. Four-momentum conservation leaves no d.o.f.. No sampling necessary. Aborting..." << std::endl;
 		throw;
 	}
-	AddParameter("phi1", 0., 2*M_PI, "#phi_{1}");
-	AddParameter("cosTheta1", -1., 1., "cos(#theta_{1})"); // sample cos(theta), because dOmega = sin(theta) dtheta dphi = dcos(theta) dphi
-	double mSum = 0;
-	for (size_t p = 1; p < _nPart; ++p) { // The first particle never appears in the mSum
-		mSum += _masses[p];
+	if (_mMin > _mMax) {
+		printErr << "_mMin = " << _mMin << " > _mMax " << _mMax << ". Aborting..." << std::endl;
+		throw;
 	}
-	for (size_t part = 2; part < _nPart; ++part) {
-		std::stringstream nameM;
-		std::stringstream namePhi;
-		std::stringstream nameTheta;
-		std::stringstream texM;
-		std::stringstream texPhi;
-		std::stringstream texTheta;
 
+	// follow the convention of the nBodyPhaseSpace classes
+	double mMinPar = _masses[0];
+	_mSum          = _masses[0];
+	for (size_t part = 1; part < _nPart; ++part) {
+		mMinPar += _masses[part];
+		_mSum   += _masses[part];
+
+		std::stringstream nameM;
+		std::stringstream texM;
 		nameM << "m";
 		texM << "m_{";
-		for (size_t p = part; p < _nPart+1; ++p) {
+		for (size_t p = 1; p <= part+1; ++p) {
 			nameM << p;
 			texM << p;
 		}
 		texM << "}";
-		namePhi << "phi" << part;
-		texPhi << "#phi_{" << part << "}";
-		nameTheta << "cosTheta" << part; // sample cos(theta), because dOmega = sin(theta) dtheta dphi = dcos(theta) dphi
-		texTheta << "cos(#theta_{" << part << "})";
-		AddParameter(nameM.str(), mSum, _mMax, texM.str());
-		mSum -= _masses[part-1];
-		AddParameter(namePhi.str(), 0., 2*M_PI, texPhi.str());
+		BCParameter param(nameM.str(), mMinPar, _mMax, texM.str());
+		if (part == _nPart-1) {
+			if (_mMin == _mMax) {
+				// X mass is fixed to one value
+				param.Fix(_mMax);
+			} else {
+				param.SetLimits(_mMin, _mMax);
+			}
+		}
+		AddParameter(param);
+
+		// sample cos(theta), because dOmega = sin(theta) dtheta dphi = dcos(theta) dphi
+		std::stringstream nameTheta;
+		std::stringstream texTheta;
+		nameTheta << "cosTheta" << part+1;
+		texTheta << "cos(#theta_{" << part+1 << "})";
 		AddParameter(nameTheta.str(), -1., 1., texTheta.str());
-	}
-	if (_mMin < _mMax) {
-		AddParameter("mass", _mMin, _mMax, "m_{X}");
-	} else if (_mMin == _mMax) {
-		printInfo << "zeroBinWidth, do not sample mX" << std::endl;
-		_zeroBinWidth = true;
-	} else {
-		printErr << "_mMin = " << _mMin << " > _mMax = " << _mMax << ". Aborting..." << std::endl;
-		throw;
+
+		std::stringstream namePhi;
+		std::stringstream texPhi;
+		namePhi << "phi" << part+1;
+		texPhi << "#phi_{" << part+1 << "}";
+		AddParameter(namePhi.str(), 0., 2*M_PI, texPhi.str());
 	}
 	for (size_t part = 0; part < _nPart; ++part) {
 		for (size_t qart = 0; qart < part; ++qart) {
@@ -89,194 +95,101 @@ rpwa::importanceSampler::importanceSampler(const double            mMin,
 
 
 double
-rpwa::importanceSampler::LogLikelihood(const std::vector<double>& parameters)
+rpwa::importanceSampler::LogAPrioriProbability(const std::vector<double>& parameters)
 {
-	++_nCalls;
-	if (!_productionGeneratorInitialized) {
-		printErr << "Production kinematics not initilized. Cannot generate beam." << std::endl;
-		throw;
+	rpwa::nBodyPhaseSpaceKinematics nBodyPhaseSpace;
+	if (not initializeNBodyPhaseSpace(nBodyPhaseSpace, parameters, false)) {
+		return -std::numeric_limits<double>::infinity();
 	}
-	if (!_phaseSpaceOnly) {
-		std::vector<TLorentzVector> fourVectors = getFinalStateMomenta(parameters);
-		std::vector<TVector3> decayKinMomenta(_nPart);
-		for (size_t part = 0; part < _nPart; ++part) {
-			decayKinMomenta[part] = fourVectors[part].Vect();
-		}
-		const double intens = _model->getIntensity(decayKinMomenta);
-		return std::log(intens);
-	} else {
-		return -1;
-	}
+
+	const double phaseSpace = nBodyPhaseSpace.calcWeight() / std::pow(parameters[3*_nPart-6] - _mSum, _nPart-2);
+	return std::log(phaseSpace);
 }
 
 
 double
-rpwa::importanceSampler::LogAPrioriProbability(const std::vector<double>& parameters)
+rpwa::importanceSampler::LogLikelihood(const std::vector<double>& parameters)
 {
-	// Just calculate non constant parts;
-	double mass = _mMin;
-	if (!_zeroBinWidth) {
-		mass = parameters[parameters.size()-1];
-		if (mass < _mMin || mass >= _mMax) {
-			return -std::numeric_limits<double>::infinity();
-		}
+	++_nCalls;
+	if (_phaseSpaceOnly) {
+		return -1;
 	}
 
-	double phaseSpace = 1./pow(mass, 4); // Prior = 1/M^2 => calculate prior^2 -> 1/M^4
-	if (_nPart == 2) { // Two particle phase space is constant. Handle this case special that part == 0 and part == _mParr-2 can appear laser.
-		return std::log(phaseSpace)/2.;
+	rpwa::nBodyPhaseSpaceKinematics nBodyPhaseSpace;
+	if (not initializeNBodyPhaseSpace(nBodyPhaseSpace, parameters, true)) {
+		printErr << "error while initializing n-body phase space. Aborting..." << std::endl;
+		throw;
 	}
 
-	for (size_t part = 0; part < _nPart - 1; ++part) {
-		double M, m1, m2;
-		if (part == 0) {
-			M  = mass;
-			m1 = _masses[0];
-			m2 = parameters[2];
-		} else if (part == _nPart-2) {
-			M  = parameters[3*part-1];
-			m1 = _masses[part];
-			m2 = _masses[part+1];
-		} else {
-			M  = parameters[3*part-1];
-			m1 = _masses[part];
-			m2 = parameters[3*part+2];
-		}
-		if (M < m1 + m2) {
-			return -std::numeric_limits<double>::infinity();
-		}
-		phaseSpace *= breakupMomentumSquared(M, m1, m2, true);
-		if (phaseSpace < 0.) {
-			return -std::numeric_limits<double>::infinity();
-		}
+	nBodyPhaseSpace.calcBreakupMomenta();
+	nBodyPhaseSpace.calcEventKinematics(TLorentzVector(0., 0., 0., parameters[3*_nPart-6]));
+	std::vector<TVector3> decayKinMomenta(_nPart);
+	for (size_t part = 0; part < _nPart; ++part) {
+		decayKinMomenta[part] = nBodyPhaseSpace.daughter(part).Vect();
 	}
-	if (_massPrior) {
-		double massPrior = _massPrior->Eval(mass);
-		phaseSpace *= massPrior*massPrior; // massPrior^2 since everything is sqared up to now
-	}
-	return std::log(phaseSpace)/2; // The product above is actually multiplied with the square of the phase space, positivity is ensured, so the missung sqrt becomes a factor 1/2 when pulling it out of the log
+
+	const double intensity = _model->getIntensity(decayKinMomenta);
+	return std::log(intensity);
 }
 
 
 void
 rpwa::importanceSampler::CalculateObservables(const std::vector<double>& parameters)
 {
-	std::vector<TLorentzVector> vectors = getFinalStateMomenta(parameters);
+	if (!_productionGeneratorInitialized) {
+		printErr << "Production kinematics not initilized. Cannot generate beam." << std::endl;
+		throw;
+	}
+
+
+	rpwa::nBodyPhaseSpaceKinematics nBodyPhaseSpace;
+	if (not initializeNBodyPhaseSpace(nBodyPhaseSpace, parameters, true)) {
+		printErr << "error while initializing n-body phase space. Aborting..." << std::endl;
+		throw;
+	}
+
+	nBodyPhaseSpace.calcBreakupMomenta();
+	nBodyPhaseSpace.calcEventKinematics(TLorentzVector(0., 0., 0., parameters[3*_nPart-6]));
+
 	size_t count = 0;
 	for (size_t part = 0; part < _nPart; ++part) {
 		for (size_t qart = 0; qart < part; ++qart) {
-			GetObservable(count) = (vectors[part] + vectors[qart]).M2();
+			GetObservable(count) = (nBodyPhaseSpace.daughter(part) + nBodyPhaseSpace.daughter(qart)).M2();
 			++count;
 		}
 	}
+
 	if (_fileWriter.initialized() && GetPhase() > 0) { // Put file writer stuff here
 		if (fMCMCCurrentIteration % fMCMCNLag != 0) {
 			return; // apply lag
 		}
-		std::vector<TVector3> decayKinMomenta(vectors.size());
-		double mass = _mMin;
-		if (!_zeroBinWidth) {
-			mass = parameters[parameters.size()-1];
-		}
 
-		std::pair<std::pair<bool, double>, std::vector<TLorentzVector> > production = getProductionKinematics(mass);
+		std::pair<std::pair<bool, double>, std::vector<TLorentzVector> > production = getProductionKinematics(parameters[3*_nPart-6]);
 		if (!production.first.first) {
 			printErr << "generation of production failed" << std::endl;
 			throw;
 		}
-		TLorentzVector pX;
-		std::pair<bool, TLorentzRotation> inverseGJ = getInverseGJTransform(production.second[0], production.second[1]);
-		for (size_t part = 0; part < vectors.size(); ++part) {
-			vectors[part].Transform(inverseGJ.second);
-			decayKinMomenta[part] = vectors[part].Vect();
-			pX+=vectors[part];
+
+		const TLorentzRotation toLab = rpwa::isobarAmplitude::gjTransform(production.second[0], production.second[1]).Inverse();
+		std::vector<TVector3> decayKinMomenta(_nPart);
+		TLorentzVector pX(0.,0.,0.,0.);
+		for (size_t part = 0; part < _nPart; ++part) {
+			TLorentzVector p = nBodyPhaseSpace.daughter(part);
+			p.Transform(toLab);
+			decayKinMomenta[part] = p.Vect();
+			pX += p;
 		}
+
 		std::vector<double>var(3+_nPart);
 		var[0] = production.first.second;
 		var[1] = pX.M();
 		var[2] = pX.E();
 		for (size_t part = 0; part < _nPart; ++part) {
-			var[part + 3] = vectors[part].E();
+			var[part + 3] = nBodyPhaseSpace.daughter(part).E();
 		}
 		std::vector<TVector3> prodKinMomenta(1, production.second[0].Vect());
 		_fileWriter.addEvent(prodKinMomenta, decayKinMomenta, var);
 	}
-}
-
-
-std::vector<TLorentzVector>
-rpwa::importanceSampler::getFinalStateMomenta(const std::vector<double>& samplingParameters) const
-{
-	std::vector<TLorentzVector> retVal(_nPart);
-	double MX = _mMin;
-	if (!_zeroBinWidth) {
-		MX = samplingParameters[samplingParameters.size()-1];
-	}
-	if (_nPart == 2) {
-		double q = rpwa::breakupMomentum(MX, _masses[0], _masses[1]);
-		double E1 = pow(q*q+_masses[0]*_masses[0], .5);
-		double E2 = pow(q*q+_masses[1]*_masses[1], .5);
-		double cosT = samplingParameters[1];
-		double sinT = sqrt(1. - cosT*cosT); // Can be done, since theta in [0, pi] -> sin(theta) >= 0.
-		retVal[0] = TLorentzVector(q*cos(samplingParameters[0])*sinT,
-		                           q*sin(samplingParameters[0])*sinT,
-		                           q*cosT,
-		                           E1);
-		retVal[1] = TLorentzVector(-q*cos(samplingParameters[0])*sinT,
-		                           -q*sin(samplingParameters[0])*sinT,
-		                           -q*cosT,
-		                            E2);
-		return retVal;
-	}
-
-	TLorentzVector isobarMomentum(0., 0., 0., MX);
-	double q  = 0.;
-	double M  = 0.;
-	double m1 = 0.;
-	double m2 = 0.;
-	double E1 = 0.;
-	double E2 = 0.;
-	for (size_t part = 0; part < _nPart-1; ++part) {
-		if (part == 0) {
-			M  = MX;
-			m1 = _masses[part];
-			m2 = samplingParameters[3*part+2];
-		} else if (part == _nPart-2) {
-			M  = samplingParameters[3*part-1];
-			m1 = _masses[part  ];
-			m2 = _masses[part+1];
-		} else {
-			M  = samplingParameters[3*part-1];
-			m1 = _masses[part];
-			m2 = samplingParameters[3*part+2];
-		}
-		q  = rpwa::breakupMomentumSquared(M, m1, m2, true);
-		if (q < 0.) {
-			q = 0.;
-		} else {
-			q = sqrt(q);
-		}
-		E1 = pow(q*q+m1*m1, .5);
-		E2 = pow(q*q+m2*m2, .5);
-
-		TVector3 boostVector = isobarMomentum.BoostVector();
-		double cosT = samplingParameters[3*part+1];
-		double sinT = sqrt(1. - cosT*cosT); // Can be done, since theta in [0, pi] -> sin(theta) >= 0.
-		retVal[part]         = TLorentzVector(q*cos(samplingParameters[3*part])*sinT,
-		                                      q*sin(samplingParameters[3*part])*sinT,
-		                                      q*cosT,
-		                                      E1);
-		retVal[part].Boost(boostVector);
-		isobarMomentum = TLorentzVector(-q*cos(samplingParameters[3*part])*sinT,
-		                                -q*sin(samplingParameters[3*part])*sinT,
-		                                -q*cosT,
-		                                 E2);
-		isobarMomentum.Boost(boostVector);
-		if (part == _nPart-2) {
-			retVal[part+1] = isobarMomentum;
-		}
-	}
-	return retVal;
 }
 
 
@@ -395,29 +308,39 @@ rpwa::importanceSampler::getProductionKinematics(const double xMass)
 }
 
 
-std::pair<bool, TLorentzRotation>
-rpwa::importanceSampler::getInverseGJTransform(const TLorentzVector& beamLv,
-                                               const TLorentzVector& XLv)
+bool
+rpwa::importanceSampler::initializeNBodyPhaseSpace(rpwa::nBodyPhaseSpaceKinematics& nBodyPhaseSpace,
+                                                   const std::vector<double>&       parameters,
+                                                   const bool                       angles) const
 {
-	TLorentzVector beam = beamLv;
-	TLorentzVector X    = XLv;
-	const TVector3 yGjAxis = beam.Vect().Cross(X.Vect()); // y-axis of Gottfried-Jackson frame
-	// rotate so that yGjAxis becomes parallel to y-axis and beam momentum ends up in (x, z)-plane
-	TRotation rot1;
-	rot1.RotateZ(piHalf - yGjAxis.Phi());
-	rot1.RotateX(yGjAxis.Theta() - piHalf);
-	beam *= rot1;
-	X    *= rot1;
-	// boost to X RF
-	TLorentzRotation boost;
-	boost.Boost(-X.BoostVector());
-	beam *= boost;
-	// rotate about yGjAxis so that beam momentum is along z-axis
-	TRotation rot2;
-	rot2.RotateY(-signum(beam.X()) * beam.Theta());
-	// construct total transformation
-	TLorentzRotation gjTransform(rot1);
-	gjTransform.Transform(boost);
-	gjTransform.Transform(rot2);
-	return std::pair<bool, TLorentzRotation>(true, gjTransform.Inverse());
+	// currently these options are in the default values, but just to be safe
+	nBodyPhaseSpace.setWeightType(rpwa::nBodyPhaseSpaceKinematics::S_U_CHUNG);
+	nBodyPhaseSpace.setKinematicsType(rpwa::nBodyPhaseSpaceKinematics::BLOCK);
+
+	if (not nBodyPhaseSpace.setDecay(_masses)) {
+		return false;
+	}
+
+	std::vector<double> masses(_nPart);
+	masses[0] = _masses[0];
+	for (size_t part = 1; part < _nPart; ++part) {
+		masses[part] = parameters[3*part-3];
+		if ((masses[part-1] + _masses[part]) > masses[part])
+			return false;
+	}
+	nBodyPhaseSpace.setMasses(masses);
+
+	if (angles) {
+		std::vector<double> cosTheta(_nPart);
+		std::vector<double> phi     (_nPart);
+
+		for (size_t part = 1; part < _nPart; ++part) {
+			cosTheta[part] = parameters[3*part-2];
+			phi     [part] = parameters[3*part-1];
+		}
+
+		nBodyPhaseSpace.setAngles(cosTheta, phi);
+	}
+
+	return true;
 }

--- a/generators/importanceSampler.cc
+++ b/generators/importanceSampler.cc
@@ -1,0 +1,423 @@
+#include<cmath>
+#include<iostream>
+#include<sstream>
+
+#include<TFile.h>
+
+#include<BAT/BCMath.h>
+
+#include"importanceSampler.h"
+#include"physUtils.hpp"
+#include"randomNumberGenerator.h"
+
+
+size_t rpwa::importanceSampler::_nCalls = 0;
+
+
+rpwa::importanceSampler::importanceSampler(const double            mMin,
+                                           const double            mMax,
+                                           rpwa::modelIntensityPtr model)
+	: BCModel("phaseSpaceImportanceSampling"),
+	  _phaseSpaceOnly(false),
+	  _productionGeneratorInitialized(false),
+	  _zeroBinWidth(false),
+	  _nPart(0),
+	  _mMin(mMin),
+	  _mMax(mMax),
+	  _masses(model->finalStateMasses()),
+	  _massPrior(0),
+	  _model(model),
+	  _fileWriter(),
+	  _beamAndVertexGenerator(beamAndVertexGeneratorPtr(new beamAndVertexGenerator())),
+	  _pickerFunction(massAndTPrimePickerPtr())
+{
+	_nPart = _model->nFinalState();
+	if (_nPart < 2) {
+		printErr << "less than two particles to sample. Four-momentum conservation leaves no d.o.f.. No sampling necessary. Aborting..." << std::endl;
+		throw;
+	}
+	AddParameter("phi1", 0., 2*M_PI, "#phi_{1}");
+	AddParameter("cosTheta1", -1., 1., "cos(#theta_{1})"); // sample cos(theta), because dOmega = sin(theta) dtheta dphi = dcos(theta) dphi
+	double mSum = 0;
+	for (size_t p = 1; p < _nPart; ++p) { // The first particle never appears in the mSum
+		mSum += _masses[p];
+	}
+	for (size_t part = 2; part < _nPart; ++part) {
+		std::stringstream nameM;
+		std::stringstream namePhi;
+		std::stringstream nameTheta;
+		std::stringstream texM;
+		std::stringstream texPhi;
+		std::stringstream texTheta;
+
+		nameM << "m";
+		texM << "m_{";
+		for (size_t p = part; p < _nPart+1; ++p) {
+			nameM << p;
+			texM << p;
+		}
+		texM << "}";
+		namePhi << "phi" << part;
+		texPhi << "#phi_{" << part << "}";
+		nameTheta << "cosTheta" << part; // sample cos(theta), because dOmega = sin(theta) dtheta dphi = dcos(theta) dphi
+		texTheta << "cos(#theta_{" << part << "})";
+		AddParameter(nameM.str(), mSum, _mMax, texM.str());
+		mSum -= _masses[part-1];
+		AddParameter(namePhi.str(), 0., 2*M_PI, texPhi.str());
+		AddParameter(nameTheta.str(), -1., 1., texTheta.str());
+	}
+	if (_mMin < _mMax) {
+		AddParameter("mass", _mMin, _mMax, "m_{X}");
+	} else if (_mMin == _mMax) {
+		printInfo << "zeroBinWidth, do not sample mX" << std::endl;
+		_zeroBinWidth = true;
+	} else {
+		printErr << "_mMin = " << _mMin << " > _mMax = " << _mMax << ". Aborting..." << std::endl;
+		throw;
+	}
+	for (size_t part = 0; part < _nPart; ++part) {
+		for (size_t qart = 0; qart < part; ++qart) {
+			std::stringstream name;
+			std::stringstream tex;
+			name << "M" << qart+1 << part+1 << 2;
+			tex << "m^{2}_{" << qart+1 << part+1 << "}";
+			AddObservable(name.str(), 0., _mMax*_mMax, tex.str());
+		}
+	}
+	BCAux::SetStyle();
+}
+
+
+double
+rpwa::importanceSampler::LogLikelihood(const std::vector<double>& parameters)
+{
+	++_nCalls;
+	if (!_productionGeneratorInitialized) {
+		printErr << "Production kinematics not initilized. Cannot generate beam." << std::endl;
+		throw;
+	}
+	if (!_phaseSpaceOnly) {
+		std::vector<TLorentzVector> fourVectors = getFinalStateMomenta(parameters);
+		std::vector<TVector3> decayKinMomenta(_nPart);
+		for (size_t part = 0; part < _nPart; ++part) {
+			decayKinMomenta[part] = fourVectors[part].Vect();
+		}
+		const double intens = _model->getIntensity(decayKinMomenta);
+		return std::log(intens);
+	} else {
+		return -1;
+	}
+}
+
+
+double
+rpwa::importanceSampler::LogAPrioriProbability(const std::vector<double>& parameters)
+{
+	// Just calculate non constant parts;
+	double mass = _mMin;
+	if (!_zeroBinWidth) {
+		mass = parameters[parameters.size()-1];
+		if (mass < _mMin || mass >= _mMax) {
+			return -std::numeric_limits<double>::infinity();
+		}
+	}
+
+	double phaseSpace = 1./pow(mass, 4); // Prior = 1/M^2 => calculate prior^2 -> 1/M^4
+	if (_nPart == 2) { // Two particle phase space is constant. Handle this case special that part == 0 and part == _mParr-2 can appear laser.
+		return std::log(phaseSpace)/2.;
+	}
+
+	for (size_t part = 0; part < _nPart - 1; ++part) {
+		double M, m1, m2;
+		if (part == 0) {
+			M  = mass;
+			m1 = _masses[0];
+			m2 = parameters[2];
+		} else if (part == _nPart-2) {
+			M  = parameters[3*part-1];
+			m1 = _masses[part];
+			m2 = _masses[part+1];
+		} else {
+			M  = parameters[3*part-1];
+			m1 = _masses[part];
+			m2 = parameters[3*part+2];
+		}
+		if (M < m1 + m2) {
+			return -std::numeric_limits<double>::infinity();
+		}
+		phaseSpace *= breakupMomentumSquared(M, m1, m2, true);
+		if (phaseSpace < 0.) {
+			return -std::numeric_limits<double>::infinity();
+		}
+	}
+	if (_massPrior) {
+		double massPrior = _massPrior->Eval(mass);
+		phaseSpace *= massPrior*massPrior; // massPrior^2 since everything is sqared up to now
+	}
+	return std::log(phaseSpace)/2; // The product above is actually multiplied with the square of the phase space, positivity is ensured, so the missung sqrt becomes a factor 1/2 when pulling it out of the log
+}
+
+
+void
+rpwa::importanceSampler::CalculateObservables(const std::vector<double>& parameters)
+{
+	std::vector<TLorentzVector> vectors = getFinalStateMomenta(parameters);
+	size_t count = 0;
+	for (size_t part = 0; part < _nPart; ++part) {
+		for (size_t qart = 0; qart < part; ++qart) {
+			GetObservable(count) = (vectors[part] + vectors[qart]).M2();
+			++count;
+		}
+	}
+	if (_fileWriter.initialized() && GetPhase() > 0) { // Put file writer stuff here
+		if (fMCMCCurrentIteration % fMCMCNLag != 0) {
+			return; // apply lag
+		}
+		std::vector<TVector3> decayKinMomenta(vectors.size());
+		double mass = _mMin;
+		if (!_zeroBinWidth) {
+			mass = parameters[parameters.size()-1];
+		}
+
+		std::pair<std::pair<bool, double>, std::vector<TLorentzVector> > production = getProductionKinematics(mass);
+		if (!production.first.first) {
+			printErr << "generation of production failed" << std::endl;
+			throw;
+		}
+		TLorentzVector pX;
+		std::pair<bool, TLorentzRotation> inverseGJ = getInverseGJTransform(production.second[0], production.second[1]);
+		for (size_t part = 0; part < vectors.size(); ++part) {
+			vectors[part].Transform(inverseGJ.second);
+			decayKinMomenta[part] = vectors[part].Vect();
+			pX+=vectors[part];
+		}
+		std::vector<double>var(3+_nPart);
+		var[0] = production.first.second;
+		var[1] = pX.M();
+		var[2] = pX.E();
+		for (size_t part = 0; part < _nPart; ++part) {
+			var[part + 3] = vectors[part].E();
+		}
+		std::vector<TVector3> prodKinMomenta(1, production.second[0].Vect());
+		_fileWriter.addEvent(prodKinMomenta, decayKinMomenta, var);
+	}
+}
+
+
+std::vector<TLorentzVector>
+rpwa::importanceSampler::getFinalStateMomenta(const std::vector<double>& samplingParameters) const
+{
+	std::vector<TLorentzVector> retVal(_nPart);
+	double MX = _mMin;
+	if (!_zeroBinWidth) {
+		MX = samplingParameters[samplingParameters.size()-1];
+	}
+	if (_nPart == 2) {
+		double q = rpwa::breakupMomentum(MX, _masses[0], _masses[1]);
+		double E1 = pow(q*q+_masses[0]*_masses[0], .5);
+		double E2 = pow(q*q+_masses[1]*_masses[1], .5);
+		double cosT = samplingParameters[1];
+		double sinT = sqrt(1. - cosT*cosT); // Can be done, since theta in [0, pi] -> sin(theta) >= 0.
+		retVal[0] = TLorentzVector(q*cos(samplingParameters[0])*sinT,
+		                           q*sin(samplingParameters[0])*sinT,
+		                           q*cosT,
+		                           E1);
+		retVal[1] = TLorentzVector(-q*cos(samplingParameters[0])*sinT,
+		                           -q*sin(samplingParameters[0])*sinT,
+		                           -q*cosT,
+		                            E2);
+		return retVal;
+	}
+
+	TLorentzVector isobarMomentum(0., 0., 0., MX);
+	double q  = 0.;
+	double M  = 0.;
+	double m1 = 0.;
+	double m2 = 0.;
+	double E1 = 0.;
+	double E2 = 0.;
+	for (size_t part = 0; part < _nPart-1; ++part) {
+		if (part == 0) {
+			M  = MX;
+			m1 = _masses[part];
+			m2 = samplingParameters[3*part+2];
+		} else if (part == _nPart-2) {
+			M  = samplingParameters[3*part-1];
+			m1 = _masses[part  ];
+			m2 = _masses[part+1];
+		} else {
+			M  = samplingParameters[3*part-1];
+			m1 = _masses[part];
+			m2 = samplingParameters[3*part+2];
+		}
+		q  = rpwa::breakupMomentumSquared(M, m1, m2, true);
+		if (q < 0.) {
+			q = 0.;
+		} else {
+			q = sqrt(q);
+		}
+		E1 = pow(q*q+m1*m1, .5);
+		E2 = pow(q*q+m2*m2, .5);
+
+		TVector3 boostVector = isobarMomentum.BoostVector();
+		double cosT = samplingParameters[3*part+1];
+		double sinT = sqrt(1. - cosT*cosT); // Can be done, since theta in [0, pi] -> sin(theta) >= 0.
+		retVal[part]         = TLorentzVector(q*cos(samplingParameters[3*part])*sinT,
+		                                      q*sin(samplingParameters[3*part])*sinT,
+		                                      q*cosT,
+		                                      E1);
+		retVal[part].Boost(boostVector);
+		isobarMomentum = TLorentzVector(-q*cos(samplingParameters[3*part])*sinT,
+		                                -q*sin(samplingParameters[3*part])*sinT,
+		                                -q*cosT,
+		                                 E2);
+		isobarMomentum.Boost(boostVector);
+		if (part == _nPart-2) {
+			retVal[part+1] = isobarMomentum;
+		}
+	}
+	return retVal;
+}
+
+
+bool
+rpwa::importanceSampler::initializeFileWriter(TFile* outFile)
+{
+	std::string userString("importanceSampledEvents");
+	std::map<std::string, std::pair<double, double> > binning;
+	binning["mass"] = std::pair<double, double> (_mMin, _mMax); // Use own mass range, since the range of the picker will be overridden
+	if (_productionGeneratorInitialized) {
+		binning["tPrime"] = _pickerFunction->tPrimeRange(); // Use tPicker t' range, since the actual sampling is decoupled from t'.
+	}
+	std::vector<std::string> var(1, "tPrime");
+	var.push_back("mass");
+	var.push_back("EXlab");
+	for (size_t part = 0; part < _nPart; ++part) {
+		std::stringstream name;
+		name << "E" << part+1;
+		var.push_back(name.str());
+	}
+	return _fileWriter.initialize(*outFile,
+	                              userString,
+	                              rpwa::eventMetadata::GENERATED,
+	                              _model->initialStateParticles(),
+	                              _model->finalStateParticles(),
+	                              binning,
+	                              var);
+}
+
+
+bool
+rpwa::importanceSampler::finalizeFileWriter()
+{
+	return _fileWriter.finalize();
+}
+
+
+bool
+rpwa::importanceSampler::initializeProductionGenerator(rpwa::Beam&                     beam,
+                                                       rpwa::Target&                   target,
+                                                       rpwa::beamAndVertexGeneratorPtr generator,
+                                                       rpwa::massAndTPrimePickerPtr    picker)
+{
+	_productionGeneratorInitialized = false;
+	_target = rpwa::Target(target);
+	_beam   = rpwa::Beam(beam);
+	_beamAndVertexGenerator = rpwa::beamAndVertexGeneratorPtr(generator);
+	_pickerFunction = rpwa::massAndTPrimePickerPtr(picker);
+	_productionGeneratorInitialized = true;
+	return true;
+}
+
+
+std::pair<std::pair<bool, double>, std::vector<TLorentzVector> >
+rpwa::importanceSampler::getProductionKinematics(const double xMass)
+{
+	if (!_productionGeneratorInitialized) {
+		printErr << "poduction generators not initalized" << std::endl;
+		return std::pair<std::pair<bool, double>, std::vector<TLorentzVector> >(std::pair<bool, double>(false, 0.), std::vector<TLorentzVector>(2));
+	}
+	if(not _beamAndVertexGenerator->event(_target, _beam)) {
+		printErr << "could not generate vertex/beam. Aborting..." << std::endl;
+		return std::pair<std::pair<bool, double>, std::vector<TLorentzVector> >(std::pair<bool, double>(false, 0.), std::vector<TLorentzVector>(2));;
+	}
+	const TLorentzVector targetLab(0., 0., 0., _target.targetParticle.mass());
+	_beam.particle.setLzVec(_beamAndVertexGenerator->getBeam());
+	const TLorentzVector& beamLorentzVector = _beam.particle.lzVec();
+	const TLorentzVector overallCm = beamLorentzVector + targetLab;  // beam-target center-of-mass system
+
+
+	double tPrime;
+	if (not _pickerFunction->pickTPrimeForMass(xMass, tPrime)) {
+		printErr << "t' pick failed" << std::endl;
+		return std::pair<std::pair<bool, double>, std::vector<TLorentzVector> >(std::pair<bool, double>(false, 0.), std::vector<TLorentzVector>(2));
+	}
+	TRandom3* random = randomNumberGenerator::instance()->getGenerator();
+
+	const double s            = overallCm.Mag2();
+	const double sqrtS        = sqrt(s);
+	const double recoilMass2  = _target.recoilParticle.mass2();
+	const double xMass2       = xMass * xMass;
+	const double xEnergyCM    = (s - recoilMass2 + xMass2) / (2 * sqrtS);  // breakup energy
+	const double xMomCM       = sqrt(xEnergyCM * xEnergyCM - xMass2);      // breakup momentum
+	const double beamMass2    = _beam.particle.mass2();
+	const double targetMass2  = _target.targetParticle.mass2();
+	const double beamEnergyCM = (s - targetMass2 + beamMass2) / (2 * sqrtS);    // breakup energy
+	const double beamMomCM    = sqrt(beamEnergyCM * beamEnergyCM - beamMass2);  // breakup momentum
+	const double t0           = (xEnergyCM - beamEnergyCM) * (xEnergyCM - beamEnergyCM) -
+	                            (xMomCM - beamMomCM) * (xMomCM - beamMomCM);
+	const double t            = t0 - tPrime;
+
+	// construct X Lorentz-vector in lab frame (= target RF)
+	// convention used here: Reggeon = X - beam = target - recoil (momentum transfer from target to beam vertex)
+	const double beamEnergy       = beamLorentzVector.E();
+	const double beamMomentum     = beamLorentzVector.P();
+	const double reggeonEnergyLab = (targetMass2 - recoilMass2 + t) / (2 * _target.targetParticle.mass());  // breakup energy
+	const double xEnergyLab       = beamEnergy + reggeonEnergyLab;
+	const double xMomLab          = sqrt(xEnergyLab * xEnergyLab - xMass2);
+	const double xCosThetaLab     = (t - xMass2 - beamMass2 + 2 * beamEnergy * xEnergyLab) / (2 * beamMomentum * xMomLab);
+	const double xSinThetaLab     = sqrt(1 - xCosThetaLab * xCosThetaLab);
+	const double xPtLab           = xMomLab * xSinThetaLab;
+	const double xPhiLab          = random->Uniform(0., TMath::TwoPi());
+
+	// xSystemLab is defined w.r.t. beam direction
+	TLorentzVector xSystemLab = TLorentzVector(xPtLab  * cos(xPhiLab),
+	                                           xPtLab  * sin(xPhiLab),
+	                                           xMomLab * xCosThetaLab,
+	                                           xEnergyLab);
+
+	TVector3 beamDir = _beam.particle.momentum().Unit();
+	xSystemLab.RotateUz(beamDir);
+	std::vector<TLorentzVector> kinematics(2);
+	kinematics[0] = beamLorentzVector;
+	kinematics[1] = xSystemLab;
+	return std::pair<std::pair<bool, double>, std::vector<TLorentzVector> >(std::pair<bool, double>(true, tPrime), kinematics);
+}
+
+
+std::pair<bool, TLorentzRotation>
+rpwa::importanceSampler::getInverseGJTransform(const TLorentzVector& beamLv,
+                                               const TLorentzVector& XLv)
+{
+	TLorentzVector beam = beamLv;
+	TLorentzVector X    = XLv;
+	const TVector3 yGjAxis = beam.Vect().Cross(X.Vect()); // y-axis of Gottfried-Jackson frame
+	// rotate so that yGjAxis becomes parallel to y-axis and beam momentum ends up in (x, z)-plane
+	TRotation rot1;
+	rot1.RotateZ(piHalf - yGjAxis.Phi());
+	rot1.RotateX(yGjAxis.Theta() - piHalf);
+	beam *= rot1;
+	X    *= rot1;
+	// boost to X RF
+	TLorentzRotation boost;
+	boost.Boost(-X.BoostVector());
+	beam *= boost;
+	// rotate about yGjAxis so that beam momentum is along z-axis
+	TRotation rot2;
+	rot2.RotateY(-signum(beam.X()) * beam.Theta());
+	// construct total transformation
+	TLorentzRotation gjTransform(rot1);
+	gjTransform.Transform(boost);
+	gjTransform.Transform(rot2);
+	return std::pair<bool, TLorentzRotation>(true, gjTransform.Inverse());
+}

--- a/generators/importanceSampler.cc
+++ b/generators/importanceSampler.cc
@@ -220,13 +220,12 @@ rpwa::importanceSampler::CalculateObservables(const std::vector<double>& paramet
 
 bool
 rpwa::importanceSampler::initializeFileWriter(TFile*             outFile,
+                                              const std::string& userString,
                                               const bool         storeMassAndTPrime,
                                               const std::string& massVariableName,
                                               const std::string& tPrimeVariableName)
 {
 	_storeMassAndTPrime = storeMassAndTPrime;
-
-	std::string userString("importanceSampledEvents");
 
 	std::vector<std::string> prodKinParticleNames(1);
 	prodKinParticleNames[0] = _beam.particle.name();

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -40,6 +40,7 @@ namespace rpwa {
 		void CalculateObservables(const std::vector<double>& parameters);
 
 		bool initializeFileWriter(TFile*             outFile,
+		                          const std::string& userString         = "importanceSampledEvents",
 		                          const bool         storeMassAndTPrime = true,
 		                          const std::string& massVariableName   = "mass",
 		                          const std::string& tPrimeVariableName = "tPrime");

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -47,6 +47,7 @@ namespace rpwa {
 		bool finalizeFileWriter();
 
 		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
+		void setMassPrior     (TF1*       prior = 0   ) { _massPrior      = prior; }
 
 	private:
 
@@ -68,6 +69,7 @@ namespace rpwa {
 		std::vector<double>             _masses;
 		double                          _mSum;
 		bool                            _phaseSpaceOnly;
+		TF1*                            _massPrior;
 
 		rpwa::eventFileWriter           _fileWriter;
 		bool                            _storeMassAndTPrime;

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -18,6 +18,9 @@ class TFile;
 namespace rpwa {
 
 
+	class nBodyPhaseSpaceKinematics;
+
+
 	class importanceSampler : public BCModel {
 
 	public:
@@ -26,15 +29,15 @@ namespace rpwa {
 		                  const double mMax,
 		                  rpwa::modelIntensityPtr model);
 
-		bool setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; return true; }
+		// overload BAT methods
+		double LogAPrioriProbability(const std::vector<double>& parameters);
+		double LogLikelihood(const std::vector<double>& parameters);
+		void CalculateObservables(const std::vector<double>& parameters);
 
-		bool setMassPrior(TF1* massPrior) { _massPrior = massPrior; return true; }
+		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
 
 		bool initializeFileWriter(TFile* outFile);
 		bool finalizeFileWriter();
-
-		double LogLikelihood(const std::vector<double>& parameters);
-		double LogAPrioriProbability(const std::vector<double>& parameters);
 
 		bool initializeProductionGenerator(rpwa::Beam& beam,
 		                                   rpwa::Target& target,
@@ -45,23 +48,20 @@ namespace rpwa {
 
 		size_t nCalls() const { return _nCalls; }
 
-		static std::pair<bool, TLorentzRotation> getInverseGJTransform(const TLorentzVector& beamLv, const TLorentzVector& XLv);
-
 	private:
 
-		std::vector<TLorentzVector> getFinalStateMomenta(const std::vector<double>& parameters) const;
-
-		void CalculateObservables(const std::vector<double>& parameters);
+		bool initializeNBodyPhaseSpace(rpwa::nBodyPhaseSpaceKinematics& nBodyPhaseSpace,
+		                               const std::vector<double>&       parameters,
+		                               const bool                       angles = true) const;
 
 		bool                    _phaseSpaceOnly;
 		bool                    _productionGeneratorInitialized;
-		bool                    _zeroBinWidth;
 		size_t                  _nPart;
 		static size_t           _nCalls;
 		double                  _mMin;
 		double                  _mMax;
 		std::vector<double>     _masses;
-		TF1*                    _massPrior;
+		double                  _mSum;
 		rpwa::modelIntensityPtr _model;
 		rpwa::eventFileWriter   _fileWriter;
 

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -44,8 +44,6 @@ namespace rpwa {
 
 		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
 
-		unsigned int nCalls() const { return _nCalls; }
-
 	private:
 
 		boost::tuples::tuple<bool, double, TLorentzVector, TLorentzVector> getProductionKinematics(const double mass) const;
@@ -70,7 +68,23 @@ namespace rpwa {
 		rpwa::eventFileWriter           _fileWriter;
 
 
-		static size_t                   _nCalls;
+		// function call statistics (copied from pwaLikelihood)
+	public:
+		unsigned int nCalls() const { return _funcCallInfo[LOGLIKELIHOOD].nmbCalls; }
+		void resetFuncInfo();
+		std::ostream& printFuncInfo(std::ostream& out = std::cout) const;
+	private:
+		enum functionCallEnum {
+			LOGAPRIORIPROBABILITY = 0,
+			LOGLIKELIHOOD         = 1,
+			CALCULATEOBSERVABLES  = 2,
+			NMB_FUNCTIONCALLENUM  = 3
+		};
+		struct functionCallInfo {
+			unsigned int nmbCalls;   // number of times function was called
+			double       totalTime;  // total execution time of function
+		};
+		mutable functionCallInfo        _funcCallInfo[NMB_FUNCTIONCALLENUM];
 
 
 	};

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -4,8 +4,6 @@
 #include<string>
 #include<vector>
 
-#include<TF1.h>
-
 #include<BAT/BCModel.h>
 
 #include"eventFileWriter.h"
@@ -21,54 +19,59 @@ namespace rpwa {
 	class nBodyPhaseSpaceKinematics;
 
 
+	class importanceSampler;
+	typedef boost::shared_ptr<importanceSampler> importanceSamplerPtr;
+
+
 	class importanceSampler : public BCModel {
 
 	public:
 
-		importanceSampler(const double mMin,
-		                  const double mMax,
-		                  rpwa::modelIntensityPtr model);
+		importanceSampler(rpwa::modelIntensityPtr model,
+		                  rpwa::beamAndVertexGeneratorPtr beamAndVertexGenerator,
+		                  rpwa::massAndTPrimePickerPtr massAndTPrimePicker,
+		                  const rpwa::Beam& beam,
+		                  const rpwa::Target& target,
+		                  const rpwa::FinalState& finalState);
 
 		// overload BAT methods
 		double LogAPrioriProbability(const std::vector<double>& parameters);
 		double LogLikelihood(const std::vector<double>& parameters);
 		void CalculateObservables(const std::vector<double>& parameters);
 
-		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
-
 		bool initializeFileWriter(TFile* outFile);
 		bool finalizeFileWriter();
 
-		bool initializeProductionGenerator(rpwa::Beam& beam,
-		                                   rpwa::Target& target,
-		                                   rpwa::beamAndVertexGeneratorPtr generator,
-		                                   rpwa::massAndTPrimePickerPtr picker);
+		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
 
-		std::pair<std::pair<bool,double>, std::vector<TLorentzVector> > getProductionKinematics(const double mass);
-
-		size_t nCalls() const { return _nCalls; }
+		unsigned int nCalls() const { return _nCalls; }
 
 	private:
+
+		boost::tuples::tuple<bool, double, TLorentzVector, TLorentzVector> getProductionKinematics(const double mass) const;
 
 		bool initializeNBodyPhaseSpace(rpwa::nBodyPhaseSpaceKinematics& nBodyPhaseSpace,
 		                               const std::vector<double>&       parameters,
 		                               const bool                       angles = true) const;
 
-		bool                    _phaseSpaceOnly;
-		bool                    _productionGeneratorInitialized;
-		size_t                  _nPart;
-		static size_t           _nCalls;
-		double                  _mMin;
-		double                  _mMax;
-		std::vector<double>     _masses;
-		double                  _mSum;
-		rpwa::modelIntensityPtr _model;
-		rpwa::eventFileWriter   _fileWriter;
+		rpwa::modelIntensityPtr         _model;
 
-		rpwa::Beam                      _beam;
-		rpwa::Target                    _target;
 		rpwa::beamAndVertexGeneratorPtr _beamAndVertexGenerator;
-		rpwa::massAndTPrimePickerPtr    _pickerFunction;
+		rpwa::massAndTPrimePickerPtr    _massAndTPrimePicker;
+		const rpwa::Beam                _beam;
+		const rpwa::Target              _target;
+		const rpwa::FinalState          _finalState;
+
+		const size_t                    _nPart;
+		std::vector<double>             _masses;
+		double                          _mSum;
+		bool                            _phaseSpaceOnly;
+
+		rpwa::eventFileWriter           _fileWriter;
+
+
+		static size_t                   _nCalls;
+
 
 	};
 

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -1,0 +1,79 @@
+#ifndef IMPORTANCESAMPLER_H
+#define IMPORTANCESAMPLER_H
+
+#include<string>
+#include<vector>
+
+#include<TF1.h>
+
+#include<BAT/BCModel.h>
+
+#include"eventFileWriter.h"
+#include"generator.h"
+#include"modelIntensity.h"
+
+class TFile;
+
+
+namespace rpwa {
+
+
+	class importanceSampler : public BCModel {
+
+	public:
+
+		importanceSampler(const double mMin,
+		                  const double mMax,
+		                  rpwa::modelIntensityPtr model);
+
+		bool setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; return true; }
+
+		bool setMassPrior(TF1* massPrior) { _massPrior = massPrior; return true; }
+
+		bool initializeFileWriter(TFile* outFile);
+		bool finalizeFileWriter();
+
+		double LogLikelihood(const std::vector<double>& parameters);
+		double LogAPrioriProbability(const std::vector<double>& parameters);
+
+		bool initializeProductionGenerator(rpwa::Beam& beam,
+		                                   rpwa::Target& target,
+		                                   rpwa::beamAndVertexGeneratorPtr generator,
+		                                   rpwa::massAndTPrimePickerPtr picker);
+
+		std::pair<std::pair<bool,double>, std::vector<TLorentzVector> > getProductionKinematics(const double mass);
+
+		size_t nCalls() const { return _nCalls; }
+
+		static std::pair<bool, TLorentzRotation> getInverseGJTransform(const TLorentzVector& beamLv, const TLorentzVector& XLv);
+
+	private:
+
+		std::vector<TLorentzVector> getFinalStateMomenta(const std::vector<double>& parameters) const;
+
+		void CalculateObservables(const std::vector<double>& parameters);
+
+		bool                    _phaseSpaceOnly;
+		bool                    _productionGeneratorInitialized;
+		bool                    _zeroBinWidth;
+		size_t                  _nPart;
+		static size_t           _nCalls;
+		double                  _mMin;
+		double                  _mMax;
+		std::vector<double>     _masses;
+		TF1*                    _massPrior;
+		rpwa::modelIntensityPtr _model;
+		rpwa::eventFileWriter   _fileWriter;
+
+		rpwa::Beam                      _beam;
+		rpwa::Target                    _target;
+		rpwa::beamAndVertexGeneratorPtr _beamAndVertexGenerator;
+		rpwa::massAndTPrimePickerPtr    _pickerFunction;
+
+	};
+
+
+} //namespace rpwa
+
+
+#endif // IMPORTANCESAMPLER_H

--- a/generators/importanceSampler.h
+++ b/generators/importanceSampler.h
@@ -39,7 +39,10 @@ namespace rpwa {
 		double LogLikelihood(const std::vector<double>& parameters);
 		void CalculateObservables(const std::vector<double>& parameters);
 
-		bool initializeFileWriter(TFile* outFile);
+		bool initializeFileWriter(TFile*             outFile,
+		                          const bool         storeMassAndTPrime = true,
+		                          const std::string& massVariableName   = "mass",
+		                          const std::string& tPrimeVariableName = "tPrime");
 		bool finalizeFileWriter();
 
 		void setPhaseSpaceOnly(const bool input = true) { _phaseSpaceOnly = input; }
@@ -66,6 +69,7 @@ namespace rpwa {
 		bool                            _phaseSpaceOnly;
 
 		rpwa::eventFileWriter           _fileWriter;
+		bool                            _storeMassAndTPrime;
 
 
 		// function call statistics (copied from pwaLikelihood)

--- a/generators/modelIntensity.cc
+++ b/generators/modelIntensity.cc
@@ -3,22 +3,145 @@
 #include"waveDescription.h"
 
 
-rpwa::modelIntensity::modelIntensity()
-	: _allIntsLoaded(true),
+rpwa::modelIntensity::modelIntensity(fitResultPtr fitResult)
+	: _fitResult(fitResult),
 	  _amplitudesInitialized(false),
-	  _mBeam(0.),
-	  _mTarget(0.),
-	  _target("p+"),
-	  _waveNames(),
-	  _initialStateParticles(),
-	  _finalStateParticles(),
-	  _finalStateMasses(),
-	  _prodKinMomenta(std::vector<TVector3>(1, TVector3())),
-	  _reflectivities(),
-	  _integrals(),
-	  _transitionAmplitudes(),
-	  _amplitudes()
+	  _amplitudes(fitResult->nmbWaves()),
+	  _refls(fitResult->nmbWaves(), 0),
+	  _integralsLoaded(false),
+	  _integrals(fitResult->nmbWaves()),
+	  _amplitudesFromXDecay(false)
 {
+}
+
+
+bool
+rpwa::modelIntensity::addAmplitude(rpwa::isobarAmplitudePtr amplitude)
+{
+	const std::string waveName  = waveDescription::waveNameFromTopology(*(amplitude->decayTopology()));
+	const int         waveIndex = _fitResult->waveIndex(waveName);
+	if (waveIndex == -1) {
+		printErr << "wave '" << waveName << "' not used in fit result provided. Aborting..." << std::endl;
+		return false;
+	}
+	if (_amplitudes[waveIndex]) {
+		printErr << "amplitude for wave '" << waveName << "' is added a second time. Aborting..." << std::endl;
+		return false;
+	}
+
+	_amplitudesInitialized = false;
+	_amplitudes[waveIndex] = amplitude;
+	_refls     [waveIndex] = amplitude->decayTopology()->XIsobarDecayVertex()->parent()->reflectivity();
+	_allRefls.insert(amplitude->decayTopology()->XIsobarDecayVertex()->parent()->reflectivity());
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::addIntegral(const rpwa::ampIntegralMatrix& integralMatrix)
+{
+	_integralsLoaded = false;
+	_integrals.resize(_fitResult->nmbWaves());
+
+	for (size_t wave = 0; wave < _fitResult->nmbWaves(); ++wave) {
+		const std::string& waveName = _fitResult->waveName(wave);
+		if (waveName == "flat") {
+			_integrals[wave] = 1.;
+		} else {
+			if (not integralMatrix.containsWave(waveName)) {
+				std::cout << "wave '" << waveName << "' not in the integral matrix. Aborting..." << std::endl;
+				return false;
+			}
+			const std::complex<double> integral = integralMatrix.element(waveName, waveName);
+			_integrals[wave] = std::sqrt(integral.real());
+		}
+	}
+
+	_integralsLoaded = true;
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::initAmplitudes(const std::vector<std::string>& decayKinParticleNames)
+{
+	// get X name from first amplitude
+	std::vector<std::string> prodKinParticleNames(1);
+	for (size_t wave = 0; wave < _fitResult->nmbWaves(); ++wave) {
+		const std::string& waveName = _fitResult->waveName(wave);
+		// no amplitude for 'flat' wave
+		if (waveName == "flat") {
+			if (_amplitudes[wave]) {
+				printErr << "amplitude for flat wave was added. Aborting..." << std::endl;
+				return false;
+			}
+			continue;
+		}
+		if (not _amplitudes[wave]) {
+			printErr << "amplitude for wave '" << waveName << "' was not added. Aborting..." << std::endl;
+			return false;
+		}
+
+		const isobarDecayTopologyPtr decay  = _amplitudes[wave]->decayTopology();
+		const isobarDecayVertexPtr   vertex = decay->XIsobarDecayVertex();
+		prodKinParticleNames[0] = vertex->parent()->name();
+		break;
+	}
+
+	return initAmplitudes(prodKinParticleNames, decayKinParticleNames, true);
+}
+
+
+bool
+rpwa::modelIntensity::initAmplitudes(const std::vector<std::string>& prodKinParticleNames,
+                                     const std::vector<std::string>& decayKinParticleNames,
+                                     const bool                      fromXDecay)
+{
+	_amplitudesInitialized = false;
+	_amplitudesFromXDecay  = fromXDecay;
+
+	for (size_t wave = 0; wave < _fitResult->nmbWaves(); ++wave) {
+		const std::string& waveName = _fitResult->waveName(wave);
+		// no amplitude for 'flat' wave
+		if (waveName == "flat") {
+			if (_amplitudes[wave]) {
+				printErr << "amplitude for flat wave was added. Aborting..." << std::endl;
+				return false;
+			}
+			continue;
+		}
+		if (not _amplitudes[wave]) {
+			printErr << "amplitude for wave '" << waveName << "' was not added. Aborting..." << std::endl;
+			return false;
+		}
+
+		// start amplitude from X decay
+		if (_amplitudesFromXDecay) {
+			const isobarDecayTopologyPtr decay  = _amplitudes[wave]->decayTopology();
+			const isobarDecayVertexPtr   vertex = decay->XIsobarDecayVertex();
+			_amplitudes[wave]->setDecayTopology(rpwa::createIsobarDecayTopology(decay->subDecayConsistent(vertex)));
+		}
+		_amplitudes[wave]->init();
+		if (not _amplitudes[wave]->decayTopology()->initKinematicsData(prodKinParticleNames, decayKinParticleNames)) {
+			printErr << "could not initialize kinematics data for amplitude of wave '" << waveName << "'. Aborting..." << std::endl;
+			return false;
+		}
+	}
+
+	_amplitudesInitialized = true;
+	return true;
+}
+
+
+double
+rpwa::modelIntensity::getIntensity(const std::vector<TVector3>& decayKinMomenta) const
+{
+	if (not _amplitudesFromXDecay) {
+		printErr << "amplitudes not starting from X decay, but not production kinematics provided. Aborting..." << std::endl;
+		throw;
+	}
+
+	return getIntensity(std::vector<TVector3>(1), decayKinMomenta);
 }
 
 
@@ -26,16 +149,22 @@ double
 rpwa::modelIntensity::getIntensity(const std::vector<TVector3>& prodKinMomenta,
                                    const std::vector<TVector3>& decayKinMomenta) const
 {
-	std::vector<std::complex<double> > amplitudes = getAmplitudes(prodKinMomenta, decayKinMomenta);
-	double retVal = 0.;
-	for (size_t incoherentSubAmplitude = 0; incoherentSubAmplitude < amplitudes.size(); ++incoherentSubAmplitude) {
-		retVal += std::norm(amplitudes[incoherentSubAmplitude]);
+	const std::vector<std::complex<double> > amplitudes = getAmplitudes(prodKinMomenta, decayKinMomenta);
+
+	std::vector<unsigned int> waveIndices; for (unsigned int i=0; i<_amplitudes.size()-1; ++i) waveIndices.push_back(i);
+	double intensity = 0;
+	for (std::set<int>::const_iterator it=_allRefls.begin(); it!=_allRefls.end(); ++it) {
+		std::complex<double> amp = 0;
+		for (size_t i=0; i<waveIndices.size(); ++i) {
+			const unsigned int waveIndex = waveIndices[i];
+			if (_refls[waveIndex] == *it) {
+				amp += _fitResult->prodAmp(waveIndex) * amplitudes[waveIndex];
+			}
+		}
+		intensity += std::norm(amp);
 	}
-	if (std::isnan(retVal)) {
-		printErr << "NaN intensity encountered" << std::endl;
-		throw;
-	}
-	return retVal;
+
+	return intensity;
 }
 
 
@@ -43,199 +172,44 @@ std::vector<std::complex<double> >
 rpwa::modelIntensity::getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
                                     const std::vector<TVector3>& decayKinMomenta) const
 {
-	std::vector<std::complex<double> > retVal(2, std::complex<double>(0., 0.)); // at the moment use only positive and negative reflectivity as incoherernt amplitudes (means rank = 1)
-	if (!_allIntsLoaded) {
-		printErr << "integrals not loaded, can't evaluate model" << std::endl;
+	if (not _amplitudesInitialized) {
+		printErr << "amplitudes not initialized, cannot evaluate model. Aborting..." << std::endl;
 		throw;
 	}
-	if (!_amplitudesInitialized) {
-		printErr << "amplitudes not initialized, can't evaluate model" << std::endl;
+	if (not _integralsLoaded) {
+		printErr << "integrals not loaded, cannot evaluate model. Aborting..." << std::endl;
 		throw;
 	}
-	for (size_t amp = 0; amp < _amplitudes.size(); ++amp) {
-		if (!_amplitudes[amp]->decayTopology()->readKinematicsData(prodKinMomenta, decayKinMomenta)) {
-			printErr << "could not readKinematicsData() for wave: " << _waveNames[amp] << std::endl;
+
+	std::vector<std::complex<double> > amplitudes(_amplitudes.size());
+	for (size_t wave = 0; wave < _fitResult->nmbWaves(); ++wave) {
+		// 'flat' wave
+		if (not _amplitudes[wave]) {
+			amplitudes[wave] = 1. / _integrals[wave];
+			continue;
+		}
+
+		if (not _amplitudes[wave]->decayTopology()->readKinematicsData(prodKinMomenta, decayKinMomenta)) {
+			printErr << "could not read kinematics data for wave '" << _fitResult->waveName(wave) << "'. Aborting..." << std::endl;
 			throw;
 		}
-		const std::complex<double> amplitude = (_amplitudes[amp])->amplitude() * _transitionAmplitudes[amp] / _integrals[amp];
-		if (_reflectivities[amp] > 0) {
-			retVal[0] += amplitude;
-		} else {
-			retVal[1] += amplitude;
-		}
+		amplitudes[wave] = _amplitudes[wave]->amplitude() / _integrals[wave];
 	}
-	return retVal;
+	return amplitudes;
 }
 
 
-bool
-rpwa::modelIntensity::setParticles(const std::vector<std::string>& initialState,
-                                   const std::vector<std::string>& finalState)
+std::ostream&
+rpwa::modelIntensity::print(std::ostream& out) const
 {
-	if (_finalStateMasses.size() != 0 && _finalStateMasses.size() != finalState.size()) {
-		printErr << "number of final state particles does not match number of final state masses" << std::endl;
-		return false;
+	out << "status of model intensity object:" << std::endl
+	    << "    number of waves ........... " << _fitResult->nmbWaves() << std::endl
+	    << "    wave names" << std::endl;
+	for (size_t wave = 0; wave < _fitResult->nmbWaves(); ++wave) {
+		out << "                                " << _fitResult->waveName(wave) << std::endl;
 	}
-	_initialStateParticles = initialState;
-	_finalStateParticles   = finalState;
-	return true;
-}
-
-
-bool
-rpwa::modelIntensity::setFinalStateMasses(const std::vector<double>& masses)
-{
-	_finalStateMasses = masses;
-	if (_finalStateParticles.size() != 0 && _finalStateParticles.size() != masses.size()) {
-		printErr << "number of masses given does not match" << std::endl;
-		return false;
-	}
-	return true;
-}
-
-
-bool
-rpwa::modelIntensity::addAmplitude(const std::complex<double> transitionAmplitude,
-                                   rpwa::isobarAmplitudePtr   amplitude,
-                                   const int                  reflectivity)
-{
-	_amplitudesInitialized = false;
-	if (reflectivity != 1 && reflectivity != -1) {
-		printErr << "reflectivity != +-1 (" << reflectivity << "). Aborting..." << std::endl;
-		return false;
-	}
-	if (_initialStateParticles.size() == 0 && _finalStateParticles.size() == 0) {
-		const std::vector<particlePtr>& finalStateparticles = amplitude->decayTopology()->fsParticles();
-		std::vector<double> finalStateMasses;
-		std::vector<std::string> finalStateParticles;
-		if (finalStateparticles.size() == 0) {
-			printErr << "not final state particles found" << std::endl;
-			return false;
-		}
-		for (size_t part = 0; part < finalStateparticles.size(); ++part) {
-			finalStateMasses.push_back(finalStateparticles[part]->mass());
-			finalStateParticles.push_back(finalStateparticles[part]->name());
-		}
-		const std::vector<particlePtr>& inParticles = amplitude->decayTopology()->productionVertex()->inParticles();
-		double beamMass = 0.;
-		std::vector<std::string> initialStateNames;
-		if (inParticles.size() == 0) {
-			printErr << "no initial state particles found" << std::endl;
-			return false;
-		}
-		for (size_t part = 0; part < inParticles.size(); ++part) {
-			const std::string partName = inParticles[part]->name();
-			if (partName == _target) {
-				if (!setMtarget(inParticles[part]->mass())) {
-					printErr << "could not set target mass" << std::endl;
-				}
-				continue;
-			}
-			beamMass = inParticles[part]->mass();
-			initialStateNames.push_back(partName);
-		}
-		if (!setParticles(initialStateNames, finalStateParticles)) {
-			printErr << "could not set particles" << std::endl;
-			return false;
-		}
-		if (!setFinalStateMasses(finalStateMasses)) {
-			printErr << "could not set final state masses" << std::endl;
-			return false;
-		}
-		if (!setMbeam(beamMass)) {
-			printErr << "could not set mBeam" << std::endl;
-			return false;
-		}
-	}
-	_allIntsLoaded = false;
-	_waveNames.push_back(waveDescription::waveNameFromTopology(*(amplitude->decayTopology())));
-	_reflectivities.push_back(reflectivity);
-	_transitionAmplitudes.push_back(transitionAmplitude);
-	_amplitudes.push_back(amplitude);
-	return true;
-}
-
-
-bool
-rpwa::modelIntensity::loadIntegrals(const rpwa::ampIntegralMatrix& integralMatrix)
-{
-	std::vector<double> integrals;
-	const unsigned long nmbEvents = integralMatrix.nmbEvents();
-	for (size_t wn = 0; wn < _waveNames.size(); ++wn) {
-		if (!integralMatrix.containsWave(_waveNames[wn])) {
-			std::cout << "wave '" << wn << "' not in the integral matrix. Aborting..." << std::endl;
-			return false;
-		}
-		const std::complex<double> integral = integralMatrix.element(_waveNames[wn], _waveNames[wn]);
-		integrals.push_back(std::sqrt(integral.real()*nmbEvents));
-	}
-	if (integrals.size() != _amplitudes.size()) {
-		printErr << "integral.size() != _amplitudes.size(). Aborting..." << std::endl;
-		return false;
-	}
-	_integrals = integrals;
-	_allIntsLoaded = true;
-	return true;
-}
-
-
-bool
-rpwa::modelIntensity::setProdKinMomenta(const std::vector<TVector3>& prodKinMomenta)
-{
-	if (_initialStateParticles.size() != 0 && _initialStateParticles.size() != prodKinMomenta.size()) {
-		printErr << "prodKinMomenta.size() = " << prodKinMomenta.size() << " != _initialStateParticles.size() = " << _initialStateParticles.size() << ". Aborting..." << std::endl;
-		return false;
-	}
-	_prodKinMomenta = prodKinMomenta;
-	return true;
-}
-
-
-bool
-rpwa::modelIntensity::initAmplitudes(const bool fromXdecay)
-{
-	std::vector<std::string> initialStateParticles = _initialStateParticles;
-	for (size_t amp = 0; amp < _amplitudes.size(); ++amp) {
-		if (fromXdecay) {
-			_amplitudes[amp]->setDecayTopology(rpwa::createIsobarDecayTopology(_amplitudes[amp]->decayTopology()->subDecayConsistent(_amplitudes[amp]->decayTopology()->XIsobarDecayVertex())));
-			initialStateParticles = std::vector<std::string>(1, "X-");
-		}
-		_amplitudes[amp]->init();
-		if (!_amplitudes[amp]->decayTopology()->initKinematicsData(initialStateParticles, _finalStateParticles)) {
-			printErr << "could not initKinematicsData()" << std::endl;
-			return false;
-		}
-	}
-	_amplitudesInitialized = true;
-	return true;
-}
-
-
-void
-rpwa::modelIntensity::print() const
-{
-	std::cout << "status of modelIntensity" << std::endl;
-	std::cout << "  waveNames:" << std::endl;
-	for (size_t i = 0; i < _waveNames.size(); ++i) {
-		std::cout << "   - " << _waveNames[i] << std::endl;
-	}
-	std::cout << "  initial particles" << std::endl;
-	for (size_t i = 0; i < _initialStateParticles.size(); ++i) {
-		std::cout << "   - " << _initialStateParticles[i] << std::endl;
-	}
-	std::cout << "  final particles" << std::endl;
-	for (size_t i = 0; i < _finalStateParticles.size(); ++i) {
-		std::cout << "   - " << _finalStateParticles[i] << std::endl;
-	}
-}
-
-
-const std::string&
-rpwa::modelIntensity::finalStateParticleName(const size_t particleIndex) const
-{
-	if (particleIndex >= nFinalState()) {
-		printErr << "particle index " << particleIndex << " exceeds number of final state particles " << nFinalState() << std::endl;
-		throw;
-	}
-	return _finalStateParticles[particleIndex];
+	out << "    amplitudes initialized .... " << yesNo(_amplitudesInitialized) << std::endl
+	    << "    integrals loaded .......... " << yesNo(_integralsLoaded) << std::endl
+	    << "    amplitudes from X decay ... " << yesNo(_amplitudesFromXDecay) << std::endl;
+	return out;
 }

--- a/generators/modelIntensity.cc
+++ b/generators/modelIntensity.cc
@@ -12,6 +12,11 @@ rpwa::modelIntensity::modelIntensity(fitResultPtr fitResult)
 	  _integrals(fitResult->nmbWaves()),
 	  _amplitudesFromXDecay(false)
 {
+	// use the phase-space integrals from fit result if available
+	if (fitResult->phaseSpaceIntegralVector().size() == fitResult->nmbWaves()) {
+		_integralsLoaded = true;
+		_integrals       = fitResult->phaseSpaceIntegralVector();
+	}
 }
 
 

--- a/generators/modelIntensity.cc
+++ b/generators/modelIntensity.cc
@@ -1,0 +1,241 @@
+#include"modelIntensity.h"
+#include"ampIntegralMatrix.h"
+#include"waveDescription.h"
+
+
+rpwa::modelIntensity::modelIntensity()
+	: _allIntsLoaded(true),
+	  _amplitudesInitialized(false),
+	  _mBeam(0.),
+	  _mTarget(0.),
+	  _target("p+"),
+	  _waveNames(),
+	  _initialStateParticles(),
+	  _finalStateParticles(),
+	  _finalStateMasses(),
+	  _prodKinMomenta(std::vector<TVector3>(1, TVector3())),
+	  _reflectivities(),
+	  _integrals(),
+	  _transitionAmplitudes(),
+	  _amplitudes()
+{
+}
+
+
+double
+rpwa::modelIntensity::getIntensity(const std::vector<TVector3>& prodKinMomenta,
+                                   const std::vector<TVector3>& decayKinMomenta) const
+{
+	std::vector<std::complex<double> > amplitudes = getAmplitudes(prodKinMomenta, decayKinMomenta);
+	double retVal = 0.;
+	for (size_t incoherentSubAmplitude = 0; incoherentSubAmplitude < amplitudes.size(); ++incoherentSubAmplitude) {
+		retVal += std::norm(amplitudes[incoherentSubAmplitude]);
+	}
+	if (std::isnan(retVal)) {
+		printErr << "NaN intensity encountered" << std::endl;
+		throw;
+	}
+	return retVal;
+}
+
+
+std::vector<std::complex<double> >
+rpwa::modelIntensity::getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
+                                    const std::vector<TVector3>& decayKinMomenta) const
+{
+	std::vector<std::complex<double> > retVal(2, std::complex<double>(0., 0.)); // at the moment use only positive and negative reflectivity as incoherernt amplitudes (means rank = 1)
+	if (!_allIntsLoaded) {
+		printErr << "integrals not loaded, can't evaluate model" << std::endl;
+		throw;
+	}
+	if (!_amplitudesInitialized) {
+		printErr << "amplitudes not initialized, can't evaluate model" << std::endl;
+		throw;
+	}
+	for (size_t amp = 0; amp < _amplitudes.size(); ++amp) {
+		if (!_amplitudes[amp]->decayTopology()->readKinematicsData(prodKinMomenta, decayKinMomenta)) {
+			printErr << "could not readKinematicsData() for wave: " << _waveNames[amp] << std::endl;
+			throw;
+		}
+		const std::complex<double> amplitude = (_amplitudes[amp])->amplitude() * _transitionAmplitudes[amp] / _integrals[amp];
+		if (_reflectivities[amp] > 0) {
+			retVal[0] += amplitude;
+		} else {
+			retVal[1] += amplitude;
+		}
+	}
+	return retVal;
+}
+
+
+bool
+rpwa::modelIntensity::setParticles(const std::vector<std::string>& initialState,
+                                   const std::vector<std::string>& finalState)
+{
+	if (_finalStateMasses.size() != 0 && _finalStateMasses.size() != finalState.size()) {
+		printErr << "number of final state particles does not match number of final state masses" << std::endl;
+		return false;
+	}
+	_initialStateParticles = initialState;
+	_finalStateParticles   = finalState;
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::setFinalStateMasses(const std::vector<double>& masses)
+{
+	_finalStateMasses = masses;
+	if (_finalStateParticles.size() != 0 && _finalStateParticles.size() != masses.size()) {
+		printErr << "number of masses given does not match" << std::endl;
+		return false;
+	}
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::addAmplitude(const std::complex<double> transitionAmplitude,
+                                   rpwa::isobarAmplitudePtr   amplitude,
+                                   const int                  reflectivity)
+{
+	_amplitudesInitialized = false;
+	if (reflectivity != 1 && reflectivity != -1) {
+		printErr << "reflectivity != +-1 (" << reflectivity << "). Aborting..." << std::endl;
+		return false;
+	}
+	if (_initialStateParticles.size() == 0 && _finalStateParticles.size() == 0) {
+		const std::vector<particlePtr>& finalStateparticles = amplitude->decayTopology()->fsParticles();
+		std::vector<double> finalStateMasses;
+		std::vector<std::string> finalStateParticles;
+		if (finalStateparticles.size() == 0) {
+			printErr << "not final state particles found" << std::endl;
+			return false;
+		}
+		for (size_t part = 0; part < finalStateparticles.size(); ++part) {
+			finalStateMasses.push_back(finalStateparticles[part]->mass());
+			finalStateParticles.push_back(finalStateparticles[part]->name());
+		}
+		const std::vector<particlePtr>& inParticles = amplitude->decayTopology()->productionVertex()->inParticles();
+		double beamMass = 0.;
+		std::vector<std::string> initialStateNames;
+		if (inParticles.size() == 0) {
+			printErr << "no initial state particles found" << std::endl;
+			return false;
+		}
+		for (size_t part = 0; part < inParticles.size(); ++part) {
+			const std::string partName = inParticles[part]->name();
+			if (partName == _target) {
+				if (!setMtarget(inParticles[part]->mass())) {
+					printErr << "could not set target mass" << std::endl;
+				}
+				continue;
+			}
+			beamMass = inParticles[part]->mass();
+			initialStateNames.push_back(partName);
+		}
+		if (!setParticles(initialStateNames, finalStateParticles)) {
+			printErr << "could not set particles" << std::endl;
+			return false;
+		}
+		if (!setFinalStateMasses(finalStateMasses)) {
+			printErr << "could not set final state masses" << std::endl;
+			return false;
+		}
+		if (!setMbeam(beamMass)) {
+			printErr << "could not set mBeam" << std::endl;
+			return false;
+		}
+	}
+	_allIntsLoaded = false;
+	_waveNames.push_back(waveDescription::waveNameFromTopology(*(amplitude->decayTopology())));
+	_reflectivities.push_back(reflectivity);
+	_transitionAmplitudes.push_back(transitionAmplitude);
+	_amplitudes.push_back(amplitude);
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::loadIntegrals(const rpwa::ampIntegralMatrix& integralMatrix)
+{
+	std::vector<double> integrals;
+	const unsigned long nmbEvents = integralMatrix.nmbEvents();
+	for (size_t wn = 0; wn < _waveNames.size(); ++wn) {
+		if (!integralMatrix.containsWave(_waveNames[wn])) {
+			std::cout << "wave '" << wn << "' not in the integral matrix. Aborting..." << std::endl;
+			return false;
+		}
+		const std::complex<double> integral = integralMatrix.element(_waveNames[wn], _waveNames[wn]);
+		integrals.push_back(std::sqrt(integral.real()*nmbEvents));
+	}
+	if (integrals.size() != _amplitudes.size()) {
+		printErr << "integral.size() != _amplitudes.size(). Aborting..." << std::endl;
+		return false;
+	}
+	_integrals = integrals;
+	_allIntsLoaded = true;
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::setProdKinMomenta(const std::vector<TVector3>& prodKinMomenta)
+{
+	if (_initialStateParticles.size() != 0 && _initialStateParticles.size() != prodKinMomenta.size()) {
+		printErr << "prodKinMomenta.size() = " << prodKinMomenta.size() << " != _initialStateParticles.size() = " << _initialStateParticles.size() << ". Aborting..." << std::endl;
+		return false;
+	}
+	_prodKinMomenta = prodKinMomenta;
+	return true;
+}
+
+
+bool
+rpwa::modelIntensity::initAmplitudes(const bool fromXdecay)
+{
+	std::vector<std::string> initialStateParticles = _initialStateParticles;
+	for (size_t amp = 0; amp < _amplitudes.size(); ++amp) {
+		if (fromXdecay) {
+			_amplitudes[amp]->setDecayTopology(rpwa::createIsobarDecayTopology(_amplitudes[amp]->decayTopology()->subDecayConsistent(_amplitudes[amp]->decayTopology()->XIsobarDecayVertex())));
+			initialStateParticles = std::vector<std::string>(1, "X-");
+		}
+		_amplitudes[amp]->init();
+		if (!_amplitudes[amp]->decayTopology()->initKinematicsData(initialStateParticles, _finalStateParticles)) {
+			printErr << "could not initKinematicsData()" << std::endl;
+			return false;
+		}
+	}
+	_amplitudesInitialized = true;
+	return true;
+}
+
+
+void
+rpwa::modelIntensity::print() const
+{
+	std::cout << "status of modelIntensity" << std::endl;
+	std::cout << "  waveNames:" << std::endl;
+	for (size_t i = 0; i < _waveNames.size(); ++i) {
+		std::cout << "   - " << _waveNames[i] << std::endl;
+	}
+	std::cout << "  initial particles" << std::endl;
+	for (size_t i = 0; i < _initialStateParticles.size(); ++i) {
+		std::cout << "   - " << _initialStateParticles[i] << std::endl;
+	}
+	std::cout << "  final particles" << std::endl;
+	for (size_t i = 0; i < _finalStateParticles.size(); ++i) {
+		std::cout << "   - " << _finalStateParticles[i] << std::endl;
+	}
+}
+
+
+const std::string&
+rpwa::modelIntensity::finalStateParticleName(const size_t particleIndex) const
+{
+	if (particleIndex >= nFinalState()) {
+		printErr << "particle index " << particleIndex << " exceeds number of final state particles " << nFinalState() << std::endl;
+		throw;
+	}
+	return _finalStateParticles[particleIndex];
+}

--- a/generators/modelIntensity.cc
+++ b/generators/modelIntensity.cc
@@ -17,6 +17,8 @@ rpwa::modelIntensity::modelIntensity(fitResultPtr fitResult)
 		_integralsLoaded = true;
 		_integrals       = fitResult->phaseSpaceIntegralVector();
 	}
+
+	_waveIndicesWithoutFlat = fitResult->waveIndicesMatchingPattern("^(?!flat$).*$");
 }
 
 
@@ -139,24 +141,12 @@ rpwa::modelIntensity::initAmplitudes(const std::vector<std::string>& prodKinPart
 
 
 double
-rpwa::modelIntensity::getIntensity(const std::vector<TVector3>& decayKinMomenta) const
-{
-	if (not _amplitudesFromXDecay) {
-		printErr << "amplitudes not starting from X decay, but not production kinematics provided. Aborting..." << std::endl;
-		throw;
-	}
-
-	return getIntensity(std::vector<TVector3>(1), decayKinMomenta);
-}
-
-
-double
-rpwa::modelIntensity::getIntensity(const std::vector<TVector3>& prodKinMomenta,
-                                   const std::vector<TVector3>& decayKinMomenta) const
+rpwa::modelIntensity::getIntensity(const std::vector<unsigned int>& waveIndices,
+                                   const std::vector<TVector3>&     prodKinMomenta,
+                                   const std::vector<TVector3>&     decayKinMomenta) const
 {
 	const std::vector<std::complex<double> > amplitudes = getAmplitudes(prodKinMomenta, decayKinMomenta);
 
-	std::vector<unsigned int> waveIndices; for (unsigned int i=0; i<_amplitudes.size()-1; ++i) waveIndices.push_back(i);
 	double intensity = 0;
 	for (std::set<int>::const_iterator it=_allRefls.begin(); it!=_allRefls.end(); ++it) {
 		std::complex<double> amp = 0;

--- a/generators/modelIntensity.h
+++ b/generators/modelIntensity.h
@@ -28,19 +28,19 @@ namespace rpwa {
 
 		modelIntensity(fitResultPtr fitResult);
 
-		bool addAmplitude(isobarAmplitudePtr             amplitude);
-		bool addIntegral (const rpwa::ampIntegralMatrix& integralMatrix);
+		bool addDecayAmplitude     (isobarAmplitudePtr             decayAmplitude);
+		bool loadPhaseSpaceIntegral(const rpwa::ampIntegralMatrix& integralMatrix);
 
-		// initialize amplitudes starting from X decay
-		bool initAmplitudes(const std::vector<std::string>& decayKinParticleNames);
+		// initialize decay amplitudes starting from X decay
+		bool initDecayAmplitudes(const std::vector<std::string>& decayKinParticleNames);
 
-		bool initAmplitudes(const std::vector<std::string>& prodKinParticleNames,
-		                    const std::vector<std::string>& decayKinParticleNames,
-		                    const bool                      fromXDecay = false);
+		bool initDecayAmplitudes(const std::vector<std::string>& prodKinParticleNames,
+		                         const std::vector<std::string>& decayKinParticleNames,
+		                         const bool                      fromXDecay = false);
 
 		// get intensity of all waves except flat wave
 
-		// get intensity if amplitudes have been initialized to start from X decay
+		// get intensity if decay amplitudes have been initialized to start from X decay
 		double getIntensity(const std::vector<TVector3>& decayKinMomenta) const;
 
 		double getIntensity(const std::vector<TVector3>& prodKinMomenta,
@@ -48,7 +48,7 @@ namespace rpwa {
 
 		// get intensity for set of waves
 
-		// get intensity if amplitudes have been initialized to start from X decay
+		// get intensity if decay amplitudes have been initialized to start from X decay
 		double getIntensity(const std::vector<unsigned int>& waveIndices,
 		                    const std::vector<TVector3>&     decayKinMomenta) const;
 
@@ -62,21 +62,21 @@ namespace rpwa {
 
 	private:
 
-		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
-		                                                 const std::vector<TVector3>& decayKinMomenta) const;
+		std::vector<std::complex<double> > getDecayAmplitudes(const std::vector<TVector3>& prodKinMomenta,
+		                                                      const std::vector<TVector3>& decayKinMomenta) const;
 
 		fitResultPtr                       _fitResult;
 		std::vector<unsigned int>          _waveIndicesWithoutFlat;
 
-		bool                               _amplitudesInitialized;
-		std::vector<isobarAmplitudePtr>    _amplitudes;
+		bool                               _decayAmplitudesInitialized;
+		std::vector<isobarAmplitudePtr>    _decayAmplitudes;
 		std::vector<int>                   _refls;
 		std::set<int>                      _allRefls;
 
-		bool                               _integralsLoaded;
-		std::vector<double>                _integrals;
+		bool                               _phaseSpaceIntegralsLoaded;
+		std::vector<double>                _phaseSpaceIntegrals;
 
-		bool                               _amplitudesFromXDecay;
+		bool                               _decayAmplitudesFromXDecay;
 
 	};
 
@@ -103,8 +103,8 @@ namespace rpwa {
 	modelIntensity::getIntensity(const std::vector<unsigned int>& waveIndices,
 	                             const std::vector<TVector3>&     decayKinMomenta) const
 	{
-		if (not _amplitudesFromXDecay) {
-			printErr << "amplitudes not starting from X decay, but not production kinematics provided. Aborting..." << std::endl;
+		if (not _decayAmplitudesFromXDecay) {
+			printErr << "decay amplitudes are not starting from X decay, but no production kinematics provided. Aborting..." << std::endl;
 			throw;
 		}
 

--- a/generators/modelIntensity.h
+++ b/generators/modelIntensity.h
@@ -1,0 +1,89 @@
+#ifndef MODELINTENSITY_H
+#define MODELINTENSITY_H
+
+
+#include<complex>
+#include<vector>
+
+#include<boost/shared_ptr.hpp>
+
+#include<TVector3.h>
+
+#include"isobarAmplitude.h"
+
+
+namespace rpwa {
+
+
+	class ampIntegralMatrix;
+	class modelIntensity;
+	typedef boost::shared_ptr<modelIntensity> modelIntensityPtr;
+
+
+	class modelIntensity {
+
+	public:
+
+		modelIntensity();
+
+		double getIntensity(const std::vector<TVector3>& prodKinMomenta,
+		                    const std::vector<TVector3>& decayKinMomenta) const;
+		double getIntensity(const std::vector<TVector3>& decayKinMomenta) const { return getIntensity(_prodKinMomenta, decayKinMomenta); }
+
+		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
+		                                                 const std::vector<TVector3>& decayKinMomenta) const;
+		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& decayKinMomenta) const { return getAmplitudes(_prodKinMomenta, decayKinMomenta); }
+
+		bool addAmplitude(const std::complex<double> transitionAmplitude,
+		                  isobarAmplitudePtr amplitude,
+		                  const int reflectivity = 1);
+		bool loadIntegrals(const rpwa::ampIntegralMatrix& integrals);
+		bool setProdKinMomenta(const std::vector<TVector3>& prodKinMomenta);
+		bool initAmplitudes(const bool fromXdecay = true);
+
+		bool setTarget(const std::string& target) { _target = target; return true; }
+
+		double mBeam() const { return _mBeam; }
+		double mTarget() const { return _mTarget; }
+
+		size_t nFinalState() const { return _finalStateParticles.size(); }
+		const std::string& finalStateParticleName(const size_t particleIndex) const;
+		const std::string& tagetParticleName() const { return _target; }
+
+		const std::vector<double>& finalStateMasses() const { return _finalStateMasses; }
+		void print() const;
+
+		bool setMbeam(const double mass) { _mBeam = mass; return true; }
+		bool setMtarget(const double mass) { _mTarget = mass; return true; }
+		bool setFinalStateMasses(const std::vector<double>& masses);
+		bool setParticles(const std::vector<std::string>& initialState,
+		                  const std::vector<std::string>& finalState);
+
+		const std::vector<std::string>& initialStateParticles() const { return _initialStateParticles; }
+		const std::vector<std::string>& finalStateParticles() const { return _finalStateParticles; }
+
+	private:
+
+		bool                               _allIntsLoaded;
+		bool                               _amplitudesInitialized;
+		double                             _mBeam;
+		double                             _mTarget;
+		std::string                        _target;
+		std::vector<std::string>           _waveNames;
+		std::vector<std::string>           _initialStateParticles;
+		std::vector<std::string>           _finalStateParticles;
+		std::vector<double>                _finalStateMasses;
+
+		std::vector<TVector3>              _prodKinMomenta;
+		std::vector<int>                   _reflectivities;
+		std::vector<double>                _integrals;
+		std::vector<std::complex<double> > _transitionAmplitudes;
+		std::vector<isobarAmplitudePtr>    _amplitudes;
+
+	};
+
+
+} // namespace rpwa
+
+
+#endif // MODELINTENSITY_H

--- a/generators/modelIntensity.h
+++ b/generators/modelIntensity.h
@@ -10,12 +10,14 @@
 #include<TVector3.h>
 
 #include"isobarAmplitude.h"
+#include"fitResult.h"
 
 
 namespace rpwa {
 
 
 	class ampIntegralMatrix;
+
 	class modelIntensity;
 	typedef boost::shared_ptr<modelIntensity> modelIntensityPtr;
 
@@ -24,61 +26,44 @@ namespace rpwa {
 
 	public:
 
-		modelIntensity();
+		modelIntensity(fitResultPtr fitResult);
+
+		bool addAmplitude(isobarAmplitudePtr             amplitude);
+		bool addIntegral (const rpwa::ampIntegralMatrix& integralMatrix);
+
+		// initialize amplitudes starting from X decay
+		bool initAmplitudes(const std::vector<std::string>& decayKinParticleNames);
+
+		bool initAmplitudes(const std::vector<std::string>& prodKinParticleNames,
+		                    const std::vector<std::string>& decayKinParticleNames,
+		                    const bool                      fromXDecay = false);
+
+		// get intensity if amplitudes have been initialized to start from X decay
+		double getIntensity(const std::vector<TVector3>& decayKinMomenta) const;
 
 		double getIntensity(const std::vector<TVector3>& prodKinMomenta,
 		                    const std::vector<TVector3>& decayKinMomenta) const;
-		double getIntensity(const std::vector<TVector3>& decayKinMomenta) const { return getIntensity(_prodKinMomenta, decayKinMomenta); }
 
-		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
-		                                                 const std::vector<TVector3>& decayKinMomenta) const;
-		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& decayKinMomenta) const { return getAmplitudes(_prodKinMomenta, decayKinMomenta); }
-
-		bool addAmplitude(const std::complex<double> transitionAmplitude,
-		                  isobarAmplitudePtr amplitude,
-		                  const int reflectivity = 1);
-		bool loadIntegrals(const rpwa::ampIntegralMatrix& integrals);
-		bool setProdKinMomenta(const std::vector<TVector3>& prodKinMomenta);
-		bool initAmplitudes(const bool fromXdecay = true);
-
-		bool setTarget(const std::string& target) { _target = target; return true; }
-
-		double mBeam() const { return _mBeam; }
-		double mTarget() const { return _mTarget; }
-
-		size_t nFinalState() const { return _finalStateParticles.size(); }
-		const std::string& finalStateParticleName(const size_t particleIndex) const;
-		const std::string& tagetParticleName() const { return _target; }
-
-		const std::vector<double>& finalStateMasses() const { return _finalStateMasses; }
-		void print() const;
-
-		bool setMbeam(const double mass) { _mBeam = mass; return true; }
-		bool setMtarget(const double mass) { _mTarget = mass; return true; }
-		bool setFinalStateMasses(const std::vector<double>& masses);
-		bool setParticles(const std::vector<std::string>& initialState,
-		                  const std::vector<std::string>& finalState);
-
-		const std::vector<std::string>& initialStateParticles() const { return _initialStateParticles; }
-		const std::vector<std::string>& finalStateParticles() const { return _finalStateParticles; }
+		std::ostream& print(std::ostream& out = std::cout) const;
+		friend std::ostream& operator << (std::ostream&         out,
+		                                  const modelIntensity& model) { return model.print(out); }
 
 	private:
 
-		bool                               _allIntsLoaded;
-		bool                               _amplitudesInitialized;
-		double                             _mBeam;
-		double                             _mTarget;
-		std::string                        _target;
-		std::vector<std::string>           _waveNames;
-		std::vector<std::string>           _initialStateParticles;
-		std::vector<std::string>           _finalStateParticles;
-		std::vector<double>                _finalStateMasses;
+		std::vector<std::complex<double> > getAmplitudes(const std::vector<TVector3>& prodKinMomenta,
+		                                                 const std::vector<TVector3>& decayKinMomenta) const;
 
-		std::vector<TVector3>              _prodKinMomenta;
-		std::vector<int>                   _reflectivities;
-		std::vector<double>                _integrals;
-		std::vector<std::complex<double> > _transitionAmplitudes;
+		fitResultPtr                       _fitResult;
+
+		bool                               _amplitudesInitialized;
 		std::vector<isobarAmplitudePtr>    _amplitudes;
+		std::vector<int>                   _refls;
+		std::set<int>                      _allRefls;
+
+		bool                               _integralsLoaded;
+		std::vector<double>                _integrals;
+
+		bool                               _amplitudesFromXDecay;
 
 	};
 

--- a/generators/modelIntensity.h
+++ b/generators/modelIntensity.h
@@ -38,11 +38,23 @@ namespace rpwa {
 		                    const std::vector<std::string>& decayKinParticleNames,
 		                    const bool                      fromXDecay = false);
 
+		// get intensity of all waves except flat wave
+
 		// get intensity if amplitudes have been initialized to start from X decay
 		double getIntensity(const std::vector<TVector3>& decayKinMomenta) const;
 
 		double getIntensity(const std::vector<TVector3>& prodKinMomenta,
 		                    const std::vector<TVector3>& decayKinMomenta) const;
+
+		// get intensity for set of waves
+
+		// get intensity if amplitudes have been initialized to start from X decay
+		double getIntensity(const std::vector<unsigned int>& waveIndices,
+		                    const std::vector<TVector3>&     decayKinMomenta) const;
+
+		double getIntensity(const std::vector<unsigned int>& waveIndices,
+		                    const std::vector<TVector3>&     prodKinMomenta,
+		                    const std::vector<TVector3>&     decayKinMomenta) const;
 
 		std::ostream& print(std::ostream& out = std::cout) const;
 		friend std::ostream& operator << (std::ostream&         out,
@@ -54,6 +66,7 @@ namespace rpwa {
 		                                                 const std::vector<TVector3>& decayKinMomenta) const;
 
 		fitResultPtr                       _fitResult;
+		std::vector<unsigned int>          _waveIndicesWithoutFlat;
 
 		bool                               _amplitudesInitialized;
 		std::vector<isobarAmplitudePtr>    _amplitudes;
@@ -66,6 +79,37 @@ namespace rpwa {
 		bool                               _amplitudesFromXDecay;
 
 	};
+
+
+	inline
+	double
+	modelIntensity::getIntensity(const std::vector<TVector3>& decayKinMomenta) const
+	{
+		return getIntensity(_waveIndicesWithoutFlat, decayKinMomenta);
+	}
+
+
+	inline
+	double
+	modelIntensity::getIntensity(const std::vector<TVector3>& prodKinMomenta,
+	                             const std::vector<TVector3>& decayKinMomenta) const
+	{
+		return getIntensity(_waveIndicesWithoutFlat, prodKinMomenta, decayKinMomenta);
+	}
+
+
+	inline
+	double
+	modelIntensity::getIntensity(const std::vector<unsigned int>& waveIndices,
+	                             const std::vector<TVector3>&     decayKinMomenta) const
+	{
+		if (not _amplitudesFromXDecay) {
+			printErr << "amplitudes not starting from X decay, but not production kinematics provided. Aborting..." << std::endl;
+			throw;
+		}
+
+		return getIntensity(waveIndices, std::vector<TVector3>(1), decayKinMomenta);
+	}
 
 
 } // namespace rpwa

--- a/generators/modelIntensity.h
+++ b/generators/modelIntensity.h
@@ -35,8 +35,7 @@ namespace rpwa {
 		bool initDecayAmplitudes(const std::vector<std::string>& decayKinParticleNames);
 
 		bool initDecayAmplitudes(const std::vector<std::string>& prodKinParticleNames,
-		                         const std::vector<std::string>& decayKinParticleNames,
-		                         const bool                      fromXDecay = false);
+		                         const std::vector<std::string>& decayKinParticleNames);
 
 		// get intensity of all waves except flat wave
 
@@ -61,6 +60,11 @@ namespace rpwa {
 		                                  const modelIntensity& model) { return model.print(out); }
 
 	private:
+
+		template<typename T>
+		bool initDecayAmplitudes(T&                              prodKinParticleNames,
+		                         const std::vector<std::string>& decayKinParticleNames,
+		                         const bool                      fromXDecay);
 
 		std::vector<std::complex<double> > getDecayAmplitudes(const std::vector<TVector3>& prodKinMomenta,
 		                                                      const std::vector<TVector3>& decayKinMomenta) const;

--- a/nBodyPhaseSpace/nBodyPhaseSpaceKinematics.cc
+++ b/nBodyPhaseSpace/nBodyPhaseSpaceKinematics.cc
@@ -218,15 +218,25 @@ nBodyPhaseSpaceKinematics::setAngles(const std::vector<double>& cosTheta,
 }
 
 
+// computes breakup momenta
+// uses vector of intermediate two-body masses prepared by setting
+// _m either directly or via setMasses
+void
+nBodyPhaseSpaceKinematics::calcBreakupMomenta()
+{
+	for (unsigned int i = 1; i < _n; ++i) {  // loop over 2- to n-bodies
+		_breakupMom[i] = breakupMomentum(_M[i], _M[i - 1], _m[i]);
+	}
+}
+
+
 // computes event weight (= integrand value) and breakup momenta
 // uses vector of intermediate two-body masses prepared by setting
 // _m either directly or via setMasses
 double
 nBodyPhaseSpaceKinematics::calcWeight()
 {
-	for (unsigned int i = 1; i < _n; ++i) {  // loop over 2- to n-bodies
-		_breakupMom[i] = breakupMomentum(_M[i], _M[i - 1], _m[i]);
-	}
+	calcBreakupMomenta();
 	switch (_weightType) {
 		case S_U_CHUNG:
 			{  // S. U. Chung's weight

--- a/nBodyPhaseSpace/nBodyPhaseSpaceKinematics.h
+++ b/nBodyPhaseSpace/nBodyPhaseSpaceKinematics.h
@@ -124,8 +124,10 @@ namespace rpwa {
 		void           setWeightType(const weightTypeEnum weightType) { _weightType = weightType; }  ///< selects formula used for weight calculation
 		weightTypeEnum weightType   () const                          { return _weightType;       }  ///< returns formula used for weight calculation
 
+		/// \brief computes breakup momenta
+		void calcBreakupMomenta();
+
 		/// \brief computes event weight and breakup momenta
-		/// operates on vector of intermediate two-body masses
 		double calcWeight();
 
 		enum kinematicsTypeEnum {BLOCK         = 1,   // method for calculation of event kinematics used in nuphaz (faster)
@@ -134,7 +136,8 @@ namespace rpwa {
 		kinematicsTypeEnum kinematicsType   () const                                  { return _kinematicsType;           }  ///< returns algorithm used to calculate event kinematics
 
 		/// \brief calculates full event kinematics from the effective masses of the (i + 1)-body systems and the Lorentz vector of the decaying system
-		/// uses the break-up momenta calculated by calcWeight() and angles from pickAngles()
+		/// uses the break-up momenta calculated by calcBreakupMomenta() (either called
+		/// directly or implicitly via calcWeight()) and angles from setAngles()
 		void calcEventKinematics(const TLorentzVector& nBody);  // Lorentz vector of n-body system in lab frame
 
 

--- a/partialWaveFit/fitResult.h
+++ b/partialWaveFit/fitResult.h
@@ -155,6 +155,9 @@ namespace rpwa {
 		int waveIndex   (const std::string& waveName   ) const;  ///< returns wave index corresponding to wave name
 		int prodAmpIndex(const std::string& prodAmpName) const;  ///< returns production amplitude index corresponding to production amplitude name
 
+		/// returns indices of waves that match the regular expression
+		inline std::vector<unsigned int> waveIndicesMatchingPattern(const std::string& waveNamePattern) const;
+
 		double fitParameter(const std::string& parName) const;  ///< returns value of fit parameter with name
 
 		/// returns production amplitude value at index
@@ -290,8 +293,6 @@ namespace rpwa {
 		std::complex<double> normIntegralForProdAmp(const unsigned int prodAmpIndexA,
 		                                            const unsigned int prodAmpIndexB) const;
 
-		/// returns indices of waves that match the regular expression
-		inline std::vector<unsigned int> waveIndicesMatchingPattern   (const std::string& waveNamePattern   ) const;
 		/// returns indices of production amplitudes that match the regular expression
 		inline std::vector<unsigned int> prodAmpIndicesMatchingPattern(const std::string& prodAmpNamePattern) const;
 		/// returns indices of production amplitudes that belong to wave at index

--- a/pyInterface/CMakeLists.txt
+++ b/pyInterface/CMakeLists.txt
@@ -126,12 +126,14 @@ set(RPWA_PYTHON_SCRIPTS_FILES
 	eigenvectorLikelihoodSlices.py
 	generatePhaseSpace.py
 	genPseudoData.py
-	genPseudoDataImportanceSampling.py
 	likelihoodPointCalculator.py
 	plotAngles.py
 	printMetadata.py
 	pwaFit.py
 )
+if(USE_BAT)
+	LIST(APPEND RPWA_PYTHON_SCRIPTS_FILES genPseudoDataImportanceSampling.py)
+endif()
 if(USE_NLOPT)
 	LIST(APPEND RPWA_PYTHON_SCRIPTS_FILES pwaNloptFit.py)
 endif()

--- a/pyInterface/CMakeLists.txt
+++ b/pyInterface/CMakeLists.txt
@@ -124,8 +124,9 @@ set(RPWA_PYTHON_SCRIPTS_FILES
 	createFileManager.py
 	deWeight.py
 	eigenvectorLikelihoodSlices.py
-	genPseudoData.py
 	generatePhaseSpace.py
+	genPseudoData.py
+	genPseudoDataImportanceSampling.py
 	likelihoodPointCalculator.py
 	plotAngles.py
 	printMetadata.py

--- a/pyInterface/bindings/CMakeLists.txt
+++ b/pyInterface/bindings/CMakeLists.txt
@@ -98,6 +98,7 @@ set(SOURCES
 	${GENERATORS_SUBDIR}/generatorManager_py.cc
 	${GENERATORS_SUBDIR}/generatorParameters_py.cc
 	${GENERATORS_SUBDIR}/generatorPickerFunctions_py.cc
+	${GENERATORS_SUBDIR}/modelIntensity_py.cc
 	${HIGHLEVELINTERFACE_SUBDIR}/calcAmplitude_py.cc
 	${HIGHLEVELINTERFACE_SUBDIR}/pwaFit_py.cc
 	${NBODYPHASESPACE_SUBDIR}/nBodyPhaseSpaceGenerator_py.cc

--- a/pyInterface/bindings/CMakeLists.txt
+++ b/pyInterface/bindings/CMakeLists.txt
@@ -71,6 +71,12 @@ include_directories(
 	${PYTHON_INCLUDE_DIRS}
 	${ROOT_INCLUDE_DIR}
 	)
+if(USE_BAT)
+	include_directories(
+		SYSTEM
+		${BAT_INCLUDE_DIR}
+	)
+endif()
 
 
 # source files that are compiled into library
@@ -121,6 +127,9 @@ set(SOURCES
 	${UTILITIES_SUBDIR}/reportingUtilsEnvironment_py.cc
 	${HIGHLEVELINTERFACE_SUBDIR}/getMassShapes_py.cc
 	)
+if(USE_BAT)
+	LIST(APPEND SOURCES ${GENERATORS_SUBDIR}/importanceSampler_py.cc)
+endif()
 if(USE_NLOPT)
 	LIST(APPEND SOURCES ${HIGHLEVELINTERFACE_SUBDIR}/pwaNloptFit_py.cc)
 endif()

--- a/pyInterface/bindings/decayAmplitude/ampIntegralMatrix_py.cc
+++ b/pyInterface/bindings/decayAmplitude/ampIntegralMatrix_py.cc
@@ -177,8 +177,6 @@ void rpwa::py::exportAmpIntegralMatrix() {
 		.def("readAscii", &ampIntegralMatrix_readAscii)
 
 		.def("Write", &ampIntegralMatrix_Write, bp::arg("name")=0)
-		.def("getFromTDirectory", &rpwa::py::getFromTDirectory<rpwa::ampIntegralMatrix>, bp::return_value_policy<bp::manage_new_object>())
-		.staticmethod("getFromTDirectory")
 
 		.add_static_property("debugAmpIntegralMatrix", &rpwa::ampIntegralMatrix::debug, &rpwa::ampIntegralMatrix::setDebug)
 		.def_readonly("integralObjectName", &rpwa::ampIntegralMatrix::integralObjectName);

--- a/pyInterface/bindings/generators/generatorManager_py.cc
+++ b/pyInterface/bindings/generators/generatorManager_py.cc
@@ -16,7 +16,15 @@ void rpwa::py::exportGeneratorManager() {
 		.def(
 			"getGenerator"
 			, &rpwa::generatorManager::getGenerator
-			, bp::return_internal_reference<1>())
+			, bp::return_internal_reference<1>()
+		)
+#ifdef USE_BAT
+		.def(
+			"getImportanceSampler"
+			, &rpwa::generatorManager::getImportanceSampler
+			, (bp::arg("model"))
+		)
+#endif
 		.def("readReactionFile", &rpwa::generatorManager::readReactionFile)
 		.def("initializeGenerator", &rpwa::generatorManager::initializeGenerator)
 		.def("overrideMassRange", &rpwa::generatorManager::overrideMassRange)
@@ -24,7 +32,7 @@ void rpwa::py::exportGeneratorManager() {
 		.def(
 			"readBeamfileSequentially"
 			, &rpwa::generatorManager::readBeamfileSequentially
-			, bp::arg("readBeamfileSequentially")=true
+			, (bp::arg("readBeamfileSequentially")=true)
 		)
 		.def("randomizeBeamfileStartingPosition", &rpwa::generatorManager::randomizeBeamfileStartingPosition)
 		.add_static_property("debugGeneratorManager", &rpwa::generatorManager::debug, &rpwa::generatorManager::setDebug);

--- a/pyInterface/bindings/generators/importanceSampler_py.cc
+++ b/pyInterface/bindings/generators/importanceSampler_py.cc
@@ -14,7 +14,10 @@ namespace {
 
 	bool
 	importanceSampler_initializeFileWriter(rpwa::importanceSampler& self,
-	                                       PyObject*                outFilePy)
+	                                       PyObject*                outFilePy,
+	                                       const bool               storeMassAndTPrime,
+	                                       const std::string&       massVariableName,
+	                                       const std::string&       tPrimeVariableName)
 	{
 		TFile* outputFile = rpwa::py::convertFromPy<TFile*>(outFilePy);
 		if(not outputFile) {
@@ -22,7 +25,7 @@ namespace {
 			bp::throw_error_already_set();
 		}
 
-		return self.initializeFileWriter(outputFile);
+		return self.initializeFileWriter(outputFile, storeMassAndTPrime, massVariableName, tPrimeVariableName);
 	}
 
 
@@ -136,7 +139,10 @@ void rpwa::py::exportImportanceSampler() {
 		.def(
 			"initializeFileWriter"
 			, &::importanceSampler_initializeFileWriter
-			, (bp::arg("outFile"))
+			, (bp::arg("outFile"),
+			   bp::arg("storeMassAndTPrime") = true,
+			   bp::arg("massVariableName") = "mass",
+			   bp::arg("tPrimeVariableName") = "tPrime")
 		)
 		.def("finalizeFileWriter", &rpwa::importanceSampler::finalizeFileWriter)
 

--- a/pyInterface/bindings/generators/importanceSampler_py.cc
+++ b/pyInterface/bindings/generators/importanceSampler_py.cc
@@ -15,6 +15,7 @@ namespace {
 	bool
 	importanceSampler_initializeFileWriter(rpwa::importanceSampler& self,
 	                                       PyObject*                outFilePy,
+	                                       const std::string&       userString,
 	                                       const bool               storeMassAndTPrime,
 	                                       const std::string&       massVariableName,
 	                                       const std::string&       tPrimeVariableName)
@@ -25,7 +26,7 @@ namespace {
 			bp::throw_error_already_set();
 		}
 
-		return self.initializeFileWriter(outputFile, storeMassAndTPrime, massVariableName, tPrimeVariableName);
+		return self.initializeFileWriter(outputFile, userString, storeMassAndTPrime, massVariableName, tPrimeVariableName);
 	}
 
 
@@ -140,6 +141,7 @@ void rpwa::py::exportImportanceSampler() {
 			"initializeFileWriter"
 			, &::importanceSampler_initializeFileWriter
 			, (bp::arg("outFile"),
+			   bp::arg("userString") = "importanceSampledEvents",
 			   bp::arg("storeMassAndTPrime") = true,
 			   bp::arg("massVariableName") = "mass",
 			   bp::arg("tPrimeVariableName") = "tPrime")

--- a/pyInterface/bindings/generators/importanceSampler_py.cc
+++ b/pyInterface/bindings/generators/importanceSampler_py.cc
@@ -11,6 +11,21 @@ namespace bp = boost::python;
 
 namespace {
 
+
+	bool
+	importanceSampler_initializeFileWriter(rpwa::importanceSampler& self,
+	                                       PyObject*                outFilePy)
+	{
+		TFile* outputFile = rpwa::py::convertFromPy<TFile*>(outFilePy);
+		if(not outputFile) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for outputFile when executing rpwa::importanceSampler::initializeFileWriter(...)");
+			bp::throw_error_already_set();
+		}
+
+		return self.initializeFileWriter(outputFile);
+	}
+
+
 	double
 	importanceSampler_LogLikelihood(rpwa::importanceSampler& self,
 	                                const bp::list&          pyParameters)
@@ -85,19 +100,6 @@ namespace {
 	}
 
 
-	bool
-	importanceSampler_initializeFileWriter(rpwa::importanceSampler& self,
-	                                       PyObject*                outFilePy)
-	{
-		TFile* outputFile = rpwa::py::convertFromPy<TFile*>(outFilePy);
-		if(not outputFile) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for outputFile when executing rpwa::importanceSampler::initializeFileWriter(...)");
-			bp::throw_error_already_set();
-		}
-
-		return self.initializeFileWriter(outputFile);
-	}
-
 	void
 	importanceSampler_SetInitialPositions(rpwa::importanceSampler& self,
 	                                      const bp::list&          positionPy)
@@ -111,26 +113,35 @@ namespace {
 		self.SetInitialPositions(position);
 	}
 
+
 }
 
 
 void rpwa::py::exportImportanceSampler() {
 
-	bp::class_<rpwa::importanceSampler>("importanceSampler", bp::init<const double, const double, modelIntensityPtr>())
+	bp::class_<rpwa::importanceSampler>("importanceSampler", bp::init<rpwa::modelIntensityPtr,
+	                                                                  rpwa::beamAndVertexGeneratorPtr,
+	                                                                  rpwa::massAndTPrimePickerPtr,
+	                                                                  const rpwa::Beam&,
+	                                                                  const rpwa::Target&,
+	                                                                  const rpwa::FinalState&>())
 
-		.def(
-			"setPhaseSpaceOnly"
-			, &rpwa::importanceSampler::setPhaseSpaceOnly
-			, (bp::arg("inputValue") = true)
-		)
 		.def(
 			"initializeFileWriter"
 			, &::importanceSampler_initializeFileWriter
 			, (bp::arg("outFile"))
 		)
 		.def("finalizeFileWriter", &rpwa::importanceSampler::finalizeFileWriter)
+
+		.def(
+			"setPhaseSpaceOnly"
+			, &rpwa::importanceSampler::setPhaseSpaceOnly
+			, (bp::arg("inputValue") = true)
+		)
+
 		.def("nCalls", &rpwa::importanceSampler::nCalls)
-	// From here BAT stuff. Therefore names start with capital letters
+
+		// From here BAT stuff. Therefore names start with capital letters
 		.def(
 			"LogLikelihood"
 			, &::importanceSampler_LogLikelihood
@@ -197,5 +208,7 @@ void rpwa::py::exportImportanceSampler() {
 		)
 
 	;
+
+	bp::register_ptr_to_python<rpwa::importanceSamplerPtr>();
 
 }

--- a/pyInterface/bindings/generators/importanceSampler_py.cc
+++ b/pyInterface/bindings/generators/importanceSampler_py.cc
@@ -31,6 +31,23 @@ namespace {
 
 
 	void
+	importanceSampler_setMassPrior(rpwa::importanceSampler& self,
+	                               bp::object&              pyPrior)
+	{
+		TF1* prior = 0;
+		if(not pyPrior.is_none()) {
+			prior = rpwa::py::convertFromPy<TF1*>(pyPrior.ptr());
+			if(not prior) {
+				PyErr_SetString(PyExc_TypeError, "Got invalid input for prior when executing rpwa::importanceSampler::setMassPrior(...)");
+				bp::throw_error_already_set();
+			}
+		}
+
+		self.setMassPrior(prior);
+	}
+
+
+	void
 	importanceSampler_printFuncInfo(rpwa::importanceSampler& self)
 	{
 		self.printFuncInfo(std::cout);
@@ -152,6 +169,12 @@ void rpwa::py::exportImportanceSampler() {
 			"setPhaseSpaceOnly"
 			, &rpwa::importanceSampler::setPhaseSpaceOnly
 			, (bp::arg("inputValue") = true)
+		)
+		.def(
+			"setMassPrior"
+			, &importanceSampler_setMassPrior
+			, bp::with_custodian_and_ward<1,2>()
+			, (bp::arg("prior") = boost::python::object())
 		)
 
 		.def("nCalls", &rpwa::importanceSampler::nCalls)

--- a/pyInterface/bindings/generators/importanceSampler_py.cc
+++ b/pyInterface/bindings/generators/importanceSampler_py.cc
@@ -26,6 +26,13 @@ namespace {
 	}
 
 
+	void
+	importanceSampler_printFuncInfo(rpwa::importanceSampler& self)
+	{
+		self.printFuncInfo(std::cout);
+	}
+
+
 	double
 	importanceSampler_LogLikelihood(rpwa::importanceSampler& self,
 	                                const bp::list&          pyParameters)
@@ -140,6 +147,8 @@ void rpwa::py::exportImportanceSampler() {
 		)
 
 		.def("nCalls", &rpwa::importanceSampler::nCalls)
+		.def("resetFuncInfo", &rpwa::importanceSampler::resetFuncInfo)
+		.def("printFuncInfo", &importanceSampler_printFuncInfo)
 
 		// From here BAT stuff. Therefore names start with capital letters
 		.def(

--- a/pyInterface/bindings/generators/importanceSampler_py.h
+++ b/pyInterface/bindings/generators/importanceSampler_py.h
@@ -1,0 +1,10 @@
+#ifndef IMPORTANCESAMPLER_PY_H
+#define IMPORTANCESAMPLER_PY_H
+
+namespace rpwa {
+	namespace py {
+		void exportImportanceSampler();
+	}
+}
+
+#endif

--- a/pyInterface/bindings/generators/modelIntensity_py.cc
+++ b/pyInterface/bindings/generators/modelIntensity_py.cc
@@ -44,8 +44,7 @@ namespace {
 	double
 	modelIntensity_initDecayAmplitudes_2(rpwa::modelIntensity& self,
 	                                     const bp::list&       pyProdKinParticleNames,
-	                                     const bp::list&       pyDecayKinParticleNames,
-	                                     const bool            fromXDecay)
+	                                     const bp::list&       pyDecayKinParticleNames)
 	{
 		std::vector<std::string> prodKinParticleNames;
 		if(not rpwa::py::convertBPObjectToVector<std::string>(pyProdKinParticleNames, prodKinParticleNames)) {
@@ -59,7 +58,7 @@ namespace {
 			bp::throw_error_already_set();
 		}
 
-		return self.initDecayAmplitudes(prodKinParticleNames, decayKinParticleNames, fromXDecay);
+		return self.initDecayAmplitudes(prodKinParticleNames, decayKinParticleNames);
 	}
 
 
@@ -193,8 +192,7 @@ void rpwa::py::exportModelIntensity() {
 			"initDecayAmplitudes"
 			, &modelIntensity_initDecayAmplitudes_2
 			, (bp::arg("prodKinParticleNames"),
-			   bp::arg("decayKinParticleNames"),
-			   bp::arg("fromXdecay") = false)
+			   bp::arg("decayKinParticleNames"))
 		)
 
 		.def(

--- a/pyInterface/bindings/generators/modelIntensity_py.cc
+++ b/pyInterface/bindings/generators/modelIntensity_py.cc
@@ -1,0 +1,224 @@
+#include"modelIntensity_py.h"
+
+#include<boost/python.hpp>
+
+#include<TVector3.h>
+
+#include"ampIntegralMatrix.h"
+#include"modelIntensity.h"
+#include"rootConverters_py.h"
+#include"stlContainers_py.h"
+
+namespace bp = boost::python;
+
+
+namespace {
+
+	bool
+	modelIntensity_loadIntegrals(rpwa::modelIntensity& self,
+	                             PyObject*             pyIntegralMatrix)
+	{
+		rpwa::ampIntegralMatrix* integralMatrix = rpwa::py::convertFromPy<rpwa::ampIntegralMatrix* >(pyIntegralMatrix);
+		if(not integralMatrix) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for integralMatrix when executing modelIntensity::loadIntegrals");
+			bp::throw_error_already_set();
+		}
+		return self.loadIntegrals(*integralMatrix);
+	}
+
+
+	bool
+	modelIntensity_setFinalStateMasses(rpwa::modelIntensity& self,
+	                                   const bp::list&       pyMasses)
+	{
+		std::vector<double> masses;
+		if(not rpwa::py::convertBPObjectToVector<double>(pyMasses, masses)) {
+			PyErr_SetString(PyExc_TypeError, "invalid masses gotten");
+			bp::throw_error_already_set();
+		}
+		return self.setFinalStateMasses(masses);
+	}
+
+
+	bool
+	modelIntensity_setParticles(rpwa::modelIntensity& self,
+	                            const bp::list&       pyInitial,
+	                            const bp::list&       pyFinal)
+	{
+		std::vector<std::string> initial;
+		if (not rpwa::py::convertBPObjectToVector<std::string>(pyInitial, initial)) {
+			PyErr_SetString(PyExc_TypeError, "invalid initial particles gotten");
+			bp::throw_error_already_set();
+		}
+
+		std::vector<std::string> final;
+		if (not rpwa::py::convertBPObjectToVector<std::string>(pyFinal, final)) {
+			PyErr_SetString(PyExc_TypeError, "invalid final particles gotten");
+			bp::throw_error_already_set();
+		}
+
+		return self.setParticles(initial, final);
+	}
+
+
+	bool
+	modelIntensity_setProdKinMomenta(rpwa::modelIntensity& self,
+	                                 PyObject*             pyProdKinMomenta)
+	{
+		bp::extract<bp::list> getProdKinMomentaList(pyProdKinMomenta);
+		if(not getProdKinMomentaList.check()) {
+			printErr<<"Got invalid input for prodKinMomenta when executing rpwa::modelIntensity::setProdKinMomenta()"<<std::endl;
+			return false;
+		}
+		bp::list prodKinMomentaList = getProdKinMomentaList();
+
+		std::vector<TVector3> prodKinMomenta(len(prodKinMomentaList));
+		for(int i = 0; i < len(prodKinMomentaList); ++i) {
+			bp::object item = bp::extract<bp::object>(prodKinMomentaList[i]);
+			prodKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
+		}
+
+		return self.setProdKinMomenta(prodKinMomenta);
+	}
+
+
+	double
+	modelIntensity_getIntensity1(rpwa::modelIntensity& self,
+	                             PyObject*             pyDecayKinMomenta)
+	{
+		bp::extract<bp::list> getDecayKinMomentaList(pyDecayKinMomenta);
+		if(not getDecayKinMomentaList.check()) {
+			PyErr_SetString(PyExc_TypeError,"Got invalid input for decayKinMomenta when executing rpwa::modelIntensity::getIntensity()");
+			bp::throw_error_already_set();
+		}
+		bp::list decayKinMomentaList = getDecayKinMomentaList();
+
+		std::vector<TVector3> decayKinMomenta(len(decayKinMomentaList));
+		for(int i = 0; i < len(decayKinMomentaList); ++i) {
+			bp::object item = bp::extract<bp::object>(decayKinMomentaList[i]);
+			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
+		}
+
+		return self.getIntensity(decayKinMomenta);
+	}
+
+
+	double
+	modelIntensity_getIntensity2(rpwa::modelIntensity& self,
+	                             PyObject*             pyProdKinMomenta,
+	                             PyObject*             pyDecayKinMomenta)
+	{
+		bp::extract<bp::list> getProdKinMomentaList(pyProdKinMomenta);
+		if(not getProdKinMomentaList.check()) {
+			PyErr_SetString(PyExc_TypeError,"Got invalid input for prodKinMomenta when executing rpwa::modelIntensity::getIntensity()");
+			bp::throw_error_already_set();
+		}
+		bp::list prodKinMomentaList = getProdKinMomentaList();
+
+		std::vector<TVector3> prodKinMomenta(len(prodKinMomentaList));
+		for (int i = 0; i < len(prodKinMomentaList); ++i) {
+			bp::object item = bp::extract<bp::object>(prodKinMomentaList[i]);
+			prodKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
+		}
+
+		bp::extract<bp::list> getDecayKinMomentaList(pyDecayKinMomenta);
+		if(not getDecayKinMomentaList.check()) {
+			PyErr_SetString(PyExc_TypeError,"Got invalid input for decayKinMomenta when executing rpwa::modelIntensity::getIntensity()");
+			bp::throw_error_already_set();
+		}
+		bp::list decayKinMomentaList = getDecayKinMomentaList();
+
+		std::vector<TVector3> decayKinMomenta(len(decayKinMomentaList));
+		for(int i = 0; i < len(decayKinMomentaList); ++i) {
+			bp::object item = bp::extract<bp::object>(decayKinMomentaList[i]);
+			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
+		}
+
+		return self.getIntensity(prodKinMomenta, decayKinMomenta);
+	}
+
+}
+
+
+void rpwa::py::exportModelIntensity() {
+
+	bp::class_<rpwa::modelIntensity>("modelIntensity")
+
+		.def(
+			"getIntensity"
+			, &::modelIntensity_getIntensity1
+			, (bp::arg("decayKinMomenta"))
+		)
+		.def(
+			"getIntensity"
+			, &::modelIntensity_getIntensity2
+			, (bp::arg("prodKinMomenta"),
+			   bp::arg("decayKinMomenta"))
+		)
+
+		.def(
+			"loadIntegrals"
+			, &::modelIntensity_loadIntegrals
+			, (bp::arg("integralMatrix"))
+		)
+		.def(
+			"loadIntegrals"
+			, &rpwa::modelIntensity::loadIntegrals
+			, (bp::arg("integralMatrix"))
+		)
+
+		.def(
+			"addAmplitude"
+			, &rpwa::modelIntensity::addAmplitude
+			, (bp::arg("transitionAmplitude"),
+			   bp::arg("amplitude"),
+			   bp::arg("reflectivity") = 1)
+		)
+		.def(
+			"initAmplitudes"
+			, &rpwa::modelIntensity::initAmplitudes
+			, (bp::arg("fromXdecay") = true)
+		)
+
+		.def(
+			"setProdKinMomenta"
+			, &::modelIntensity_setProdKinMomenta
+			, (bp::arg("prodKinMomenta"))
+		)
+
+		.def("mBeam", &rpwa::modelIntensity::mBeam)
+		.def(
+			"setMbeam"
+			, &rpwa::modelIntensity::setMbeam
+			, (bp::arg("mBeam"))
+		)
+
+		.def("mTarget", &rpwa::modelIntensity::mTarget)
+		.def(
+			"setMtarget"
+			, &rpwa::modelIntensity::setMtarget
+			, (bp::arg("mTarget"))
+		)
+		.def(
+			"setTarget"
+			, &rpwa::modelIntensity::setTarget
+			, (bp::arg("target"))
+		)
+
+		.def(
+			"setParticles"
+			, &::modelIntensity_setParticles
+			, (bp::arg("intialState"),
+			   bp::arg("finalState"))
+		)
+		.def(
+			"setFinalStateMasses"
+			, &::modelIntensity_setFinalStateMasses
+			, (bp::arg("masses"))
+		)
+
+		.def("Print", &rpwa::modelIntensity::print)
+
+	;
+
+}

--- a/pyInterface/bindings/generators/modelIntensity_py.cc
+++ b/pyInterface/bindings/generators/modelIntensity_py.cc
@@ -15,51 +15,51 @@ namespace bp = boost::python;
 namespace {
 
 	bool
-	modelIntensity_addIntegral(rpwa::modelIntensity& self,
-	                           PyObject*             pyIntegralMatrix)
+	modelIntensity_loadPhaseSpaceIntegral(rpwa::modelIntensity& self,
+	                                      PyObject*             pyIntegralMatrix)
 	{
-		rpwa::ampIntegralMatrix* integralMatrix = rpwa::py::convertFromPy<rpwa::ampIntegralMatrix* >(pyIntegralMatrix);
+		rpwa::ampIntegralMatrix* integralMatrix = rpwa::py::convertFromPy<rpwa::ampIntegralMatrix*>(pyIntegralMatrix);
 		if(not integralMatrix) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for integralMatrix when executing modelIntensity::addIntegral");
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for integralMatrix when executing modelIntensity::loadPhaseSpaceIntegral()");
 			bp::throw_error_already_set();
 		}
-		return self.addIntegral(*integralMatrix);
+		return self.loadPhaseSpaceIntegral(*integralMatrix);
 	}
 
 
 	double
-	modelIntensity_initAmplitudes_1(rpwa::modelIntensity& self,
-	                                const bp::list&       pyDecayKinParticleNames)
+	modelIntensity_initDecayAmplitudes_1(rpwa::modelIntensity& self,
+	                                     const bp::list&       pyDecayKinParticleNames)
 	{
 		std::vector<std::string> decayKinParticleNames;
 		if(not rpwa::py::convertBPObjectToVector<std::string>(pyDecayKinParticleNames, decayKinParticleNames)) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initDecayAmplitudes()");
 			bp::throw_error_already_set();
 		}
 
-		return self.initAmplitudes(decayKinParticleNames);
+		return self.initDecayAmplitudes(decayKinParticleNames);
 	}
 
 
 	double
-	modelIntensity_initAmplitudes_2(rpwa::modelIntensity& self,
-	                                const bp::list&       pyProdKinParticleNames,
-	                                const bp::list&       pyDecayKinParticleNames,
-	                                const bool            fromXDecay)
+	modelIntensity_initDecayAmplitudes_2(rpwa::modelIntensity& self,
+	                                     const bp::list&       pyProdKinParticleNames,
+	                                     const bp::list&       pyDecayKinParticleNames,
+	                                     const bool            fromXDecay)
 	{
 		std::vector<std::string> prodKinParticleNames;
 		if(not rpwa::py::convertBPObjectToVector<std::string>(pyProdKinParticleNames, prodKinParticleNames)) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for prodKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for prodKinParticleNames when executing rpwa::modelIntensity::initDecayAmplitudes()");
 			bp::throw_error_already_set();
 		}
 
 		std::vector<std::string> decayKinParticleNames;
 		if(not rpwa::py::convertBPObjectToVector<std::string>(pyDecayKinParticleNames, decayKinParticleNames)) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initDecayAmplitudes()");
 			bp::throw_error_already_set();
 		}
 
-		return self.initAmplitudes(prodKinParticleNames, decayKinParticleNames, fromXDecay);
+		return self.initDecayAmplitudes(prodKinParticleNames, decayKinParticleNames, fromXDecay);
 	}
 
 
@@ -91,7 +91,7 @@ namespace {
 			if (itemU.check()) {
 				indices = true;
 				if (momenta) {
-					PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is a mixed list of 'unsigned int' and 'TVector3'.");
+					PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity() is a mixed list of 'unsigned int' and 'TVector3'.");
 					bp::throw_error_already_set();
 				}
 				waveIndices[i] = itemU();
@@ -103,14 +103,14 @@ namespace {
 				if (ptrV) {
 					momenta = true;
 					if (indices) {
-						PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is a mixed list of 'unsigned int' and 'TVector3'.");
+						PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity() is a mixed list of 'unsigned int' and 'TVector3'.");
 						bp::throw_error_already_set();
 					}
 					prodKinMomenta[i] = *ptrV;
 					continue;
 				}
 			}
-			PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is not a list of either 'unsigned int' or 'TVector3'.");
+			PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity() is not a list of either 'unsigned int' or 'TVector3'.");
 			bp::throw_error_already_set();
 		}
 
@@ -125,7 +125,7 @@ namespace {
 		if (momenta)
 			return self.getIntensity(prodKinMomenta, decayKinMomenta);
 
-		PyErr_SetString(PyExc_TypeError, "Could not determine type of first argument of modelIntensity::getIntensity.");
+		PyErr_SetString(PyExc_TypeError, "Could not determine type of first argument of modelIntensity::getIntensity().");
 		bp::throw_error_already_set();
 		return 0;
 	}
@@ -139,7 +139,7 @@ namespace {
 	{
 		std::vector<unsigned int> waveIndices;
 		if (not rpwa::py::convertBPObjectToVector<unsigned int>(pyWaveIndices, waveIndices)) {
-			PyErr_SetString(PyExc_TypeError, "Cannot convert first argument of modelIntensity::getIntensity to a vector of 'unsigned int'.");
+			PyErr_SetString(PyExc_TypeError, "Cannot convert first argument of modelIntensity::getIntensity() to a vector of 'unsigned int'.");
 			bp::throw_error_already_set();
 		}
 
@@ -168,30 +168,30 @@ void rpwa::py::exportModelIntensity() {
 		.def(bp::self_ns::str(bp::self))
 
 		.def(
-			"addAmplitude"
-			, &rpwa::modelIntensity::addAmplitude
+			"addDecayAmplitude"
+			, &rpwa::modelIntensity::addDecayAmplitude
 			, (bp::arg("amplitude"))
 		)
 
 		.def(
-			"addIntegral"
-			, &::modelIntensity_addIntegral
+			"loadPhaseSpaceIntegral"
+			, &::modelIntensity_loadPhaseSpaceIntegral
 			, (bp::arg("integralMatrix"))
 		)
 		.def(
-			"addIntegral"
-			, &rpwa::modelIntensity::addIntegral
+			"loadPhaseSpaceIntegral"
+			, &rpwa::modelIntensity::loadPhaseSpaceIntegral
 			, (bp::arg("integralMatrix"))
 		)
 
 		.def(
-			"initAmplitudes"
-			, &modelIntensity_initAmplitudes_1
+			"initDecayAmplitudes"
+			, &modelIntensity_initDecayAmplitudes_1
 			, (bp::arg("decayKinParticleNames"))
 		)
 		.def(
-			"initAmplitudes"
-			, &modelIntensity_initAmplitudes_2
+			"initDecayAmplitudes"
+			, &modelIntensity_initDecayAmplitudes_2
 			, (bp::arg("prodKinParticleNames"),
 			   bp::arg("decayKinParticleNames"),
 			   bp::arg("fromXdecay") = false)

--- a/pyInterface/bindings/generators/modelIntensity_py.cc
+++ b/pyInterface/bindings/generators/modelIntensity_py.cc
@@ -79,9 +79,70 @@ namespace {
 
 	double
 	modelIntensity_getIntensity_2(rpwa::modelIntensity& self,
+	                              const bp::list&       pyList,
+	                              const bp::list&       pyDecayKinMomenta)
+	{
+		bool                      indices = false;
+		std::vector<unsigned int> waveIndices   (len(pyList));
+		bool                      momenta = false;
+		std::vector<TVector3>     prodKinMomenta(len(pyList));
+		for(unsigned int i = 0; i < len(pyList); ++i) {
+			bp::extract<unsigned int> itemU(pyList[i]);
+			if (itemU.check()) {
+				indices = true;
+				if (momenta) {
+					PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is a mixed list of 'unsigned int' and 'TVector3'.");
+					bp::throw_error_already_set();
+				}
+				waveIndices[i] = itemU();
+				continue;
+			}
+			bp::extract<bp::object> itemV(pyList[i]);
+			if (itemV.check()) {
+				TVector3* ptrV = rpwa::py::convertFromPy<TVector3*>(itemV().ptr());
+				if (ptrV) {
+					momenta = true;
+					if (indices) {
+						PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is a mixed list of 'unsigned int' and 'TVector3'.");
+						bp::throw_error_already_set();
+					}
+					prodKinMomenta[i] = *ptrV;
+					continue;
+				}
+			}
+			PyErr_SetString(PyExc_TypeError, "First argument of modelIntensity::getIntensity is not a list of either 'unsigned int' or 'TVector3'.");
+			bp::throw_error_already_set();
+		}
+
+		std::vector<TVector3> decayKinMomenta(len(pyDecayKinMomenta));
+		for(unsigned int i = 0; i < len(pyDecayKinMomenta); ++i) {
+			bp::object item = bp::extract<bp::object>(pyDecayKinMomenta[i]);
+			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
+		}
+
+		if (indices)
+			return self.getIntensity(waveIndices, decayKinMomenta);
+		if (momenta)
+			return self.getIntensity(prodKinMomenta, decayKinMomenta);
+
+		PyErr_SetString(PyExc_TypeError, "Could not determine type of first argument of modelIntensity::getIntensity.");
+		bp::throw_error_already_set();
+		return 0;
+	}
+
+
+	double
+	modelIntensity_getIntensity_3(rpwa::modelIntensity& self,
+	                              const bp::list&       pyWaveIndices,
 	                              const bp::list&       pyProdKinMomenta,
 	                              const bp::list&       pyDecayKinMomenta)
 	{
+		std::vector<unsigned int> waveIndices;
+		if (not rpwa::py::convertBPObjectToVector<unsigned int>(pyWaveIndices, waveIndices)) {
+			PyErr_SetString(PyExc_TypeError, "Cannot convert first argument of modelIntensity::getIntensity to a vector of 'unsigned int'.");
+			bp::throw_error_already_set();
+		}
+
 		std::vector<TVector3> prodKinMomenta(len(pyProdKinMomenta));
 		for(unsigned int i = 0; i < len(pyProdKinMomenta); ++i) {
 			bp::object item = bp::extract<bp::object>(pyProdKinMomenta[i]);
@@ -94,7 +155,7 @@ namespace {
 			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
 		}
 
-		return self.getIntensity(prodKinMomenta, decayKinMomenta);
+		return self.getIntensity(waveIndices, prodKinMomenta, decayKinMomenta);
 	}
 
 }
@@ -145,6 +206,19 @@ void rpwa::py::exportModelIntensity() {
 			"getIntensity"
 			, &modelIntensity_getIntensity_2
 			, (bp::arg("prodKinMomenta"),
+			   bp::arg("decayKinMomenta"))
+		)
+		.def(
+			"getIntensity"
+			, &modelIntensity_getIntensity_2
+			, (bp::arg("waveIndices"),
+			   bp::arg("decayKinMomenta"))
+		)
+		.def(
+			"getIntensity"
+			, &modelIntensity_getIntensity_3
+			, (bp::arg("waveIndices"),
+			   bp::arg("prodKinMomenta"),
 			   bp::arg("decayKinMomenta"))
 		)
 

--- a/pyInterface/bindings/generators/modelIntensity_py.cc
+++ b/pyInterface/bindings/generators/modelIntensity_py.cc
@@ -15,87 +15,61 @@ namespace bp = boost::python;
 namespace {
 
 	bool
-	modelIntensity_loadIntegrals(rpwa::modelIntensity& self,
-	                             PyObject*             pyIntegralMatrix)
+	modelIntensity_addIntegral(rpwa::modelIntensity& self,
+	                           PyObject*             pyIntegralMatrix)
 	{
 		rpwa::ampIntegralMatrix* integralMatrix = rpwa::py::convertFromPy<rpwa::ampIntegralMatrix* >(pyIntegralMatrix);
 		if(not integralMatrix) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for integralMatrix when executing modelIntensity::loadIntegrals");
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for integralMatrix when executing modelIntensity::addIntegral");
 			bp::throw_error_already_set();
 		}
-		return self.loadIntegrals(*integralMatrix);
-	}
-
-
-	bool
-	modelIntensity_setFinalStateMasses(rpwa::modelIntensity& self,
-	                                   const bp::list&       pyMasses)
-	{
-		std::vector<double> masses;
-		if(not rpwa::py::convertBPObjectToVector<double>(pyMasses, masses)) {
-			PyErr_SetString(PyExc_TypeError, "invalid masses gotten");
-			bp::throw_error_already_set();
-		}
-		return self.setFinalStateMasses(masses);
-	}
-
-
-	bool
-	modelIntensity_setParticles(rpwa::modelIntensity& self,
-	                            const bp::list&       pyInitial,
-	                            const bp::list&       pyFinal)
-	{
-		std::vector<std::string> initial;
-		if (not rpwa::py::convertBPObjectToVector<std::string>(pyInitial, initial)) {
-			PyErr_SetString(PyExc_TypeError, "invalid initial particles gotten");
-			bp::throw_error_already_set();
-		}
-
-		std::vector<std::string> final;
-		if (not rpwa::py::convertBPObjectToVector<std::string>(pyFinal, final)) {
-			PyErr_SetString(PyExc_TypeError, "invalid final particles gotten");
-			bp::throw_error_already_set();
-		}
-
-		return self.setParticles(initial, final);
-	}
-
-
-	bool
-	modelIntensity_setProdKinMomenta(rpwa::modelIntensity& self,
-	                                 PyObject*             pyProdKinMomenta)
-	{
-		bp::extract<bp::list> getProdKinMomentaList(pyProdKinMomenta);
-		if(not getProdKinMomentaList.check()) {
-			printErr<<"Got invalid input for prodKinMomenta when executing rpwa::modelIntensity::setProdKinMomenta()"<<std::endl;
-			return false;
-		}
-		bp::list prodKinMomentaList = getProdKinMomentaList();
-
-		std::vector<TVector3> prodKinMomenta(len(prodKinMomentaList));
-		for(int i = 0; i < len(prodKinMomentaList); ++i) {
-			bp::object item = bp::extract<bp::object>(prodKinMomentaList[i]);
-			prodKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
-		}
-
-		return self.setProdKinMomenta(prodKinMomenta);
+		return self.addIntegral(*integralMatrix);
 	}
 
 
 	double
-	modelIntensity_getIntensity1(rpwa::modelIntensity& self,
-	                             PyObject*             pyDecayKinMomenta)
+	modelIntensity_initAmplitudes_1(rpwa::modelIntensity& self,
+	                                const bp::list&       pyDecayKinParticleNames)
 	{
-		bp::extract<bp::list> getDecayKinMomentaList(pyDecayKinMomenta);
-		if(not getDecayKinMomentaList.check()) {
-			PyErr_SetString(PyExc_TypeError,"Got invalid input for decayKinMomenta when executing rpwa::modelIntensity::getIntensity()");
+		std::vector<std::string> decayKinParticleNames;
+		if(not rpwa::py::convertBPObjectToVector<std::string>(pyDecayKinParticleNames, decayKinParticleNames)) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
 			bp::throw_error_already_set();
 		}
-		bp::list decayKinMomentaList = getDecayKinMomentaList();
 
-		std::vector<TVector3> decayKinMomenta(len(decayKinMomentaList));
-		for(int i = 0; i < len(decayKinMomentaList); ++i) {
-			bp::object item = bp::extract<bp::object>(decayKinMomentaList[i]);
+		return self.initAmplitudes(decayKinParticleNames);
+	}
+
+
+	double
+	modelIntensity_initAmplitudes_2(rpwa::modelIntensity& self,
+	                                const bp::list&       pyProdKinParticleNames,
+	                                const bp::list&       pyDecayKinParticleNames,
+	                                const bool            fromXDecay)
+	{
+		std::vector<std::string> prodKinParticleNames;
+		if(not rpwa::py::convertBPObjectToVector<std::string>(pyProdKinParticleNames, prodKinParticleNames)) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for prodKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
+			bp::throw_error_already_set();
+		}
+
+		std::vector<std::string> decayKinParticleNames;
+		if(not rpwa::py::convertBPObjectToVector<std::string>(pyDecayKinParticleNames, decayKinParticleNames)) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid input for decayKinParticleNames when executing rpwa::modelIntensity::initAmplitudes()");
+			bp::throw_error_already_set();
+		}
+
+		return self.initAmplitudes(prodKinParticleNames, decayKinParticleNames, fromXDecay);
+	}
+
+
+	double
+	modelIntensity_getIntensity_1(rpwa::modelIntensity& self,
+	                              const bp::list&       pyDecayKinMomenta)
+	{
+		std::vector<TVector3> decayKinMomenta(len(pyDecayKinMomenta));
+		for(unsigned int i = 0; i < len(pyDecayKinMomenta); ++i) {
+			bp::object item = bp::extract<bp::object>(pyDecayKinMomenta[i]);
 			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
 		}
 
@@ -104,33 +78,19 @@ namespace {
 
 
 	double
-	modelIntensity_getIntensity2(rpwa::modelIntensity& self,
-	                             PyObject*             pyProdKinMomenta,
-	                             PyObject*             pyDecayKinMomenta)
+	modelIntensity_getIntensity_2(rpwa::modelIntensity& self,
+	                              const bp::list&       pyProdKinMomenta,
+	                              const bp::list&       pyDecayKinMomenta)
 	{
-		bp::extract<bp::list> getProdKinMomentaList(pyProdKinMomenta);
-		if(not getProdKinMomentaList.check()) {
-			PyErr_SetString(PyExc_TypeError,"Got invalid input for prodKinMomenta when executing rpwa::modelIntensity::getIntensity()");
-			bp::throw_error_already_set();
-		}
-		bp::list prodKinMomentaList = getProdKinMomentaList();
-
-		std::vector<TVector3> prodKinMomenta(len(prodKinMomentaList));
-		for (int i = 0; i < len(prodKinMomentaList); ++i) {
-			bp::object item = bp::extract<bp::object>(prodKinMomentaList[i]);
+		std::vector<TVector3> prodKinMomenta(len(pyProdKinMomenta));
+		for(unsigned int i = 0; i < len(pyProdKinMomenta); ++i) {
+			bp::object item = bp::extract<bp::object>(pyProdKinMomenta[i]);
 			prodKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
 		}
 
-		bp::extract<bp::list> getDecayKinMomentaList(pyDecayKinMomenta);
-		if(not getDecayKinMomentaList.check()) {
-			PyErr_SetString(PyExc_TypeError,"Got invalid input for decayKinMomenta when executing rpwa::modelIntensity::getIntensity()");
-			bp::throw_error_already_set();
-		}
-		bp::list decayKinMomentaList = getDecayKinMomentaList();
-
-		std::vector<TVector3> decayKinMomenta(len(decayKinMomentaList));
-		for(int i = 0; i < len(decayKinMomentaList); ++i) {
-			bp::object item = bp::extract<bp::object>(decayKinMomentaList[i]);
+		std::vector<TVector3> decayKinMomenta(len(pyDecayKinMomenta));
+		for(unsigned int i = 0; i < len(pyDecayKinMomenta); ++i) {
+			bp::object item = bp::extract<bp::object>(pyDecayKinMomenta[i]);
 			decayKinMomenta[i] = *rpwa::py::convertFromPy<TVector3*>(item.ptr());
 		}
 
@@ -142,83 +102,54 @@ namespace {
 
 void rpwa::py::exportModelIntensity() {
 
-	bp::class_<rpwa::modelIntensity>("modelIntensity")
+	bp::class_<rpwa::modelIntensity>("modelIntensity", bp::init<fitResultPtr>())
 
-		.def(
-			"getIntensity"
-			, &::modelIntensity_getIntensity1
-			, (bp::arg("decayKinMomenta"))
-		)
-		.def(
-			"getIntensity"
-			, &::modelIntensity_getIntensity2
-			, (bp::arg("prodKinMomenta"),
-			   bp::arg("decayKinMomenta"))
-		)
-
-		.def(
-			"loadIntegrals"
-			, &::modelIntensity_loadIntegrals
-			, (bp::arg("integralMatrix"))
-		)
-		.def(
-			"loadIntegrals"
-			, &rpwa::modelIntensity::loadIntegrals
-			, (bp::arg("integralMatrix"))
-		)
+		.def(bp::self_ns::str(bp::self))
 
 		.def(
 			"addAmplitude"
 			, &rpwa::modelIntensity::addAmplitude
-			, (bp::arg("transitionAmplitude"),
-			   bp::arg("amplitude"),
-			   bp::arg("reflectivity") = 1)
+			, (bp::arg("amplitude"))
+		)
+
+		.def(
+			"addIntegral"
+			, &::modelIntensity_addIntegral
+			, (bp::arg("integralMatrix"))
+		)
+		.def(
+			"addIntegral"
+			, &rpwa::modelIntensity::addIntegral
+			, (bp::arg("integralMatrix"))
+		)
+
+		.def(
+			"initAmplitudes"
+			, &modelIntensity_initAmplitudes_1
+			, (bp::arg("decayKinParticleNames"))
 		)
 		.def(
 			"initAmplitudes"
-			, &rpwa::modelIntensity::initAmplitudes
-			, (bp::arg("fromXdecay") = true)
+			, &modelIntensity_initAmplitudes_2
+			, (bp::arg("prodKinParticleNames"),
+			   bp::arg("decayKinParticleNames"),
+			   bp::arg("fromXdecay") = false)
 		)
 
 		.def(
-			"setProdKinMomenta"
-			, &::modelIntensity_setProdKinMomenta
-			, (bp::arg("prodKinMomenta"))
-		)
-
-		.def("mBeam", &rpwa::modelIntensity::mBeam)
-		.def(
-			"setMbeam"
-			, &rpwa::modelIntensity::setMbeam
-			, (bp::arg("mBeam"))
-		)
-
-		.def("mTarget", &rpwa::modelIntensity::mTarget)
-		.def(
-			"setMtarget"
-			, &rpwa::modelIntensity::setMtarget
-			, (bp::arg("mTarget"))
+			"getIntensity"
+			, &modelIntensity_getIntensity_1
+			, (bp::arg("decayKinMomenta"))
 		)
 		.def(
-			"setTarget"
-			, &rpwa::modelIntensity::setTarget
-			, (bp::arg("target"))
+			"getIntensity"
+			, &modelIntensity_getIntensity_2
+			, (bp::arg("prodKinMomenta"),
+			   bp::arg("decayKinMomenta"))
 		)
-
-		.def(
-			"setParticles"
-			, &::modelIntensity_setParticles
-			, (bp::arg("intialState"),
-			   bp::arg("finalState"))
-		)
-		.def(
-			"setFinalStateMasses"
-			, &::modelIntensity_setFinalStateMasses
-			, (bp::arg("masses"))
-		)
-
-		.def("Print", &rpwa::modelIntensity::print)
 
 	;
+
+	bp::register_ptr_to_python<rpwa::modelIntensityPtr>();
 
 }

--- a/pyInterface/bindings/generators/modelIntensity_py.h
+++ b/pyInterface/bindings/generators/modelIntensity_py.h
@@ -1,0 +1,10 @@
+#ifndef MODELINTENSITY_PY_H
+#define MODELINTENSITY_PY_H
+
+namespace rpwa {
+	namespace py {
+		void exportModelIntensity();
+	}
+}
+
+#endif

--- a/pyInterface/bindings/nBodyPhaseSpace/nBodyPhaseSpaceKinematics_py.cc
+++ b/pyInterface/bindings/nBodyPhaseSpace/nBodyPhaseSpaceKinematics_py.cc
@@ -56,6 +56,8 @@ void rpwa::py::exportNBodyPhaseSpaceKinematics() {
 
 		.def("setDecay", &nBodyPhaseSpaceKinematics_setDecay)
 
+		.def("calcBreakupMomenta", &rpwa::nBodyPhaseSpaceKinematics::calcBreakupMomenta)
+
 		.def("calcWeight", &rpwa::nBodyPhaseSpaceKinematics::calcWeight)
 
 		.def("calcEventKinematics", &nBodyPhaseSpaceKinematics_calcEventKinematics)

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -72,6 +72,11 @@ namespace {
 		return bp::list(self.evidenceComponents());
 	}
 
+	bp::list fitResult_waveIndicesMatchingPattern(const rpwa::fitResult& self,
+	                                              const std::string&     pattern) {
+		return bp::list(self.waveIndicesMatchingPattern(pattern));
+	}
+
 	PyObject* fitResult_prodAmpCov_1(const rpwa::fitResult& self, const unsigned int prodAmpIndex)
 	{
 		return rpwa::py::convertToPy<TMatrixT<double> >(self.prodAmpCov(prodAmpIndex));
@@ -340,6 +345,7 @@ void rpwa::py::exportFitResult() {
 		.def("rankOfProdAmp", &rpwa::fitResult::rankOfProdAmp)
 		.def("waveIndex", &rpwa::fitResult::waveIndex)
 		.def("prodAmpIndex", &rpwa::fitResult::prodAmpIndex)
+		.def("waveIndicesMatchingPattern", &fitResult_waveIndicesMatchingPattern)
 		.def("fitParameter", &rpwa::fitResult::fitParameter)
 		.def("prodAmp", &fitResult::prodAmp)
 		.def("prodAmpCov", &fitResult_prodAmpCov_2)

--- a/pyInterface/bindings/pyUtils/rootConverters_py.cc
+++ b/pyInterface/bindings/pyUtils/rootConverters_py.cc
@@ -1,6 +1,7 @@
 #include "rootConverters_py.h"
 
 #include<TClonesArray.h>
+#include<TF1.h>
 #include<TFile.h>
 #include<TLorentzRotation.h>
 #include<TPython.h>
@@ -126,6 +127,11 @@ void rpwa::py::exportRootConverters() {
 
 	bp::def(
 		"__RootConverters_convertFromPy_TFile", &rpwa::py::convertFromPy<TFile*>
+		, bp::return_internal_reference<1>()
+	);
+
+	bp::def(
+		"__RootConverters_convertFromPy_TF1", &rpwa::py::convertFromPy<TF1*>
 		, bp::return_internal_reference<1>()
 	);
 

--- a/pyInterface/bindings/pyUtils/rootConverters_py.cc
+++ b/pyInterface/bindings/pyUtils/rootConverters_py.cc
@@ -75,42 +75,6 @@ bool rpwa::py::branch(T objectPtr, PyObject* pyTree, const std::string& name, in
 template bool rpwa::py::branch<rpwa::fitResult*>(rpwa::fitResult* objectPtr, PyObject* pyTree, const std::string& name, int bufsize, int splitlevel);
 template bool rpwa::py::branch<rpwa::amplitudeTreeLeaf*>(rpwa::amplitudeTreeLeaf* objectPtr, PyObject* pyTree, const std::string& name, int bufsize, int splitlevel);
 
-namespace {
-
-	template<typename T>
-	T* getFromTDirectoryTemplate(PyObject* pyDir, const std::string& name)
-	{
-		TDirectory* dir = rpwa::py::convertFromPy<TDirectory*>(pyDir);
-		if(not dir) {
-			PyErr_SetString(PyExc_TypeError, "Got invalid input for directory when executing rpwa::py::getFromTDirectory()");
-			bp::throw_error_already_set();
-		}
-		return dynamic_cast<T*>(dir->Get(name.c_str()));
-	}
-
-}
-
-template<typename T>
-T* rpwa::py::getFromTDirectory(PyObject* /* pyDir */, const std::string& /* name */)
-{
-	printErr<<"Because of boost::python, this function has to be explicitly instantiated."<<std::endl;
-	throw;
-}
-
-namespace rpwa {
-
-	namespace py {
-
-		template<>
-		rpwa::ampIntegralMatrix* getFromTDirectory<rpwa::ampIntegralMatrix>(PyObject* pyDir, const std::string& name)
-		{
-			return getFromTDirectoryTemplate<rpwa::ampIntegralMatrix>(pyDir, name);
-		}
-
-	}
-
-}
-
 void rpwa::py::exportRootConverters() {
 
 	bp::def("__RootConverters_convertToPy_TVector3", &rpwa::py::convertToPy<TVector3>);

--- a/pyInterface/bindings/pyUtils/rootConverters_py.h
+++ b/pyInterface/bindings/pyUtils/rootConverters_py.h
@@ -26,9 +26,6 @@ namespace rpwa {
 		            int bufsize = 32000,
 		            int splitlevel = 99);
 
-		template<typename T>
-		T* getFromTDirectory(PyObject* pyDir, const std::string& name);
-
 		void exportRootConverters();
 
 	}

--- a/pyInterface/bindings/rootPwaPy.cc
+++ b/pyInterface/bindings/rootPwaPy.cc
@@ -27,6 +27,9 @@
 #include "generatorManager_py.h"
 #include "generatorParameters_py.h"
 #include "generatorPickerFunctions_py.h"
+#ifdef USE_BAT
+#include "importanceSampler_py.h"
+#endif
 #include "modelIntensity_py.h"
 
 // highLevelInterface
@@ -96,6 +99,9 @@ BOOST_PYTHON_MODULE(libRootPwaPy){
 	rpwa::py::exportGeneratorParameters();
 	rpwa::py::exportGeneratorPickerFunctions();
 	rpwa::py::exportBeamAndVertexGenerator();
+#ifdef USE_BAT
+	rpwa::py::exportImportanceSampler();
+#endif
 	rpwa::py::exportModelIntensity();
 	rpwa::py::exportComplexMatrix();
 	rpwa::py::exportFitResult();

--- a/pyInterface/bindings/rootPwaPy.cc
+++ b/pyInterface/bindings/rootPwaPy.cc
@@ -27,6 +27,7 @@
 #include "generatorManager_py.h"
 #include "generatorParameters_py.h"
 #include "generatorPickerFunctions_py.h"
+#include "modelIntensity_py.h"
 
 // highLevelInterface
 #include "calcAmplitude_py.h"
@@ -95,6 +96,7 @@ BOOST_PYTHON_MODULE(libRootPwaPy){
 	rpwa::py::exportGeneratorParameters();
 	rpwa::py::exportGeneratorPickerFunctions();
 	rpwa::py::exportBeamAndVertexGenerator();
+	rpwa::py::exportModelIntensity();
 	rpwa::py::exportComplexMatrix();
 	rpwa::py::exportFitResult();
 	rpwa::py::exportPartialWaveFitHelper();

--- a/pyInterface/scripts/genPseudoData.py
+++ b/pyInterface/scripts/genPseudoData.py
@@ -21,15 +21,15 @@ if __name__ == "__main__":
 	parser.add_argument("fitResult", type=str, metavar="fitResult", help="fitResult to get the production amplitudes")
 	parser.add_argument("outputFile", type=str, metavar="outputFile", help="output root file")
 	parser.add_argument("-c", type=str, metavar="config-file", default="rootpwa.config", dest="configFileName",
-	                    help="path to config file (default: ./rootpwa.config)")
+	                    help="path to config file (default: '%(default)s')")
 	parser.add_argument("-i", "--integralFile", type=str, metavar="integralFile", help="integral file")
-	parser.add_argument("-n", type=int, metavar="#", dest="nEvents", default=100, help="(max) number of events to generate (default: 100)")
-	parser.add_argument("-s", type=int, metavar="#", dest="seed", default=0, help="random number generator seed (default: 0)")
+	parser.add_argument("-n", type=int, metavar="#", dest="nEvents", default=100, help="(max) number of events to generate (default: %(default)s)")
+	parser.add_argument("-s", type=int, metavar="#", dest="seed", default=0, help="random number generator seed (default: %(default)s)")
 	parser.add_argument("-M", type=float, metavar="#", dest="massLowerBinBoundary",
 	                    help="lower boundary of mass range in MeV (!) (overwrites values from reaction file)")
 	parser.add_argument("-B", type=float, metavar="#", dest="massBinWidth", help="width of mass bin in MeV (!)")
 	parser.add_argument("-u", "--userString", type=str, metavar="#", dest="userString", help="metadata user string", default="phaseSpaceEvents")
-	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: %(default)s)",
+	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: '%(default)s')",
 	                    default="mass,tPrime")
 	parser.add_argument("--noStoreMassTPrime", action="store_true", dest="noStoreMassTPrime", help="Do not store mass and t' variable of each event.")
 	parser.add_argument("--beamfile", type=str, metavar="<beamFile>", dest="beamFileName", help="path to beam file (overrides values from config file)")

--- a/pyInterface/scripts/genPseudoData.py
+++ b/pyInterface/scripts/genPseudoData.py
@@ -10,7 +10,11 @@ import pyRootPwa.core
 if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(
-	                                 description="generate phase-space Monte Carlo events"
+	                                 description="""
+	                                                Generate phase-space Monte Carlo events and calculate the
+	                                                weight of each event from the provided fit result. The events
+	                                                in the output file are not deweighted.
+	                                             """
 	                                )
 
 	parser.add_argument("reactionFile", type=str, metavar="reactionFile", help="reaction config file")

--- a/pyInterface/scripts/genPseudoData.py
+++ b/pyInterface/scripts/genPseudoData.py
@@ -10,7 +10,7 @@ import pyRootPwa.core
 if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(
-	                                 description="generate phase space Monte Carlo events"
+	                                 description="generate phase-space Monte Carlo events"
 	                                )
 
 	parser.add_argument("reactionFile", type=str, metavar="reactionFile", help="reaction config file")
@@ -109,7 +109,7 @@ if __name__ == "__main__":
 		if not result:
 			printErr('could not construct amplitude for wave "' + waveName + '".')
 			sys.exit(1)
-		if not model.addAmplitude(amplitude):
+		if not model.addDecayAmplitude(amplitude):
 			printErr('could not add amplitude for wave "' + waveName + '".')
 
 	# overwrite integral matrix from fit result with one read from a file
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 		integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile, "READ")
 		integralMeta = pyRootPwa.core.ampIntegralMatrixMetadata.readIntegralFile(integralFile)
 		integral = integralMeta.getAmpIntegralMatrix()
-		model.addIntegral(integral)
+		model.loadPhaseSpaceIntegral(integral)
 
 	outputFile = pyRootPwa.ROOT.TFile.Open(args.outputFile, "NEW")
 	if not outputFile:
@@ -170,7 +170,7 @@ if __name__ == "__main__":
 					printErr('could not initialize file writer. Aborting...')
 					sys.exit(1)
 
-				if not model.initAmplitudes(prodKinNames, decayKinNames):
+				if not model.initDecayAmplitudes(prodKinNames, decayKinNames):
 					printErr('could not initialize kinematics Data. Aborting...')
 					sys.exit(1)
 				first = False

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -131,14 +131,20 @@ if __name__ == "__main__":
 		modelSampler.setPhaseSpaceOnly()
 
 	outputFile = pyRootPwa.ROOT.TFile.Open(args.outputFile, "NEW")
+	if not outputFile:
+		printErr("could not open output file. Aborting...")
+		sys.exit(1)
 	if len(args.massTPrimeVariableNames.split(',')) != 2:
 		printErr("Option --massTPrimeVariableNames has wrong format '" + args.massTPrimeVariableNames + "'. Aborting...")
 		sys.exit(1)
-	modelSampler.initializeFileWriter(outputFile,
-	                                  args.userString,
-	                                  not args.noStoreMassTPrime,
-	                                  args.massTPrimeVariableNames.split(',')[0],
-	                                  args.massTPrimeVariableNames.split(',')[1])
+	success = modelSampler.initializeFileWriter(outputFile,
+	                                            args.userString,
+	                                            not args.noStoreMassTPrime,
+	                                            args.massTPrimeVariableNames.split(',')[0],
+	                                            args.massTPrimeVariableNames.split(',')[1])
+	if not success:
+		printErr('could not initialize file writer. Aborting...')
+		sys.exit(1)
 
 	modelSampler.SetNChains(args.nChains)
 	modelSampler.SetNIterationsRun(args.nEvents/args.nChains*args.lag)

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 	parser.add_argument("-M", type=float, metavar="#", dest="massLowerBinBoundary",
 	                    help="lower boundary of mass range in MeV (!) (overwrites values from reaction file)")
 	parser.add_argument("-B", type=float, metavar="#", dest="massBinWidth", help="width of mass bin in MeV (!)")
-	parser.add_argument("-u", "--userString", type=str, metavar="#", dest="userString", help="metadata user string", default="")
+	parser.add_argument("-u", "--userString", type=str, metavar="#", dest="userString", help="metadata user string", default="importanceSampledEvents")
 	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: %(default)s)",
 	                    default="mass,tPrime")
 	parser.add_argument("--noStoreMassTPrime", action="store_true", dest="noStoreMassTPrime", help="Do not store mass and t' variable of each event.")
@@ -135,6 +135,7 @@ if __name__ == "__main__":
 		printErr("Option --massTPrimeVariableNames has wrong format '" + args.massTPrimeVariableNames + "'. Aborting...")
 		sys.exit(1)
 	modelSampler.initializeFileWriter(outputFile,
+	                                  args.userString,
 	                                  not args.noStoreMassTPrime,
 	                                  args.massTPrimeVariableNames.split(',')[0],
 	                                  args.massTPrimeVariableNames.split(',')[1])

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -10,7 +10,12 @@ import pyRootPwa.core
 if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(
-	                                 description="generate phase-space Monte Carlo events"
+	                                 description="""
+	                                                Generate Monte Carlo events according to the provided
+	                                                fit-result by sampling the phase space and the model intensity
+	                                                using BAT. The events in the output file must not need be
+	                                                deweighted.
+	                                             """
 	                                )
 
 	parser.add_argument("reactionFile", type=str, metavar="reactionFile", help="reaction config file")

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -10,7 +10,7 @@ import pyRootPwa.core
 if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(
-	                                 description="generate phase space Monte Carlo events"
+	                                 description="generate phase-space Monte Carlo events"
 	                                )
 
 	parser.add_argument("reactionFile", type=str, metavar="reactionFile", help="reaction config file")
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 		if not result:
 			printErr('could not construct amplitude for wave "' + waveName + '".')
 			sys.exit(1)
-		if not model.addAmplitude(amplitude):
+		if not model.addDecayAmplitude(amplitude):
 			printErr('could not add amplitude for wave "' + waveName + '".')
 
 	# overwrite integral matrix from fit result with one read from a file
@@ -120,7 +120,7 @@ if __name__ == "__main__":
 		integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile, "READ")
 		integralMeta = pyRootPwa.core.ampIntegralMatrixMetadata.readIntegralFile(integralFile)
 		integral = integralMeta.getAmpIntegralMatrix()
-		model.addIntegral(integral)
+		model.loadPhaseSpaceIntegral(integral)
 
 	# do not let BAT create histograms in the eventfile, otherwise this script
 	# will exit with a segmentation violation due to ROOT ownership

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -126,13 +126,21 @@ if __name__ == "__main__":
 		modelSampler.setPhaseSpaceOnly()
 
 	outputFile = pyRootPwa.ROOT.TFile.Open(args.outputFile, "NEW")
-	modelSampler.initializeFileWriter(outputFile)
+	if len(args.massTPrimeVariableNames.split(',')) != 2:
+		printErr("Option --massTPrimeVariableNames has wrong format '" + args.massTPrimeVariableNames + "'. Aborting...")
+		sys.exit(1)
+	modelSampler.initializeFileWriter(outputFile,
+	                                  not args.noStoreMassTPrime,
+	                                  args.massTPrimeVariableNames.split(',')[0],
+	                                  args.massTPrimeVariableNames.split(',')[1])
 
 	modelSampler.SetNChains(args.nChains)
 	modelSampler.SetNIterationsRun(args.nEvents/args.nChains*args.lag)
 	modelSampler.SetNLag(args.lag)
 	modelSampler.SetRandomSeed(args.seed)
 	modelSampler.MarginalizeAll()
+
+	modelSampler.finalizeFileWriter()
 
 	modelSampler.PrintAllMarginalized(args.outputFile.replace(".root",".pdf").replace(".ROOT",".pdf"),2,4)
 	modelSampler.PrintCorrelationMatrix(args.outputFile.replace(".root","_coma.pdf").replace(".ROOT","_coma.pdf"))
@@ -149,7 +157,3 @@ if __name__ == "__main__":
 		printWarn("high efficiency encountered. Try increasing the lag to avoid correlations")
 	elif realEfficiency > 1.:
 		printErr("efficiency > 1 encountered. Data are highly correlated. Increase the lag.")
-
-	modelSampler.finalizeFileWriter()
-	outputFile.Close()
-	integralFile.Close()

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -22,20 +22,20 @@ if __name__ == "__main__":
 	parser.add_argument("fitResult", type=str, metavar="fitResult", help="fitResult to get the production amplitudes")
 	parser.add_argument("outputFile", type=str, metavar="outputFile", help="output root file")
 	parser.add_argument("-c", type=str, metavar="config-file", default="rootpwa.config", dest="configFileName",
-	                    help="path to config file (default: ./rootpwa.config)")
+	                    help="path to config file (default: '%(default)s')")
 	parser.add_argument("-i", "--integralFile", type=str, metavar="integralFile", help="integral file")
-	parser.add_argument("-n", type=int, metavar="#", dest="nEvents", default=100, help="(max) number of events to generate (default: 100)")
+	parser.add_argument("-n", type=int, metavar="#", dest="nEvents", default=100, help="(max) number of events to generate (default: %(default)s)")
 	parser.add_argument("-C", type=int, metavar="#", dest="nChains", default=5, help="number od MCMC chains to be run")
-	parser.add_argument("-s", type=int, metavar="#", dest="seed", default=0, help="random number generator seed (default: 0)")
+	parser.add_argument("-s", type=int, metavar="#", dest="seed", default=0, help="random number generator seed (default: %(default)s)")
 	parser.add_argument("-l", type=int, metavar="#", dest="lag", default=1, help="take just every nth generated event into the sample to avoid correlations")
 	parser.add_argument("-M", type=float, metavar="#", dest="massLowerBinBoundary",
 	                    help="lower boundary of mass range in MeV (!) (overwrites values from reaction file)")
 	parser.add_argument("-B", type=float, metavar="#", dest="massBinWidth", help="width of mass bin in MeV (!)")
 	parser.add_argument("-u", "--userString", type=str, metavar="#", dest="userString", help="metadata user string", default="importanceSampledEvents")
-	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: %(default)s)",
+	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: '%(default)s')",
 	                    default="mass,tPrime")
 	parser.add_argument("--noStoreMassTPrime", action="store_true", dest="noStoreMassTPrime", help="Do not store mass and t' variable of each event.")
-	parser.add_argument("-p", "--phaseSpaceOnly", help="do phase space only (default: false)", action="store_true")
+	parser.add_argument("-p", "--phaseSpaceOnly", help="do phase space only (default: %(default)s)", action="store_true")
 	parser.add_argument("--beamfile", type=str, metavar="<beamFile>", dest="beamFileName", help="path to beam file (overrides values from config file)")
 	parser.add_argument("--noRandomBeam", action="store_true", dest="noRandomBeam", help="read the events from the beamfile sequentially")
 	parser.add_argument("--randomBlockBeam", action="store_true", dest="randomBlockBeam", help="like --noRandomBeam but with random starting position")

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -137,6 +137,8 @@ if __name__ == "__main__":
 	modelSampler.PrintAllMarginalized(args.outputFile.replace(".root",".pdf").replace(".ROOT",".pdf"),2,4)
 	modelSampler.PrintCorrelationMatrix(args.outputFile.replace(".root","_coma.pdf").replace(".ROOT","_coma.pdf"))
 
+	modelSampler.printFuncInfo()
+
 	realEfficiency = float(args.nEvents)/float(modelSampler.nCalls())
 	printInfo("generated "+str(args.nEvents)+" with "+str(args.nChains)+" chains, needed "+str(modelSampler.nCalls()) + " actual calls => efficiency:"+str(realEfficiency))
 	if realEfficiency < .5 and realEfficiency > .3:

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+import argparse
+import os.path
+import sys
+
+import pyRootPwa
+import pyRootPwa.core
+
+
+if __name__ == "__main__":
+
+	parser = argparse.ArgumentParser(
+	                                 description="generate phase space Monte Carlo events"
+	                                )
+
+	parser.add_argument("reactionFile", type=str, metavar="reactionFile", help="reaction config file")
+	parser.add_argument("fitResult", type=str, metavar="fitResult", help="fitResult to get the production amplitudes")
+	parser.add_argument("integralFile", type=str, metavar="integralFile", help="integral file")
+	parser.add_argument("outputFile", type=str, metavar="outputFile", help="output root file")
+	parser.add_argument("-c", type=str, metavar="config-file", default="rootpwa.config", dest="configFileName",
+	                    help="path to config file (default: ./rootpwa.config)")
+	parser.add_argument("-n", type=int, metavar="#", dest="nEvents", default=100, help="(max) number of events to generate (default: 100)")
+	parser.add_argument("-C", type=int, metavar="#", dest="nChains", default=5, help="number od MCMC chains to be run")
+	parser.add_argument("-s", type=int, metavar="#", dest="seed", default=0, help="random number generator seed (default: 0)")
+	parser.add_argument("-l", type=int, metavar="#", dest="lag", default=1, help="take just every nth generated event into the sample to avoid correlations")
+	parser.add_argument("-M", type=float, metavar="#", dest="massLowerBinBoundary",
+	                    help="lower boundary of mass range in MeV (!) (overwrites values from reaction file)")
+	parser.add_argument("-B", type=float, metavar="#", dest="massBinWidth", help="width of mass bin in MeV (!)")
+	parser.add_argument("-u", "--userString", type=str, metavar="#", dest="userString", help="metadata user string", default="")
+	parser.add_argument("--massTPrimeVariableNames", type=str, dest="massTPrimeVariableNames", help="Name of the mass and t' variable (default: %(default)s)",
+	                    default="mass,tPrime")
+	parser.add_argument("--noStoreMassTPrime", action="store_true", dest="noStoreMassTPrime", help="Do not store mass and t' variable of each event.")
+	parser.add_argument("-p", "--phaseSpaceOnly", help="do phase space only (default: false)", action="store_true")
+	parser.add_argument("--beamfile", type=str, metavar="<beamFile>", dest="beamFileName", help="path to beam file (overrides values from config file)")
+	parser.add_argument("--noRandomBeam", action="store_true", dest="noRandomBeam", help="read the events from the beamfile sequentially")
+	parser.add_argument("--randomBlockBeam", action="store_true", dest="randomBlockBeam", help="like --noRandomBeam but with random starting position")
+
+	args = parser.parse_args()
+
+	# print some info
+	pyRootPwa.core.printCompilerInfo()
+	pyRootPwa.core.printLibraryInfo()
+	pyRootPwa.core.printGitHash()
+
+	printErr  = pyRootPwa.utils.printErr
+	printWarn = pyRootPwa.utils.printWarn
+	printSucc = pyRootPwa.utils.printSucc
+	printInfo = pyRootPwa.utils.printInfo
+	printDebug = pyRootPwa.utils.printDebug
+
+	config = pyRootPwa.rootPwaConfig()
+	if not config.initialize(args.configFileName):
+		pyRootPwa.utils.printErr("loading config file '" + args.configFileName + "' failed. Aborting...")
+		sys.exit(1)
+	pyRootPwa.core.particleDataTable.instance.readFile(config.pdgFileName)
+	fileManager = pyRootPwa.loadFileManager(config.fileManagerPath)
+	if not fileManager:
+		pyRootPwa.utils.printErr("loading the file manager failed. Aborting...")
+		sys.exit(1)
+
+	pyRootPwa.core.integralTableContainer.setDirectory(config.phaseSpaceIntegralDirectory)
+	pyRootPwa.core.integralTableContainer.setUpperMassBound(config.phaseSpaceUpperMassBound)
+
+	# read integral matrix from ROOT file
+	integralFile = pyRootPwa.ROOT.TFile.Open(args.integralFile)
+	integral = pyRootPwa.core.ampIntegralMatrix.getFromTDirectory(integralFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
+	integralFile.Close()
+	nmbNormEvents = integral.nmbEvents()
+
+	overrideMass = (args.massLowerBinBoundary is not None) or (args.massBinWidth is not None)
+
+	if overrideMass and not ((args.massLowerBinBoundary is not None) and (args.massBinWidth is not None)):
+		printErr("'-M' and '-B' can only be set together. Aborting...")
+		sys.exit(2)
+
+	printInfo("Setting random seed to " + str(args.seed))
+	pyRootPwa.core.randomNumberGenerator.instance.setSeed(args.seed)
+
+	generatorManager = pyRootPwa.core.generatorManager()
+	if args.beamFileName is not None:
+		generatorManager.overrideBeamFile(args.beamFileName)
+
+	if not generatorManager.readReactionFile(args.reactionFile):
+		printErr("could not read reaction file. Aborting...")
+		sys.exit(1)
+
+	if overrideMass:
+		generatorManager.overrideMassRange(args.massLowerBinBoundary / 1000., (args.massLowerBinBoundary + args.massBinWidth) / 1000.)
+	if args.noRandomBeam:
+		generatorManager.readBeamfileSequentially()
+	if args.randomBlockBeam:
+		generatorManager.readBeamfileSequentially()
+		generatorManager.randomizeBeamfileStartingPosition()
+
+	if not generatorManager.initializeGenerator():
+		printErr("could not initialize generator. Aborting...")
+		sys.exit(1)
+
+	massRange = generatorManager.getGenerator().getTPrimeAndMassPicker().massRange()
+	massBinCenter = (massRange[0] + massRange[1]) / 2.
+	fitResult = pyRootPwa.utils.getBestFitResultFromFile(fitResultFileName = args.fitResult,
+	                                                     massBinCenter = massBinCenter,
+	                                                     fitResultTreeName = config.fitResultTreeName,
+	                                                     fitResultBranchName = config.fitResultBranchName)
+	if not fitResult:
+		printErr("could not find fit result in file '" + args.fitResult +
+		         "' for mass bin " + str(massBinCenter) + ". Aborting...")
+		sys.exit(1)
+
+	waveNames = fitResult.waveNames()
+
+	if fitResult.nmbProdAmps() != len(waveNames):
+		pyRootPwa.utils.printErr('Number of production amplitudes (' + str(fitResult.nmbProdAmps()) +
+		                         ') not equal to number of wave names (' + str(len(waveNames)) + '). Aborting...')
+		sys.exit(1)
+
+	if 'flat' in waveNames:
+		waveNames.remove('flat')  # ignore flat wave
+
+	model = pyRootPwa.core.modelIntensity()
+
+	for waveName in waveNames:
+		waveDescription = fileManager.getWaveDescription(waveName)
+		reflectivity = pyRootPwa.core.partialWaveFitHelper.getReflectivity(waveName)
+		waveIndex = fitResult.waveIndex(waveName)
+
+		if not waveName == fitResult.waveNameForProdAmp(waveIndex):
+			printErr("mismatch between waveName '" + waveName + "' and prodAmpName '" + fitResult.waveNameForProdAmp(waveIndex) + "'. Aborting...")
+		prodAmp = fitResult.prodAmp(waveIndex)
+		(result, amplitude) = waveDescription.constructAmplitude()
+		if not result:
+			printErr('could not construct amplitude for wave "' + waveName + '".')
+			sys.exit(1)
+		model.addAmplitude(prodAmp, amplitude, reflectivity)
+
+	model.loadIntegrals(integral)
+	model.initAmplitudes()
+
+
+	modelSampler = generatorManager.getImportanceSampler(model)
+	modelOutput =  pyRootPwa.ROOT.TFile.Open(args.outputFile, "NEW")
+	modelSampler.initializeFileWriter(modelOutput)
+	modelSampler.SetNChains(args.nChains)
+	modelSampler.SetNIterationsRun(args.nEvents/args.nChains*args.lag)
+	modelSampler.SetNLag(args.lag)
+	if args.phaseSpaceOnly:
+		modelSampler.setPhaseSpaceOnly()
+
+	modelSampler.SetRandomSeed(args.seed)
+	modelSampler.MarginalizeAll()
+
+	modelSampler.PrintAllMarginalized(args.outputFile.replace(".root",".pdf").replace(".ROOT",".pdf"),2,4)
+	modelSampler.PrintCorrelationMatrix(args.outputFile.replace(".root","_coma.pdf").replace(".ROOT","_coma.pdf"))
+
+	realEfficiency = float(args.nEvents)/float(modelSampler.nCalls())
+	printInfo("generated "+str(args.nEvents)+" with "+str(args.nChains)+" chains, needed "+str(modelSampler.nCalls()) + " actual calls => efficiency:"+str(realEfficiency))
+	if realEfficiency < .5 and realEfficiency > .3:
+		printSucc("efficiency in acceptable range")
+	elif realEfficiency <= .3:
+		printWarn("low efficiency encountered. Try decreasing the lag to speed up the process")
+	elif realEfficiency >= .5 and realEfficiency <= 1.:
+		printWarn("high efficiency encountered. Try increasing the lag to avoid correlations")
+	elif realEfficiency > 1.:
+		printErr("efficiency > 1 encountered. Data are highly correlated. Increase the lag.")
+
+	modelSampler.finalizeFileWriter()
+	modelOutput.Close()
+	integralFile.Close()

--- a/pyInterface/scripts/genPseudoDataImportanceSampling.py
+++ b/pyInterface/scripts/genPseudoDataImportanceSampling.py
@@ -121,6 +121,10 @@ if __name__ == "__main__":
 			printErr('could not add amplitude for wave "' + waveName + '".')
 	model.addIntegral(integral)
 
+	# do not let BAT create histograms in the eventfile, otherwise this script
+	# will exit with a segmentation violation due to ROOT ownership
+	pyRootPwa.ROOT.TH1.AddDirectory(False)
+
 	modelSampler = generatorManager.getImportanceSampler(model)
 	if args.phaseSpaceOnly:
 		modelSampler.setPhaseSpaceOnly()

--- a/test/integralBenchmark.py
+++ b/test/integralBenchmark.py
@@ -79,8 +79,8 @@ if __name__ == "__main__":
 
 	integralBenchmarkFile = ROOT.TFile.Open(args.path + "/integralBenchmark.root", "READ")
 	integralCreatedFile   = ROOT.TFile.Open(args.path + "/integral.root", "READ")
-	ampIntMatrixBenchmark = pyRootPwa.core.ampIntegralMatrix.getFromTDirectory(integralBenchmarkFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
-	ampIntMatrixCreated   = pyRootPwa.core.ampIntegralMatrix.getFromTDirectory(integralCreatedFile, pyRootPwa.core.ampIntegralMatrix.integralObjectName)
+	ampIntMatrixBenchmark = pyRootPwa.core.ampIntegralMatrix.readIntegralFile(integralBenchmarkFile).getAmpIntegralMatrix()
+	ampIntMatrixCreated   = pyRootPwa.core.ampIntegralMatrix.readIntegralFile(integralCreatedFile).getAmpIntegralMatrix()
 
 	if ampIntMatrixBenchmark == ampIntMatrixCreated:
 		pyRootPwa.utils.printSucc("TEST SUCCEEDED!!")

--- a/test/testMC.sh
+++ b/test/testMC.sh
@@ -158,7 +158,8 @@ testStep "calculation of integrals for phase-space data" "${ROOTPWA}/build/bin/c
 # generate weighted MC pseudo data
 testStep "generation of MC data with weights" \
 "${ROOTPWA}/build/bin/genPseudoData \
-\"./generator_noBeamSimulation.conf\" \ \"${TESTDIR}/reference_fit/bin65_c2pap_bestfits_converged_MASS_1800_1820_N45340.root\" \ \"./ints/integral_binID-0_2.root\" \ \"./weighted_mc_data/weighted_pseudoData_MASS_${MASS}-$((MASS+BINWIDTH))_N_${NMB_PSEUDO_EVENTS}.root\" \
+\"./generator_noBeamSimulation.conf\" \ \"${TESTDIR}/reference_fit/bin65_c2pap_bestfits_converged_MASS_1800_1820_N45340.root\" \ \"./weighted_mc_data/weighted_pseudoData_MASS_${MASS}-$((MASS+BINWIDTH))_N_${NMB_PSEUDO_EVENTS}.root\" \
+-i \"./ints/integral_binID-0_2.root\" \
 -s ${SEED_PSEUDO} \
 -n ${NMB_PSEUDO_EVENTS} \
 -M ${MASS} \


### PR DESCRIPTION
update of #139:
* use a new method in `fitResult` class to get the intensity of the model, this adds supports for more than one rank
* clear separation of generator stuff in `importanceSampler` class and the weight calculation in `modelIntensity`
* use the new `modelIntensity` class also in the standard `genPseudoData`
* in case the fit result contains the phase-space integrals those can be used, this changes the required command line arguments for `genPseudoData` and `genPseudoDataImportanceSampler`, integrals can still be overwritten with the new `-i` option
* use the `nBodyPhaseSpaceKinematics` class to calculate phase-space weights from the `importanceSampler`
* more detailed call statistic for functions called from BAT
* fix if BAT was compiled with OpenMP
* fix a couple of segmentation violations