### PR TITLE
pyInterface: search for amplitude metadata in 'printMetadata'

### DIFF
--- a/pyInterface/scripts/printMetadata.py
+++ b/pyInterface/scripts/printMetadata.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 		# get the amplitude names from the list of keys
 		if key.GetClassName() == "rpwa::amplitudeMetadata":
 			if not key.GetName().endswith(".meta"):
-				pyRootPwa.utils.printErr("key with name '{}' is an amplitude metadata object but does not follow the naming convention.")
+				pyRootPwa.utils.printErr("key with name '{}' is an amplitude metadata object but does not follow the naming convention.".format(key.GetName()))
 				sys.exit(1)
 
 			amplitudeMeta = pyRootPwa.core.amplitudeMetadata.readAmplitudeFile(inputFile, key.GetName()[:-5], True)

--- a/pyInterface/scripts/printMetadata.py
+++ b/pyInterface/scripts/printMetadata.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(description="print event metadata")
 	parser.add_argument("inputFile", type=str, metavar="inputFile", help="input file in ROOTPWA format")
-	parser.add_argument("-r", action="store_true", dest="recalculateHash", help="recalculate hash and compare it with the stored one (default: %(default)s)")
+	parser.add_argument("-v", "--verify", action="store_true", dest="verifyHash", help="verify hash(es) (default: %(default)s)")
 	args = parser.parse_args()
 
 	inputFile = ROOT.TFile.Open(args.inputFile, "READ")
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 	if eventMeta:
 		readMeta = True
 
-		if args.recalculateHash:
+		if args.verifyHash:
 			pyRootPwa.utils.printInfo("recalculating hash...")
 			calcHash = eventMeta.recalculateHash(True)
 			if calcHash != eventMeta.contentHash():
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
 			readMeta = True
 
-			if args.recalculateHash:
+			if args.verifyHash:
 				pyRootPwa.utils.printInfo("recalculating hash...")
 				calcHash = amplitudeMeta.recalculateHash(True)
 				if calcHash != amplitudeMeta.contentHash():
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 	if ampIntegralMatrixMeta:
 		readMeta = True
 
-		if args.recalculateHash:
+		if args.verifyHash:
 			pyRootPwa.utils.printInfo("recalculating hash...")
 			calcHash = ampIntegralMatrixMeta.recalculateHash()
 			if calcHash != ampIntegralMatrixMeta.contentHash():

--- a/pyInterface/scripts/printMetadata.py
+++ b/pyInterface/scripts/printMetadata.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 import argparse
-import os
 import sys
 
 import pyRootPwa
@@ -17,7 +16,6 @@ if __name__ == "__main__":
 
 	parser = argparse.ArgumentParser(description="print event metadata")
 	parser.add_argument("inputFile", type=str, metavar="inputFile", help="input file in ROOTPWA format")
-	parser.add_argument("-a", "--amplitudeObjectBaseName", type=str, metavar="objectBaseName", help="amplitude object base name (default: try to guess from input file name)")
 	parser.add_argument("-r", action="store_true", dest="recalculateHash", help="recalculate hash and compare it with the stored one (default: %(default)s)")
 	args = parser.parse_args()
 
@@ -26,9 +24,14 @@ if __name__ == "__main__":
 		pyRootPwa.utils.printErr("could not open input file '" + args.inputFile + "'.")
 		sys.exit(1)
 
+	# keep track that at least one metadata object was found
+	readMeta = False
+
 	# try to read event metadata
 	eventMeta = pyRootPwa.core.eventMetadata.readEventFile(inputFile, True)
 	if eventMeta:
+		readMeta = True
+
 		if args.recalculateHash:
 			pyRootPwa.utils.printInfo("recalculating hash...")
 			calcHash = eventMeta.recalculateHash(True)
@@ -44,28 +47,36 @@ if __name__ == "__main__":
 		print(eventMeta)
 
 	# try to read amplitude metadata
-	amplitudeObjectBaseName = args.amplitudeObjectBaseName
-	if not amplitudeObjectBaseName:
-		amplitudeObjectBaseName = os.path.basename(args.inputFile).split("_eventFileId")[0]
-	amplitudeMeta = pyRootPwa.core.amplitudeMetadata.readAmplitudeFile(inputFile, amplitudeObjectBaseName, True)
-	if amplitudeMeta:
-		if args.recalculateHash:
-			pyRootPwa.utils.printInfo("recalculating hash...")
-			calcHash = amplitudeMeta.recalculateHash(True)
-			if calcHash != amplitudeMeta.contentHash():
-				pyRootPwa.utils.printErr("hash verification failed, hash from metadata '" +
-				                         amplitudeMeta.contentHash() +"' does not match with " +
-				                         "calculated hash '" + calcHash + "'.")
-			else:
-				print("")
-				pyRootPwa.utils.printSucc("recalculated hash matches with hash from metadata.")
-				print("")
+	for key in inputFile.GetListOfKeys():
+		# get the amplitude names from the list of keys
+		if key.GetClassName() == "rpwa::amplitudeMetadata":
+			if not key.GetName().endswith(".meta"):
+				pyRootPwa.utils.printErr("key with name '{}' is an amplitude metadata object but does not follow the naming convention.")
+				sys.exit(1)
 
-		print(amplitudeMeta)
+			amplitudeMeta = pyRootPwa.core.amplitudeMetadata.readAmplitudeFile(inputFile, key.GetName()[:-5], True)
+
+			readMeta = True
+
+			if args.recalculateHash:
+				pyRootPwa.utils.printInfo("recalculating hash...")
+				calcHash = amplitudeMeta.recalculateHash(True)
+				if calcHash != amplitudeMeta.contentHash():
+					pyRootPwa.utils.printErr("hash verification failed, hash from metadata '" +
+					                         amplitudeMeta.contentHash() +"' does not match with " +
+					                         "calculated hash '" + calcHash + "'.")
+				else:
+					print("")
+					pyRootPwa.utils.printSucc("recalculated hash matches with hash from metadata.")
+					print("")
+
+			print(amplitudeMeta)
 
 	# try to read amplitude integral matrix metadata
 	ampIntegralMatrixMeta = pyRootPwa.core.ampIntegralMatrixMetadata.readIntegralFile(inputFile, True)
 	if ampIntegralMatrixMeta:
+		readMeta = True
+
 		if args.recalculateHash:
 			pyRootPwa.utils.printInfo("recalculating hash...")
 			calcHash = ampIntegralMatrixMeta.recalculateHash()
@@ -80,6 +91,6 @@ if __name__ == "__main__":
 
 		print(ampIntegralMatrixMeta)
 
-	if not eventMeta and not amplitudeMeta and not ampIntegralMatrixMeta:
+	if not readMeta:
 		pyRootPwa.utils.printErr("could not read any metadata")
 		sys.exit(1)


### PR DESCRIPTION
Do not require that 'printMetadata' is called with an argument
specifying which amplitude to print, but loop over the keys of the ROOT
file, and print all amplitude metadata objects that are found. This
covers the typical case of one amplitude per file, but should also be
working if multiple amplitudes are stored in the same file.