### PR TITLE
Set git hash in ampIntegralMatrixMetadata

### DIFF
--- a/pyInterface/bindings/decayAmplitude/ampIntegralMatrixMetadata_py.cc
+++ b/pyInterface/bindings/decayAmplitude/ampIntegralMatrixMetadata_py.cc
@@ -112,6 +112,7 @@ void rpwa::py::exportAmpIntegralMatrixMetadata() {
 		.def("addAmplitudeHash", &ampIntegralMatrixMetadata::addAmplitudeHash, bp::arg("amplitudehash"))
 		.def("setHash",  &ampIntegralMatrixMetadata::setHash)
 		.def("recalculateHash", &rpwa::ampIntegralMatrixMetadata::recalculateHash)
+		.def("setGitHash",  &ampIntegralMatrixMetadata::setGitHash)
 
 		.def("setBinningMap", &::ampIntegralMatrixMetadata_setBinningMap)
 

--- a/pyInterface/bindings/utilities/reportingUtilsEnvironment_py.cc
+++ b/pyInterface/bindings/utilities/reportingUtilsEnvironment_py.cc
@@ -13,4 +13,6 @@ void rpwa::py::exportReportingUtilsEnvironment() {
 	bp::def("printCompilerInfo", &rpwa::printCompilerInfo);
 	bp::def("printLibraryInfo", &rpwa::printLibraryInfo);
 
+	bp::def("gitHash", &rpwa::gitHash);
+
 }

--- a/pyInterface/module/_integrals.py
+++ b/pyInterface/module/_integrals.py
@@ -8,6 +8,7 @@ def calcIntegrals(integralFileName, eventAndAmpFileDict, multiBin, weightFileNam
 		pyRootPwa.utils.printWarn("cannot open output file '" + integralFileName + "'. Aborting...")
 		return False
 	integralMetaData = pyRootPwa.core.ampIntegralMatrixMetadata()
+	integralMetaData.setGitHash(pyRootPwa.core.gitHash())
 	integralMetaData.setBinningMap(multiBin.boundaries)
 	integrals = []
 	for eventFileName, ampFileDict in eventAndAmpFileDict.iteritems():


### PR DESCRIPTION
Set the hash to a value if all amplitude files have the same hash, and this hash is the same as the current ROOTPWA hash. Otherwise leave it empty (as is currently the case).