### PR TITLE
generatePhaseSpace: Error handling if no output file

### DIFF
--- a/pyInterface/scripts/generatePhaseSpace.py
+++ b/pyInterface/scripts/generatePhaseSpace.py
@@ -95,7 +95,9 @@ if __name__ == "__main__":
 	elif not args.outputFileName.endswith(".root"):
 		printErr("output file name needs to have '.root' extension. Aborting...")
 		sys.exit(1)
-
+	elif not os.path.isfile( args.outputFileName ):
+		printErr("output file not found. Aborting...")
+		sys.exit(1)
 	outputFile = pyRootPwa.ROOT.TFile.Open(args.outputFileName, "NEW")
 	if not outputFile:
 		printErr("could not open output file. Aborting...")


### PR DESCRIPTION
If a not-existing output file is passed as argument to
generatePhaseSpace, the usage of this file as data
file via ROOT.Open(filename) gives an error

Added a check whether the args.outputFileName is a valid
file