### PR TITLE
particleData: update to PDG 2016 values

### DIFF
--- a/particleData/particleDataTable2016.txt
+++ b/particleData/particleDataTable2016.txt
@@ -1,0 +1,321 @@
+##########################################################################
+#
+#    Copyright 2012,2017
+#
+#    This file is part of rootpwa
+#
+#    rootpwa is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    rootpwa is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with rootpwa. If not, see <http://www.gnu.org/licenses/>.
+#
+##########################################################################
+#-------------------------------------------------------------------------
+#
+# Description:
+#      table with particle properties
+#
+#      most entries are from the 2016 PDF edition of the Particle Data
+#      Book (C. Patrignani et al. (Particle Data Group), Chinese
+#      Physics C, 40, 100001 (2016)). typically the PDG averages
+#      (for baryons the approximate Breit-Wigner parameters) from the
+#      summary tables are used. in cases where the PDG gives only
+#      ranges the center values were taken.
+#
+#      exceptions are:
+#
+#      * for rho(770) averages for hadroproduction (rho+-) and other
+#        reactions (rho0) were taken from the detailed listing.
+#
+#      * for Kstar(892)+/Kstarbar(892)- averages for hadroproduction
+#        were taken.
+#
+#      * for p+/pbar- and n/nbar the masses from the detailed listing
+#        were taken, the nucleon/nucleonbar mass is simply the average.
+#
+#      * some states that are only listed in the detailed listing:
+#        f1(1510)
+#        f2(1565)
+#        kappa
+#
+#      * a number of hypothetical, controversial or artificial states
+#        (that are not listed in the PDG) were added:
+#        eta(1440)
+#        b1(1500)
+#        eta1(1600)
+#        rhoPrime
+#        rho(1600)
+#        b0(1800)
+#        b1(1800)
+#        b2(1800)
+#
+#      each particle has to be explicitly defined for all its charge
+#      states in which it is going to be used in the analysis. this is
+#      dictated by the fact that in general the different charge
+#      states have slightly different masses.
+#
+#      naming scheme: <bare name>XY
+#
+#      * for singly charged particles the charge is designated by the
+#        last character Y in the particle name (e.g. 'pi0', 'rho-',
+#        'p+'). in this case X is just an empty string ''. if Y is
+#        neither of '-', '0', or '+', the particle charge is assumed
+#        to be 0.
+#
+#      * for multiply charged particles the absolute value of the
+#        charge is defined by the second-to-last character X, its sign
+#        by the last character Y (e.g. 'Delta(1232)2+').
+#
+#      !NOTE! <bare name> should not end on a digit, as this would be
+#      interpreted as the absolute value of the charge, so instead of
+#      e.g. 'pi2+' one should use 'pi2(1670)+'.
+#
+#      !NOTE! be sure to define the flavor quantum numbers of
+#      flavored mesons and baryons (isospin I, strangeness S, charm
+#      Ch, and beauty B) with the correct sign.
+#
+#      !NOTE! in the table spin J and isospin I are given as 2J and
+#      2I, respectively in order to have integer values only.
+#
+#      !NOTE! this table might be updated with the latest values at
+#      any time. it is recommended that you use a private copy of this
+#      file to make sure that your analysis is internally consistent.
+#
+#      !NOTE! for better performance it is recommended to comment out
+#      all particles that are not used as final-state particles or
+#      isobars in the analysis.
+#
+#
+# Author List:
+#      Boris Grube          TUM            (original author)
+#      Sebastian Uhl        TUM            (PDG 2016 update)
+#
+#
+#-------------------------------------------------------------------------
+#
+#
+#---------------------------------------------------------------------------------------------------------------
+# baryons
+#
+# particle       antiparticle     mass         width       baryon #    2I    S    Ch   B     G    2J     P     C
+# name           name             [GeV/c^2]    [GeV/c^2]
+#---------------------------------------------------------------------------------------------------------------
+#
+Lambda           Lambdabar        1.115683     0           +1           0   -1    0    0     0     1    +1     0
+Delta(2420)-     Deltabar(2420)+  2.42         0.4         +1           3    0    0    0     0    11    +1     0
+Delta(2420)      Deltabar(2420)   2.42         0.4         +1           3    0    0    0     0    11    +1     0
+Delta(2420)+     Deltabar(2420)-  2.42         0.4         +1           3    0    0    0     0    11    +1     0
+Delta(2420)2+    Deltabar(2420)2- 2.42         0.4         +1           3    0    0    0     0    11    +1     0
+Delta(1950)-     Deltabar(1950)+  1.93         0.285       +1           3    0    0    0     0     7    +1     0
+Delta(1950)      Deltabar(1950)   1.93         0.285       +1           3    0    0    0     0     7    +1     0
+Delta(1950)+     Deltabar(1950)-  1.93         0.285       +1           3    0    0    0     0     7    +1     0
+Delta(1950)2+    Deltabar(1950)2- 1.93         0.285       +1           3    0    0    0     0     7    +1     0
+Delta(1930)-     Deltabar(1930)+  1.95         0.36        +1           3    0    0    0     0     5    -1     0
+Delta(1930)      Deltabar(1930)   1.95         0.36        +1           3    0    0    0     0     5    -1     0
+Delta(1930)+     Deltabar(1930)-  1.95         0.36        +1           3    0    0    0     0     5    -1     0
+Delta(1930)2+    Deltabar(1930)2- 1.95         0.36        +1           3    0    0    0     0     5    -1     0
+Delta(1920)-     Deltabar(1920)+  1.92         0.26        +1           3    0    0    0     0     3    +1     0
+Delta(1920)      Deltabar(1920)   1.92         0.26        +1           3    0    0    0     0     3    +1     0
+Delta(1920)+     Deltabar(1920)-  1.92         0.26        +1           3    0    0    0     0     3    +1     0
+Delta(1920)2+    Deltabar(1920)2- 1.92         0.26        +1           3    0    0    0     0     3    +1     0
+Delta(1910)-     Deltabar(1910)+  1.89         0.28        +1           3    0    0    0     0     1    +1     0
+Delta(1910)      Deltabar(1910)   1.89         0.28        +1           3    0    0    0     0     1    +1     0
+Delta(1910)+     Deltabar(1910)-  1.89         0.28        +1           3    0    0    0     0     1    +1     0
+Delta(1910)2+    Deltabar(1910)2- 1.89         0.28        +1           3    0    0    0     0     1    +1     0
+Delta(1905)-     Deltabar(1905)+  1.88         0.33        +1           3    0    0    0     0     5    +1     0
+Delta(1905)      Deltabar(1905)   1.88         0.33        +1           3    0    0    0     0     5    +1     0
+Delta(1905)+     Deltabar(1905)-  1.88         0.33        +1           3    0    0    0     0     5    +1     0
+Delta(1905)2+    Deltabar(1905)2- 1.88         0.33        +1           3    0    0    0     0     5    +1     0
+Delta(1700)-     Deltabar(1700)+  1.7          0.3         +1           3    0    0    0     0     3    -1     0
+Delta(1700)      Deltabar(1700)   1.7          0.3         +1           3    0    0    0     0     3    -1     0
+Delta(1700)+     Deltabar(1700)-  1.7          0.3         +1           3    0    0    0     0     3    -1     0
+Delta(1700)2+    Deltabar(1700)2- 1.7          0.3         +1           3    0    0    0     0     3    -1     0
+Delta(1620)-     Deltabar(1620)+  1.63         0.14        +1           3    0    0    0     0     1    -1     0
+Delta(1620)      Deltabar(1620)   1.63         0.14        +1           3    0    0    0     0     1    -1     0
+Delta(1620)+     Deltabar(1620)-  1.63         0.14        +1           3    0    0    0     0     1    -1     0
+Delta(1620)2+    Deltabar(1620)2- 1.63         0.14        +1           3    0    0    0     0     1    -1     0
+Delta(1600)-     Deltabar(1600)+  1.6          0.32        +1           3    0    0    0     0     3    +1     0
+Delta(1600)      Deltabar(1600)   1.6          0.32        +1           3    0    0    0     0     3    +1     0
+Delta(1600)+     Deltabar(1600)-  1.6          0.32        +1           3    0    0    0     0     3    +1     0
+Delta(1600)2+    Deltabar(1600)2- 1.6          0.32        +1           3    0    0    0     0     3    +1     0
+Delta(1232)-     Deltabar(1232)+  1.232        0.117       +1           3    0    0    0     0     3    +1     0
+Delta(1232)      Deltabar(1232)   1.232        0.117       +1           3    0    0    0     0     3    +1     0
+Delta(1232)+     Deltabar(1232)-  1.232        0.117       +1           3    0    0    0     0     3    +1     0
+Delta(1232)2+    Deltabar(1232)2- 1.232        0.117       +1           3    0    0    0     0     3    +1     0
+N(2600)          Nbar(2600)       2.6          0.65        +1           1    0    0    0     0    11    -1     0
+N(2600)+         Nbar(2600)-      2.6          0.65        +1           1    0    0    0     0    11    -1     0
+N(2250)          Nbar(2250)       2.28         0.5         +1           1    0    0    0     0     9    -1     0
+N(2250)+         Nbar(2250)-      2.28         0.5         +1           1    0    0    0     0     9    -1     0
+N(2220)          Nbar(2220)       2.25         0.4         +1           1    0    0    0     0     9    +1     0
+N(2220)+         Nbar(2220)-      2.25         0.4         +1           1    0    0    0     0     9    +1     0
+N(2190)          Nbar(2190)       2.19         0.5         +1           1    0    0    0     0     7    -1     0
+N(2190)+         Nbar(2190)-      2.19         0.5         +1           1    0    0    0     0     7    -1     0
+N(1900)          Nbar(1900)       1.9          0.20        +1           1    0    0    0     0     3    +1     0
+N(1900)+         Nbar(1900)-      1.9          0.20        +1           1    0    0    0     0     3    +1     0
+N(1875)          Nbar(1875)       1.875        0.25        +1           1    0    0    0     0     3    -1     0
+N(1875)+         Nbar(1875)-      1.875        0.25        +1           1    0    0    0     0     3    -1     0
+N(1720)          Nbar(1720)       1.72         0.25        +1           1    0    0    0     0     3    +1     0
+N(1720)+         Nbar(1720)-      1.72         0.25        +1           1    0    0    0     0     3    +1     0
+N(1710)          Nbar(1710)       1.71         0.1         +1           1    0    0    0     0     1    +1     0
+N(1710)+         Nbar(1710)-      1.71         0.1         +1           1    0    0    0     0     1    +1     0
+N(1700)          Nbar(1700)       1.70         0.15        +1           1    0    0    0     0     3    -1     0
+N(1700)+         Nbar(1700)-      1.70         0.15        +1           1    0    0    0     0     3    -1     0
+N(1680)          Nbar(1680)       1.685        0.13        +1           1    0    0    0     0     5    +1     0
+N(1680)+         Nbar(1680)-      1.685        0.13        +1           1    0    0    0     0     5    +1     0
+N(1675)          Nbar(1675)       1.675        0.15        +1           1    0    0    0     0     5    -1     0
+N(1675)+         Nbar(1675)-      1.675        0.15        +1           1    0    0    0     0     5    -1     0
+N(1650)          Nbar(1650)       1.655        0.14        +1           1    0    0    0     0     1    -1     0
+N(1650)+         Nbar(1650)-      1.655        0.14        +1           1    0    0    0     0     1    -1     0
+N(1535)          Nbar(1535)       1.535        0.15        +1           1    0    0    0     0     1    -1     0
+N(1535)+         Nbar(1535)-      1.535        0.15        +1           1    0    0    0     0     1    -1     0
+N(1520)          Nbar(1520)       1.515        0.115       +1           1    0    0    0     0     3    -1     0
+N(1520)+         Nbar(1520)-      1.515        0.115       +1           1    0    0    0     0     3    -1     0
+N(1440)          Nbar(1440)       1.43         0.35        +1           1    0    0    0     0     1    +1     0
+N(1440)+         Nbar(1440)-      1.43         0.35        +1           1    0    0    0     0     1    +1     0
+d+               dbar-            1.875612928  0           +2           0    0    0    0    +1     0    +1    +1
+nucleon          nucleonbar       0.9389187473 0           +1           1    0    0    0     0     1    +1     0
+n                nbar             0.9395654133 0           +1           1    0    0    0     0     1    +1     0
+p+               pbar-            0.9382720813 0           +1           1    0    0    0     0     1    +1     0
+#
+#
+#---------------------------------------------------------------------------------------------------------------
+# strange mesons
+#
+# particle       antiparticle     mass         width       baryon #    2I    S    Ch   B     G    2J     P     C
+# name           name             [GeV/c^2]    [GeV/c^2]
+#---------------------------------------------------------------------------------------------------------------
+#
+Kstar4(2045)     Kstar4bar(2045)  2.045        0.198       0            1   +1    0    0     0     8    +1     0
+Kstar4(2045)+    Kstar4bar(2045)- 2.045        0.198       0            1   +1    0    0     0     8    +1     0
+K2(1820)         K2bar(1820)      1.816        0.276       0            1   +1    0    0     0     4    -1     0
+K2(1820)+        K2bar(1820)-     1.816        0.276       0            1   +1    0    0     0     4    -1     0
+Kstar3(1780)     Kstar3bar(1780)  1.776        0.159       0            1   +1    0    0     0     6    -1     0
+Kstar3(1780)+    Kstar3bar(1780)- 1.776        0.159       0            1   +1    0    0     0     6    -1     0
+K2(1770)         K2bar(1770)      1.773        0.186       0            1   +1    0    0     0     4    -1     0
+K2(1770)+        K2bar(1770)-     1.773        0.186       0            1   +1    0    0     0     4    -1     0
+Kstar(1680)      Kstarbar(1680)   1.717        0.322       0            1   +1    0    0     0     2    -1     0
+Kstar(1680)+     Kstarbar(1680)-  1.717        0.322       0            1   +1    0    0     0     2    -1     0
+Kstar2(1430)     Kstar2bar(1430)  1.4324       0.109       0            1   +1    0    0     0     4    +1     0
+Kstar2(1430)+    Kstar2bar(1430)- 1.4256       0.0985      0            1   +1    0    0     0     4    +1     0
+Kstar0(1430)     Kstar0bar(1430)  1.425        0.27        0            1   +1    0    0     0     0    +1     0
+Kstar0(1430)+    Kstar0bar(1430)- 1.425        0.27        0            1   +1    0    0     0     0    +1     0
+Kstar(1410)      Kstarbar(1410)   1.414        0.232       0            1   +1    0    0     0     2    -1     0
+Kstar(1410)+     Kstarbar(1410)-  1.414        0.232       0            1   +1    0    0     0     2    -1     0
+K1(1400)         K1bar(1400)      1.403        0.174       0            1   +1    0    0     0     2    +1     0
+K1(1400)+        K1bar(1400)-     1.403        0.174       0            1   +1    0    0     0     2    +1     0
+K1(1270)         K1bar(1270)      1.272        0.09        0            1   +1    0    0     0     2    +1     0
+K1(1270)+        K1bar(1270)-     1.272        0.09        0            1   +1    0    0     0     2    +1     0
+Kstar(892)       Kstarbar(892)    0.89581      0.0474      0            1   +1    0    0     0     2    -1     0
+Kstar(892)+      Kstarbar(892)-   0.89166      0.0508      0            1   +1    0    0     0     2    -1     0
+kappa            kappabar         0.682        0.547       0            1   +1    0    0     0     0    +1     0
+kappa+           kappabar-        0.682        0.547       0            1   +1    0    0     0     0    +1     0
+K0               Kbar0            0.497611     0           0            1   +1    0    0     0     0    -1     0
+K+               K-               0.493677     0           0            1   +1    0    0     0     0    -1     0
+#
+#
+#---------------------------------------------------------------------------------------------------------------
+# light unflavored mesons
+#
+# particle       antiparticle     mass         width       baryon #    2I    S    Ch   B     G    2J     P     C
+# name           name             [GeV/c^2]    [GeV/c^2]
+#---------------------------------------------------------------------------------------------------------------
+#
+f2(2340)         f2(2340)         2.345        0.322       0            0    0    0    0    +1     4    +1    +1
+f2(2300)         f2(2300)         2.297        0.149       0            0    0    0    0    +1     4    +1    +1
+phi(2170)        phi(2170)        2.189        0.079       0            0    0    0    0    -1     2    -1    -1
+f4(2050)         f4(2050)         2.018        0.237       0            0    0    0    0    +1     8    +1    +1
+a4(2040)         a4(2040)         1.995        0.257       0            2    0    0    0    -1     8    +1    +1
+a4(2040)+        a4(2040)-        1.995        0.257       0            2    0    0    0    -1     8    +1     0
+f2(2010)         f2(2010)         2.011        0.202       0            0    0    0    0    +1     4    +1    +1
+f2(1950)         f2(1950)         1.944        0.472       0            0    0    0    0    +1     4    +1    +1
+pi2(1880)        pi2(1880)        1.895        0.235       0            2    0    0    0    -1     4    -1    +1
+pi2(1880)+       pi2(1880)-       1.895        0.235       0            2    0    0    0    -1     4    -1     0
+phi3(1850)       phi3(1850)       1.854        0.087       0            0    0    0    0    -1     6    -1    -1
+b2(1800)         b2(1800)         1.8          0.3         0            2    0    0    0    +1     4    +1    -1
+b2(1800)+        b2(1800)-        1.8          0.3         0            2    0    0    0    +1     4    +1     0
+b1(1800)         b1(1800)         1.8          0.3         0            2    0    0    0    +1     2    +1    -1
+b1(1800)+        b1(1800)-        1.8          0.3         0            2    0    0    0    +1     2    +1     0
+b0(1800)         b0(1800)         1.8          0.3         0            2    0    0    0    +1     0    +1    -1
+b0(1800)+        b0(1800)-        1.8          0.3         0            2    0    0    0    +1     0    +1     0
+pi(1800)         pi(1800)         1.812        0.208       0            2    0    0    0    -1     0    -1    +1
+pi(1800)+        pi(1800)-        1.812        0.208       0            2    0    0    0    -1     0    -1     0
+f0(1710)         f0(1710)         1.723        0.139       0            0    0    0    0    +1     0    +1    +1
+rho(1700)        rho(1700)        1.72         0.25        0            2    0    0    0    +1     2    -1    -1
+rho(1700)+       rho(1700)-       1.72         0.25        0            2    0    0    0    +1     2    -1     0
+rho(1600)        rho(1600)        1.6          0.24        0            2    0    0    0    +1     2    -1    -1
+rho(1600)+       rho(1600)-       1.6          0.24        0            2    0    0    0    +1     2    -1     0
+rhoPrime         rhoPrime         1.6          0.24        0            2    0    0    0    +1     2    -1    -1
+rhoPrime+        rhoPrime-        1.6          0.24        0            2    0    0    0    +1     2    -1     0
+rho3(1690)       rho3(1690)       1.6888       0.161       0            2    0    0    0    +1     6    -1    -1
+rho3(1690)+      rho3(1690)-      1.6888       0.161       0            2    0    0    0    +1     6    -1     0
+phi(1680)        phi(1680)        1.68         0.15        0            0    0    0    0    -1     2    -1    -1
+pi2(1670)        pi2(1670)        1.6722       0.260       0            2    0    0    0    -1     4    -1    +1
+pi2(1670)+       pi2(1670)-       1.6722       0.260       0            2    0    0    0    -1     4    -1     0
+omega3(1670)     omega3(1670)     1.667        0.168       0            0    0    0    0    -1     6    -1    -1
+omega(1650)      omega(1650)      1.67         0.315       0            0    0    0    0    -1     2    -1    -1
+eta2(1645)       eta2(1645)       1.617        0.181       0            0    0    0    0    +1     4    -1    +1
+eta1(1600)       eta1(1600)       1.66         0.3         0            0    0    0    0    +1     2    -1    +1
+pi1(1600)        pi1(1600)        1.662        0.241       0            2    0    0    0    -1     2    -1    +1
+pi1(1600)+       pi1(1600)-       1.662        0.241       0            2    0    0    0    -1     2    -1     0
+f2(1565)         f2(1565)         1.562        0.134       0            0    0    0    0    +1     4    +1    +1
+f2'(1525)        f2'(1525)        1.525        0.073       0            0    0    0    0    +1     4    +1    +1
+f1(1510)         f1(1510)         1.518        0.073       0            0    0    0    0    +1     2    +1    +1
+b1(1500)         b1(1500)         1.5          0.2         0            2    0    0    0    +1     2    +1    -1
+b1(1500)+        b1(1500)-        1.5          0.2         0            2    0    0    0    +1     2    +1     0
+f0(1500)         f0(1500)         1.504        0.109       0            0    0    0    0    +1     0    +1    +1
+eta(1475)        eta(1475)        1.476        0.085       0            0    0    0    0    +1     0    -1    +1
+rho(1450)        rho(1450)        1.465        0.40        0            2    0    0    0    +1     2    -1    -1
+rho(1450)+       rho(1450)-       1.465        0.40        0            2    0    0    0    +1     2    -1     0
+a0(1450)         a0(1450)         1.474        0.265       0            2    0    0    0    -1     0    +1    +1
+a0(1450)+        a0(1450)-        1.474        0.265       0            2    0    0    0    -1     0    +1     0
+eta(1440)        eta(1440)        1.42         0.06        0            0    0    0    0    +1     0    -1    +1
+omega(1420)      omega(1420)      1.425        0.215       0            0    0    0    0    -1     2    -1    -1
+f1(1420)         f1(1420)         1.4264       0.0549      0            0    0    0    0    +1     2    +1    +1
+eta(1405)        eta(1405)        1.4088       0.0510      0            0    0    0    0    +1     0    -1    +1
+pi1(1400)        pi1(1400)        1.354        0.33        0            2    0    0    0    -1     2    -1    +1
+pi1(1400)+       pi1(1400)-       1.354        0.33        0            2    0    0    0    -1     2    -1     0
+f0(1370)         f0(1370)         1.35         0.35        0            0    0    0    0    +1     0    +1    +1
+a2(1320)         a2(1320)         1.3183       0.107       0            2    0    0    0    -1     4    +1    +1
+a2(1320)+        a2(1320)-        1.3183       0.107       0            2    0    0    0    -1     4    +1     0
+pi(1300)         pi(1300)         1.3          0.4         0            2    0    0    0    -1     0    -1    +1
+pi(1300)+        pi(1300)-        1.3          0.4         0            2    0    0    0    -1     0    -1     0
+eta(1295)        eta(1295)        1.294        0.055       0            0    0    0    0    +1     0    -1    +1
+f1(1285)         f1(1285)         1.2820       0.0241      0            0    0    0    0    +1     2    +1    +1
+f2(1270)         f2(1270)         1.2755       0.1867      0            0    0    0    0    +1     4    +1    +1
+a1(1260)         a1(1260)         1.23         0.425       0            2    0    0    0    -1     2    +1    +1
+a1(1260)+        a1(1260)-        1.23         0.425       0            2    0    0    0    -1     2    +1     0
+b1(1235)         b1(1235)         1.2295       0.142       0            2    0    0    0    +1     2    +1    -1
+b1(1235)+        b1(1235)-        1.2295       0.142       0            2    0    0    0    +1     2    +1     0
+h1(1170)         h1(1170)         1.17         0.36        0            0    0    0    0    -1     2    +1    -1
+phi(1020)        phi(1020)        1.019461     0.004266    0            0    0    0    0    -1     2    -1    -1
+a0(980)          a0(980)          0.98         0.075       0            2    0    0    0    -1     0    +1    +1
+a0(980)+         a0(980)-         0.98         0.075       0            2    0    0    0    -1     0    +1     0
+f0(980)          f0(980)          0.99         0.07        0            0    0    0    0    +1     0    +1    +1
+eta'(958)        eta'(958)        0.95778      0.000197    0            0    0    0    0    +1     0    -1    +1
+omega(782)       omega(782)       0.78265      0.00849     0            0    0    0    0    -1     2    -1    -1
+rho(770)         rho(770)         0.7690       0.1509      0            2    0    0    0    +1     2    -1    -1
+rho(770)+        rho(770)-        0.7665       0.1502      0            2    0    0    0    +1     2    -1     0
+sigma            sigma            0.475        0.55        0            0    0    0    0    +1     0    +1    +1
+eta              eta              0.547862     1.31e-06    0            0    0    0    0    +1     0    -1    +1
+pi               pi               0.1349766    0           0            2    0    0    0    -1     0    -1    +1
+pi+              pi-              0.13957018   0           0            2    0    0    0    -1     0    -1     0
+#
+#
+#-----------------------------------------------------------------------------------------------------------------
+# various other particles
+#
+# particle       antiparticle     mass            width       baryon #    2I    S    Ch   B     G    2J     P     C
+# name           name             [GeV/c^2]       [GeV/c^2]
+#-----------------------------------------------------------------------------------------------------------------
+#
+gamma            gamma            0               0           0            0    0    0    0     0     2    -1    -1
+e-               e+               0.0005109989461 0           0            0    0    0    0     0     1    +1     0
+mu-              mu+              0.1056583745    0           0            0    0    0    0     0     1    +1     0


### PR DESCRIPTION
Update the particle data table to the values from the 2016 edition of
the PDG.