### PR TITLE
partialWaveFit: less warnings for fit result without matrices

### DIFF
--- a/partialWaveFit/fitResult.cc
+++ b/partialWaveFit/fitResult.cc
@@ -251,33 +251,58 @@ fitResult::fill(const unsigned int              nmbEvents,               // numb
 		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
 		          << "does not match number of covariance matrix indices "
 		          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
-	for (unsigned int i=0; i<_fitParCovMatrixIndices.size(); ++i) {
-		if (_fitParCovMatrixIndices[i].first < 0)
-			printWarn << "entry in covariance matrix for real part of production "
-			          << "amplitude " << i << " does not exist." << endl;
-		if (_fitParCovMatrixIndices[i].first >= _fitParCovMatrix.GetNrows())
-			printWarn << "real part of production amplitude " << i << " is mapped to "
-			          << "entry in covariance matrix outside covariance matrix size "
-			          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
-		if (_fitParCovMatrixIndices[i].second >= _fitParCovMatrix.GetNrows())
-			printWarn << "imaginary part of production amplitude " << i << " is mapped to "
-			          << "entry in covariance matrix outside covariance matrix size "
-			          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+	if (_fitParCovMatrix.GetNrows() == 0) {
+		// covariance matrix does not exist
+		printWarn << "covariance matrix is empty." << endl;
+	} else {
+		// covariance matrix exists
+		for (unsigned int i=0; i<_fitParCovMatrixIndices.size(); ++i) {
+			if (_fitParCovMatrixIndices[i].first < 0)
+				printWarn << "entry in covariance matrix for real part of production "
+				          << "amplitude " << i << " does not exist." << endl;
+			if (_fitParCovMatrixIndices[i].first >= _fitParCovMatrix.GetNrows())
+				printWarn << "real part of production amplitude " << i << " is mapped to "
+				          << "entry in covariance matrix outside covariance matrix size "
+				          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+			if (_fitParCovMatrixIndices[i].second >= _fitParCovMatrix.GetNrows())
+				printWarn << "imaginary part of production amplitude " << i << " is mapped to "
+				          << "entry in covariance matrix outside covariance matrix size "
+				          << "(" << _fitParCovMatrixIndices.size() << ")." << endl;
+		}
 	}
-	if (   (_waveNames.size() != _normIntegral.nRows())
-	    or (_waveNames.size() != _normIntegral.nCols()))
-		printWarn << "number of waves (" << _waveNames.size() << ") "
-		          << "does not match size of normalization integral "
+	if (_normIntegral.nRows() != _normIntegral.nCols())
+		printWarn << "normalization integral is not a square matrix "
 		          << "(" << _normIntegral.nRows() << ", " << _normIntegral.nCols() << ")." << endl;
-	if (   (_waveNames.size() != _acceptedNormIntegral.nRows())
-	    or (_waveNames.size() != _acceptedNormIntegral.nCols()))
-		printWarn << "number of waves (" << _waveNames.size() << ") "
-		          << "does not match size of acceptance integral "
+	if (_normIntegral.nRows() == 0) {
+		// normalization integral matrix does not exist
+		printWarn << "normalization integral matrix is empty." << endl;
+	} else {
+		if (_waveNames.size() != _normIntegral.nRows())
+			printWarn << "number of waves (" << _waveNames.size() << ") "
+			          << "does not match size of normalization integral "
+			          << "(" << _normIntegral.nRows() << ", " << _normIntegral.nCols() << ")." << endl;
+	}
+	if (_acceptedNormIntegral.nRows() != _acceptedNormIntegral.nCols())
+		printWarn << "normalization integral is not a square matrix "
 		          << "(" << _acceptedNormIntegral.nRows() << ", " << _acceptedNormIntegral.nCols() << ")." << endl;
-	if (_waveNames.size() != _phaseSpaceIntegral.size())
-		printWarn << "number of waves (" << _waveNames.size() << ") "
-		          << "does not match size of phase-space integral "
-		          << "(" << _phaseSpaceIntegral.size() << ")." << endl;
+	if (_acceptedNormIntegral.nRows() == 0) {
+		// acceptance integral matrix does not exist
+		printWarn << "acceptance integral matrix is empty." << endl;
+	} else {
+		if (_waveNames.size() != _acceptedNormIntegral.nRows())
+			printWarn << "number of waves (" << _waveNames.size() << ") "
+			          << "does not match size of acceptance integral "
+			          << "(" << _acceptedNormIntegral.nRows() << ", " << _acceptedNormIntegral.nCols() << ")." << endl;
+	}
+	if (_phaseSpaceIntegral.size() == 0) {
+		// phase-space integral does not exist
+		printWarn << "phase-space integral is empty." << endl;
+	} else {
+		if (_waveNames.size() != _phaseSpaceIntegral.size())
+			printWarn << "number of waves (" << _waveNames.size() << ") "
+			          << "does not match size of phase-space integral "
+			          << "(" << _phaseSpaceIntegral.size() << ")." << endl;
+	}
 	if (_prodAmps.size() != _normIntIndexMap.size())
 		printWarn << "number of production amplitudes (" << _prodAmps.size() << ") "
 		          << "does not match number of mappings from production amplitudes to indices in integrals "


### PR DESCRIPTION
Reduce the number of warnings printed while filling a 'rpwa::fitResult'
object with empty covariance, normalization or acceptance integrals. In
that case only warn once (about an empty matrix) instead of (in case of
the covariance matrix) complain for each production amplitude.