### PR TITLE
Require C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ message(STATUS ">>> Setting up project 'ROOTPWA'.")
 project(ROOTPWA)
 
 
+# require a C++11 compatible compiler
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+
 # set path, where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/ is checked
 message(STATUS "")
 message(STATUS ">>> Setting up Cmake modules.")
@@ -60,7 +66,6 @@ message(STATUS "Using cmake module path '${CMAKE_MODULE_PATH}'.")
 include(CommonMacros)
 include(FeatureSummary)
 include(ProcessorCount)
-include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
 
@@ -125,12 +130,6 @@ endif()
 
 
 # set common compiler flags
-# test whether C++ compiler supports C++11 standard
-check_cxx_compiler_flag("-std=c++11" COMPILER_IS_CXX11_COMPATIBLE)
-if(COMPILER_IS_CXX11_COMPATIBLE)
-	message(STATUS "C++11 compatible compiler found, enable C++11 features.")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
 # consider flags -pedantic -Wsuggest-attribute=pure -Wsuggest-attribute=noreturn -Wsuggest-attribute=const
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Woverloaded-virtual -Werror")
 # options switchable via command line

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@
 
 # check if cmake has the required version
 message(STATUS ">>> This is CMake version ${CMAKE_VERSION}.")
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-cmake_policy(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_policy(VERSION 3.1)
 
 
 # set verbosity

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ message(STATUS "Using cmake module path '${CMAKE_MODULE_PATH}'.")
 include(CommonMacros)
 include(FeatureSummary)
 include(ProcessorCount)
-include(CheckCXXSourceCompiles)
 
 
 # On Apples the default filename extension of a shared library is ".dylib",
@@ -158,14 +157,6 @@ message(STATUS "Using additional linker flags '${CMAKE_CXX_LDFLAGS_${CMAKE_BUILD
 	"for build type ${CMAKE_BUILD_TYPE}.")
 if(DEBUG_OUTPUT)
 	include(CMakePrintSystemInformation)
-endif()
-
-
-# test whether thread_local is understood
-check_cxx_source_compiles("#include <iostream>
-int main() { thread_local int a = 1; std::cout << a << std::endl; }" COMPILER_PROVIDES_THREAD_LOCAL)
-if(COMPILER_PROVIDES_THREAD_LOCAL)
-	add_definitions(-DCOMPILER_PROVIDES_THREAD_LOCAL)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,8 @@ message(STATUS "Compiling for system '${CMAKE_SYSTEM_NAME}' version '${CMAKE_SYS
 
 # warn user about outdated or unsupported compiler
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
-    message(WARNING " ??? Your GCC version ${CMAKE_CXX_COMPILER_VERSION} is too low. GCC version 4.4 or higher is required. Proceed at your own risk.")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+    message(WARNING " ??? Your GCC version ${CMAKE_CXX_COMPILER_VERSION} is too low. GCC version 4.8 or higher is required. Proceed at your own risk.")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.4)
@@ -106,9 +106,9 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 			"Clang version 3.4 or higher is required. Proceed at your own risk.")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
     message(WARNING " ??? Your AppleClang version ${CMAKE_CXX_COMPILER_VERSION} is too low. "
-			"AppleClang version 6.0 or higher is required. Proceed at your own risk.")
+			"AppleClang version 8.0 or higher is required. Proceed at your own risk.")
   endif()
 else()
   message(WARNING " ??? '${CMAKE_CXX_COMPILER_ID} V${CMAKE_CXX_COMPILER_VERSION}' "

--- a/cmakeModules/FindROOT.cmake
+++ b/cmakeModules/FindROOT.cmake
@@ -416,16 +416,6 @@ function(root_generate_dictionary DICT_FILE)
 			message(STATUS "root_generate_dictionary will execute "
 				"'${RLIBMAP_EXECUTABLE} -o ${_MAP_FILE} -l ${_LIB_NAME} -c ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_LINKDEF}'")
 		endif()
-
-		if((("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 6.1.0.6020049))
-		   AND (ROOT_VERSION VERSION_LESS 5.34.32))
-			# ignore compiler warnings concerning ignored qualifiers when
-			# compiling the ROOT dictionaries (this is required for
-			# 'Apple LLVM version 6.1.0')
-			set_source_files_properties(${DICT_FILE}
-			                            PROPERTIES
-			                            COMPILE_FLAGS "-Wno-ignored-qualifiers")
-		endif()
 	else()
 		string(REGEX REPLACE "^(.*)\\.(.*)$" "\\1_rdict.pcm" _DICT_PCM "${_MAP_FILE}")
 		set(OUTPUT_FILES ${DICT_FILE} ${_DICT_PCM} ${_MAP_FILE})

--- a/resonanceFit/CMakeLists.txt
+++ b/resonanceFit/CMakeLists.txt
@@ -71,15 +71,4 @@ make_shared_library(
 	)
 
 
-if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.6.3))
-	# workaround for presumably a compiler bug
-	set_source_files_properties(massDepFit.cc
-	                            PROPERTIES
-	                            COMPILE_FLAGS "-Wno-uninitialized")
-	set_source_files_properties(massDepFitComponents.cc
-	                            PROPERTIES
-	                            COMPILE_FLAGS "-Wno-uninitialized")
-endif()
-
-
 make_executable(pwaMassFit pwaMassFit.cc ${THIS_LIB})

--- a/resonanceFit/massDepFitComponents.cc
+++ b/resonanceFit/massDepFitComponents.cc
@@ -82,16 +82,6 @@ rpwa::massDepFit::channel::~channel()
 }
 
 
-#if __cplusplus < 201103L
-rpwa::massDepFit::channel&
-rpwa::massDepFit::channel::operator=(rpwa::massDepFit::channel& other)
-{
-	std::swap(*this, other);
-	return *this;
-}
-#endif
-
-
 rpwa::massDepFit::component::component(const size_t id,
                                        const std::string& name,
                                        const std::string& type,

--- a/resonanceFit/massDepFitComponents.h
+++ b/resonanceFit/massDepFitComponents.h
@@ -66,10 +66,6 @@ namespace rpwa {
 			channel(const rpwa::massDepFit::channel& ch);
 			~channel();
 
-#if __cplusplus < 201103L
-			rpwa::massDepFit::channel& operator=(rpwa::massDepFit::channel& other);
-#endif
-
 			size_t getWaveIdx() const { return _waveIdx; }
 			const std::string& getWaveName() const { return _waveName; }
 

--- a/resonanceFit/massDepFitFunction.cc
+++ b/resonanceFit/massDepFitFunction.cc
@@ -502,7 +502,6 @@ rpwa::massDepFit::function::chiSquare(const std::vector<double>& par) const
 double
 rpwa::massDepFit::function::chiSquare(const double* par) const
 {
-#ifdef COMPILER_PROVIDES_THREAD_LOCAL
 	// in C++11 we can use a static variable per thread so that the
 	// parameters are kept over function calls and we can implement some
 	// caching
@@ -515,17 +514,6 @@ rpwa::massDepFit::function::chiSquare(const double* par) const
 	                                           _compset->getMaxChannelsInComponent(),
 	                                           _nrBins,
 	                                           _nrMassBins);
-#else
-	rpwa::massDepFit::parameters fitParameters(_compset->getNrComponents()+1,           // nr components + final-state mass-dependence
-	                                           _compset->getMaxChannelsInComponent(),
-	                                           _compset->getMaxParametersInComponent(),
-	                                           _nrBins);
-	rpwa::massDepFit::cache cache(_nrWaves,
-	                              _compset->getNrComponents()+1,           // nr components + final-state mass-dependence
-	                              _compset->getMaxChannelsInComponent(),
-	                              _nrBins,
-	                              _nrMassBins);
-#endif
 
 	// import parameters (couplings, branchings, resonance parameters, ...)
 	_compset->importParameters(par, fitParameters, cache);


### PR DESCRIPTION
Require C++11 while configuring ROOTPWA. Do not yet actually modify any code (apart from removing non-C++11 workarounds).