### PR TITLE
Remove warning when using more amplitude files for calculating the integrals

### DIFF
--- a/pyInterface/bindings/decayAmplitude/ampIntegralMatrixMetadata_py.cc
+++ b/pyInterface/bindings/decayAmplitude/ampIntegralMatrixMetadata_py.cc
@@ -116,5 +116,6 @@ void rpwa::py::exportAmpIntegralMatrixMetadata() {
 		.def("setBinningMap", &::ampIntegralMatrixMetadata_setBinningMap)
 
 		.def("addKeyFileContent" , &rpwa::ampIntegralMatrixMetadata::addKeyFileContent)
+		.def("hasKeyFileContent" , &rpwa::ampIntegralMatrixMetadata::hasKeyFileContent)
 		.def_readonly("integralObjectName", &rpwa::ampIntegralMatrixMetadata::objectNameInFile);
 }

--- a/pyInterface/module/_integrals.py
+++ b/pyInterface/module/_integrals.py
@@ -38,7 +38,7 @@ def calcIntegrals(integralFileName, eventAndAmpFileDict, multiBin, weightFileNam
 				if not integralMetaData.hasKeyFileContent(ampMeta.keyfileContent()):
 					pyRootPwa.utils.printErr("keyfile content of additional eventFiledID missing in first eventFieldID.")
 					return False
-					
+
 			if not integralMetaData.addAmplitudeHash(ampMeta.contentHash()):
 				# This error is not fatal, since in special cases the same hash can appear twice:
 				# e.g. in freed-isobar analyses with spin zero, the angular dependences are constant

--- a/pyInterface/module/_integrals.py
+++ b/pyInterface/module/_integrals.py
@@ -30,7 +30,15 @@ def calcIntegrals(integralFileName, eventAndAmpFileDict, multiBin, weightFileNam
 				pyRootPwa.utils.printErr("could not read metadata from amplitude file '" + ampFileName + "'. Aborting...")
 				return False
 			ampMetas.append(ampMeta)
-			integralMetaData.addKeyFileContent(ampMeta.keyfileContent())
+
+			if len(integrals) == 1: # first eventFieldID of the current bin
+				if not integralMetaData.addKeyFileContent(ampMeta.keyfileContent()):
+					return False
+			else:
+				if not integralMetaData.hasKeyFileContent(ampMeta.keyfileContent()):
+					pyRootPwa.utils.printErr("keyfile content of additional eventFiledID missing in first eventFieldID.")
+					return False
+					
 			if not integralMetaData.addAmplitudeHash(ampMeta.contentHash()):
 				# This error is not fatal, since in special cases the same hash can appear twice:
 				# e.g. in freed-isobar analyses with spin zero, the angular dependences are constant


### PR DESCRIPTION
When using more amplitude files for calculating the integrals, the
keyfile content was added n-files times, which created a warning. 
Now, the keyfile content is added only once and checked for any further
amplitude file.