### PR TITLE
Require 'numpy'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,19 @@ set(PYTHON_LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/pyLib")
 message(STATUS "Using python bindings output path '${PYTHON_LIBRARY_OUTPUT_PATH}'.")
 
 
+# setup numpy
+message(STATUS "")
+message(STATUS ">>> Setting up numpy.")
+find_package(NumPy 1.8 REQUIRED)
+set_package_properties(NumPy
+	PROPERTIES
+	DESCRIPTION "numerical calculations in Python"
+	URL "http://www.numpy.org"
+	PURPOSE "Used for handling of multi-dimensional arrays in Python."
+	TYPE REQUIRED
+	)
+
+
 # setup pylint (optional)
 message(STATUS "")
 message(STATUS ">>> Setting up pylint.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ set_package_properties(PYTHON
 	DESCRIPTION "General-purpose, high-level programming language"
 	URL "http://www.python.org"
 	PURPOSE "Provides scripting interface to ROOTPWA classes"
-	TYPE OPTIONAL
+	TYPE REQUIRED
 	)
 # check that Boost.Python library was found
 if(NOT Boost_PYTHON_FOUND)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ The build system tries to find your Python installation automatically. For this 
 In addition you need to compile the `Boost.Python` library (e.g. by running the supplied `compileBoostLibraries.sh` script; see "Compiling Boost Library" above). Make also sure that the ROOT installation you are using was compiled with Python support (running `root-config --features` should list `python`) against the _same_ Python version you are using (`ldd ${ROOTSYS}/lib/libPyROOT.so | grep -i python` shows you the Python library version against which ROOT was linked). Make also sure that your `PYTHONPATH` environment variable includes `${ROOTSYS}/lib`.
 
 
+### numpy ###
+
+_numpy_ (<http://www.numpy.org>) is a Python library that is required in ROOTPWA for some operations on ROOT trees. _numpy_ needs to be built against the same Python version as ROOTPWA. It is available from the repositories of most Linux distributions or via _pip_. To install from source use:
+
+1.  Download the source tarball from <http://www.scipy.org/scipylib/download.html> and extract it to a directory of your choice.
+
+2.  Build and install _numpy_.
+
+    `> python setup.py build`
+
+    `> python setup.py install --prefix=/your/folder/to/install/numpy`
+
+3.  Add the installation directory of _numpy_ to the `PYTHONPATH` environment variable:
+
+    `> export PYTHONPATH=/your/folder/to/install/numpy:$PYTHONPATH`
+
+    This should probably be added to your `.profile`.
+
+
 ### NLopt (optional) ###
 
 The _NLopt_ library (<http://ab-initio.mit.edu/wiki/index.php/NLopt>) provides a faster minimizer compared to the default Minuit2. The ROOTPWA build system is able to automatically detect and use the library if it is either installed in a system directory or if the `NLOPT` environment variable is defined.

--- a/cmakeModules/FindNumPy.cmake
+++ b/cmakeModules/FindNumPy.cmake
@@ -1,0 +1,92 @@
+#///////////////////////////////////////////////////////////////////////////
+#//
+#//    Copyright 2016
+#//
+#//    This file is part of rootpwa
+#//
+#//    rootpwa is free software: you can redistribute it and/or modify
+#//    it under the terms of the GNU General Public License as published by
+#//    the Free Software Foundation, either version 3 of the License, or
+#//    (at your option) any later version.
+#//
+#//    rootpwa is distributed in the hope that it will be useful,
+#//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#//    GNU General Public License for more details.
+#//
+#//    You should have received a copy of the GNU General Public License
+#//    along with rootpwa.  If not, see <http://www.gnu.org/licenses/>.
+#//
+#///////////////////////////////////////////////////////////////////////////
+#//-------------------------------------------------------------------------
+#//
+#// Description:
+#//      cmake module for finding numpy libraries and include files
+#//
+#//      following variables are defined:
+#//      NUMPY_FOUND              - numpy found
+#//      NUMPY_INCLUDE_DIR        - include directory for numpy
+#//      NUMPY_VERSION            - version of numpy
+#//
+#//      Example usage:
+#//          find_package(NumPy 1.8 Optional)
+#//
+#//
+#// Author List:
+#//      Sebastian Uhl        TUM            (original author)
+#//
+#//
+#//-------------------------------------------------------------------------
+
+
+unset(NUMPY_FOUND)
+unset(NUMPY_INCLUDE_DIR)
+unset(NUMPY_VERSION)
+
+# do not attempt to find numpy if Python was not found
+if(PYTHON_EXECUTABLE)
+	# get version
+	execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.__version__"
+	                RESULT_VARIABLE _NUMPY_IMPORT_SUCCESS
+	                OUTPUT_VARIABLE _NUMPY_VERSION_RAW
+	                OUTPUT_STRIP_TRAILING_WHITESPACE
+	                ERROR_QUIET
+	               )
+	if(_NUMPY_IMPORT_SUCCESS EQUAL 0)
+		# version extracted successfully
+		set(NUMPY_VERSION "${_NUMPY_VERSION_RAW}")
+
+		# get include path
+		execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print numpy.get_include()"
+		                OUTPUT_VARIABLE _NUMPY_INCLUDE_DIR_RAW
+		                OUTPUT_STRIP_TRAILING_WHITESPACE
+		                ERROR_QUIET
+		               )
+
+		# check that this directory really contains the include files
+		set(_NUMPY_INCLUDE_FILE_NAME "numpy/numpyconfig.h")
+		find_file(_NUMPY_INCLUDE_FILE
+		          NAMES ${_NUMPY_INCLUDE_FILE_NAME}
+		          PATHS ${_NUMPY_INCLUDE_DIR_RAW}
+		          NO_DEFAULT_PATH)
+		if(_NUMPY_INCLUDE_FILE)
+			set(NUMPY_INCLUDE_DIR "${_NUMPY_INCLUDE_DIR_RAW}")
+		else()
+			message(WARNING "The numpy module was found, but the include directory '${_NUMPY_INCLUDE_DIR_RAW}' does not contain the required file '${_NUMPY_INCLUDE_FILE_NAME}'.")
+		endif()
+
+		unset(_NUMPY_INCLUDE_DIR_RAW)
+		unset(_NUMPY_INCLUDE_FILE)
+		unset(_NUMPY_INCLUDE_FILE_NAME)
+	endif()
+	unset(_NUMPY_IMPORT_SUCCESS)
+	unset(_NUMPY_VERSION_RAW)
+else()
+	message(WARNING "Python needs to be set up prior to numpy.")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NUMPY
+                                  REQUIRED_VARS NUMPY_INCLUDE_DIR NUMPY_VERSION
+                                  VERSION_VAR NUMPY_VERSION
+                                 )


### PR DESCRIPTION
And a Cmake module to search for 'numpy'. 'numpy' is required for a couple of Python scripts, so it should be a hard requirement to be able to build ROOTPWA.