### PR TITLE
Another fix for ROOT 6.08

### DIFF
--- a/storageFormats/eventFileWriter.h
+++ b/storageFormats/eventFileWriter.h
@@ -7,6 +7,7 @@
 #include "eventMetadata.h"
 #include "hashCalculator.h"
 
+class TClonesArray;
 class TFile;
 class TVector3;
 class TTree;


### PR DESCRIPTION
Finally understood the second issue with ROOT 6.08 observed by @fkaspar and @cdreisbach. If also BAT is to be used, then an additional declaration of `TClonesArray` is required to compile the event file writer.