### PR TITLE
Check pylint version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,11 +294,16 @@ message(STATUS "Using python bindings output path '${PYTHON_LIBRARY_OUTPUT_PATH}
 # setup pylint (optional)
 message(STATUS "")
 message(STATUS ">>> Setting up pylint.")
-find_program(PYLINT_EXECUTABLE pylint)
-if(NOT PYLINT_EXECUTABLE)
+find_package(PYLINT 1.5.5)
+set_package_properties(PYLINT
+	PROPERTIES
+	DESCRIPTION "code analysis for Python"
+	URL "https://www.pylint.org"
+	PURPOSE "Used to assess quality of Python code."
+	TYPE OPTIONAL
+	)
+if(NOT PYLINT_FOUND)
 	message(STATUS "Cannot find pylint executable. Quality of python code will no be assessed.")
-else()
-	message(STATUS "Using pylint executable '${PYLINT_EXECUTABLE}'.")
 endif()
 
 

--- a/cmakeModules/FindPYLINT.cmake
+++ b/cmakeModules/FindPYLINT.cmake
@@ -1,0 +1,62 @@
+#///////////////////////////////////////////////////////////////////////////
+#//
+#//    Copyright 2016
+#//
+#//    This file is part of rootpwa
+#//
+#//    rootpwa is free software: you can redistribute it and/or modify
+#//    it under the terms of the GNU General Public License as published by
+#//    the Free Software Foundation, either version 3 of the License, or
+#//    (at your option) any later version.
+#//
+#//    rootpwa is distributed in the hope that it will be useful,
+#//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#//    GNU General Public License for more details.
+#//
+#//    You should have received a copy of the GNU General Public License
+#//    along with rootpwa.  If not, see <http://www.gnu.org/licenses/>.
+#//
+#///////////////////////////////////////////////////////////////////////////
+#//-------------------------------------------------------------------------
+#//
+#// Description:
+#//      cmake module for finding pylint executable
+#//
+#//      following variables are defined:
+#//      PYLINT_FOUND              - pylint found
+#//      PYLINT_EXECUTABLE         - path to pylint executable
+#//      PYLINT_VERSION            - version of pylint executable
+#//
+#//      Example usage:
+#//          find_package(PYLINT 1.5.5 Optional)
+#//
+#//
+#// Author List:
+#//      Sebastian Uhl        TUM            (original author)
+#//
+#//
+#//-------------------------------------------------------------------------
+
+
+unset(PYLINT_FOUND)
+unset(PYLINT_EXECUTABLE)
+unset(PYLINT_VERSION)
+
+# find pylint executable
+find_program(PYLINT_EXECUTABLE pylint)
+
+# if pylint was found extract its version
+if(PYLINT_EXECUTABLE)
+	execute_process(COMMAND ${PYLINT_EXECUTABLE} --version
+	                OUTPUT_VARIABLE _PYLINT_VERSION_RAW
+	                ERROR_QUIET
+	               )
+	string(REGEX REPLACE "pylint ([0123456789\\.]+).*" "\\1" PYLINT_VERSION "${_PYLINT_VERSION_RAW}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PYLINT
+                                  REQUIRED_VARS PYLINT_EXECUTABLE PYLINT_VERSION
+                                  VERSION_VAR PYLINT_VERSION
+                                 )

--- a/pyInterface/CMakeLists.txt
+++ b/pyInterface/CMakeLists.txt
@@ -153,7 +153,7 @@ add_custom_target(
 )
 
 # pylint tests
-if(PYLINT_EXECUTABLE)
+if(PYLINT_FOUND)
 	# check 'pyRootPwa' module
 	add_test(pyLintPyRootPwa ${PYLINT_EXECUTABLE} --reports=n --rcfile=${CMAKE_CURRENT_SOURCE_DIR}/pylintrc pyRootPwa)
 


### PR DESCRIPTION
Require at least version 1.5.5 of pylint and only add the tests if at least this version was found. Older versions might be fine but I cannot test starting from which version they work.