### PR TITLE
buildSystem: 'pwaNloptFit' without NLopt library

### DIFF
--- a/pyInterface/CMakeLists.txt
+++ b/pyInterface/CMakeLists.txt
@@ -130,8 +130,10 @@ set(RPWA_PYTHON_SCRIPTS_FILES
 	plotAngles.py
 	printMetadata.py
 	pwaFit.py
-	pwaNloptFit.py
 )
+if(USE_NLOPT)
+	LIST(APPEND RPWA_PYTHON_SCRIPTS_FILES pwaNloptFit.py)
+endif()
 
 set(RPWA_PYTHON_SCRIPTS_LINKS)
 foreach(_FILE ${RPWA_PYTHON_SCRIPTS_FILES})


### PR DESCRIPTION
Do not install the 'pwaNloptFit' Python script and do not add a test for this script if ROOTPWA is compiled without support for NLopt.