### PR TITLE
buildSystem: fix NLopt header when using system library

### DIFF
--- a/cmakeModules/FindNLopt.cmake
+++ b/cmakeModules/FindNLopt.cmake
@@ -59,7 +59,7 @@ if(NOT NLopt_DIR)
 	endif()
 	unset(_NLopt_LIB_NAMES)
 
-	set(_NLopt_HEADER_FILE_NAME "NLopt.h")
+	set(_NLopt_HEADER_FILE_NAME "nlopt.hpp")
 	find_file(_NLopt_HEADER_FILE
 		NAMES ${_NLopt_HEADER_FILE_NAME})
 	if(NOT _NLopt_HEADER_FILE)


### PR DESCRIPTION
Fix the name of the header file searched when the system library should
be used (i.e., the NLOPT environment variable is not set). The name jad
the wrong capitalization and we are actually interested in the header
file for C++, not pure C.