### PR TITLE
pyInterface: Implement Python converter for multibinBoundariesType

### DIFF
--- a/pyInterface/bindings/decayAmplitude/ampIntegralMatrix_py.cc
+++ b/pyInterface/bindings/decayAmplitude/ampIntegralMatrix_py.cc
@@ -56,15 +56,7 @@ namespace {
 			PyErr_SetString(PyExc_TypeError, "Got invalid input for amplitudeMetadata when executing rpwa::ampIntegralMatrix::integrate()");
 			bp::throw_error_already_set();
 		}
-		rpwa::multibinBoundariesType otfBin;
-		if(bp::len(pyOtfBin.keys()) > 0) {
-			bp::list keys = pyOtfBin.keys();
-			for(unsigned int i = 0; i < len(keys); ++i) {
-				otfBin[bp::extract<std::string>(keys[i])] =
-					rpwa::boundaryType(bp::extract<double>(pyOtfBin[pyOtfBin.keys()[i]][0]),
-					                   bp::extract<double>(pyOtfBin[pyOtfBin.keys()[i]][1]));
-			}
-		}
+		const rpwa::multibinBoundariesType otfBin = rpwa::py::convertMultibinBoundariesFromPy(pyOtfBin);
 		return self.integrate(amplitudeMeta, maxNmbEvents, weightFileName, eventMeta, otfBin);
 	}
 

--- a/pyInterface/bindings/highLevelInterface/pwaFit_py.cc
+++ b/pyInterface/bindings/highLevelInterface/pwaFit_py.cc
@@ -18,14 +18,7 @@ namespace {
 	                                 const bool saveSpace = false,
 	                                 const bool verbose = false)
 	{
-		rpwa::multibinBoundariesType multibinBoundaries;
-		const bp::list keys = pyMultibinBoundaries.keys();
-		for (int i = 0; i < bp::len(keys); ++i) {
-			const std::string binningVar = bp::extract<std::string>(keys[i]);
-			const double lowerBound = bp::extract<double>(pyMultibinBoundaries[binningVar][0]);
-			const double upperBound = bp::extract<double>(pyMultibinBoundaries[binningVar][1]);
-			multibinBoundaries[binningVar] = rpwa::boundaryType(lowerBound, upperBound);
-		}
+		const rpwa::multibinBoundariesType multibinBoundaries = rpwa::py::convertMultibinBoundariesFromPy(pyMultibinBoundaries);
 		return rpwa::hli::pwaFit(L, multibinBoundaries, seed, startValFileName, checkHessian, saveSpace, verbose);
 	}
 

--- a/pyInterface/bindings/highLevelInterface/pwaNloptFit_py.cc
+++ b/pyInterface/bindings/highLevelInterface/pwaNloptFit_py.cc
@@ -18,14 +18,7 @@ namespace{
 	                                           const bool saveSpace = false,
 	                                           const bool verbose = false)
 	{
-		rpwa::multibinBoundariesType multibinBoundaries;
-		const bp::list keys = pyMultibinBoundaries.keys();
-		for (int i = 0; i < bp::len(keys); ++i) {
-			const std::string binningVar = bp::extract<std::string>(keys[i]);
-			const double lowerBound = bp::extract<double>(pyMultibinBoundaries[binningVar][0]);
-			const double upperBound = bp::extract<double>(pyMultibinBoundaries[binningVar][1]);
-			multibinBoundaries[binningVar] = rpwa::boundaryType(lowerBound, upperBound);
-		}
+		const rpwa::multibinBoundariesType multibinBoundaries = rpwa::py::convertMultibinBoundariesFromPy(pyMultibinBoundaries);
 		return rpwa::hli::pwaNloptFit(L, multibinBoundaries, seed, startValFileName, checkHessian, saveSpace, verbose);
 	}
 

--- a/pyInterface/bindings/partialWaveFit/fitResult_py.cc
+++ b/pyInterface/bindings/partialWaveFit/fitResult_py.cc
@@ -60,14 +60,7 @@ namespace {
 			PyErr_SetString(PyExc_TypeError, "Got invalid input for phaseSpaceIntegral when executing rpwa::fitResult::fill()");
 			bp::throw_error_already_set();
 		}
-		rpwa::multibinBoundariesType multibinBoundaries;
-		const bp::list keys = pyMultibinBoundaries.keys();
-		for (int i = 0; i < bp::len(keys); ++i) {
-			const std::string binningVar = bp::extract<std::string>(keys[i]);
-			const double lowerBound = bp::extract<double>(pyMultibinBoundaries[binningVar][0]);
-			const double upperBound = bp::extract<double>(pyMultibinBoundaries[binningVar][1]);
-			multibinBoundaries[binningVar] = rpwa::boundaryType(lowerBound, upperBound);
-		}
+		const rpwa::multibinBoundariesType multibinBoundaries = rpwa::py::convertMultibinBoundariesFromPy(pyMultibinBoundaries);
 		self.fill(nmbEvents, normNmbEvents, multibinBoundaries, logLikelihood, rank, prodAmps, prodAmpNames, *fitParCovMatrix,
 		          fitParCovMatrixIndices, normIntegral, acceptedNormIntegral, phaseSpaceIntegral, converged, hasHessian);
 	}
@@ -88,14 +81,7 @@ namespace {
 	}
 
 	bp::dict fitResult_multibinBoundaries(const rpwa::fitResult& self) {
-		const rpwa::multibinBoundariesType& multibinBoundaries = self.multibinBoundaries();
-
-		bp::dict pyMultibinBoundaries;
-		for(rpwa::multibinBoundariesType::const_iterator it = multibinBoundaries.begin(); it != multibinBoundaries.end(); ++it){
-			pyMultibinBoundaries[it->first] = bp::make_tuple(it->second.first, it->second.second);
-		}
-
-		return pyMultibinBoundaries;
+		return rpwa::py::convertMultibinBoundariesToPy(self.multibinBoundaries());
 	}
 
 	bp::list fitResult_evidenceComponents(const rpwa::fitResult& self) {

--- a/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
+++ b/pyInterface/bindings/partialWaveFit/pwaLikelihood_py.cc
@@ -214,14 +214,7 @@ namespace {
 	                                 bp::dict                                    pyMultibinBoundaries,
 	                                 bp::list                                    pyEvtMetas)
 	{
-		rpwa::multibinBoundariesType multibinBoundaries;
-		const bp::list keys = pyMultibinBoundaries.keys();
-		for(unsigned int i = 0; i < bp::len(keys); i++){
-			std::string binningVar = bp::extract<std::string>(keys[i]);
-			double lowerBound      = bp::extract<double>(pyMultibinBoundaries[binningVar][0]);
-			double upperBound      = bp::extract<double>(pyMultibinBoundaries[binningVar][1]);
-			multibinBoundaries.insert(rpwa::multibinBoundariesType::value_type(binningVar, rpwa::boundaryType(lowerBound, upperBound)));
-		}
+		const rpwa::multibinBoundariesType multibinBoundaries = rpwa::py::convertMultibinBoundariesFromPy(pyMultibinBoundaries);
 		std::vector<const rpwa::eventMetadata*> evtMetas;
 		if (not rpwa::py::convertBPObjectToVector<const rpwa::eventMetadata*>(pyEvtMetas, evtMetas)){
 			PyErr_SetString(PyExc_TypeError, "could not extract event metadatas");

--- a/pyInterface/bindings/pyUtils/stlContainers_py.cc
+++ b/pyInterface/bindings/pyUtils/stlContainers_py.cc
@@ -70,3 +70,35 @@ void rpwa::py::exportStlContainers() {
 		.def(bp::vector_indexing_suite<std::vector<rpwa::pwaLikelihood<std::complex<double> >::fitParameter>, true>());
 
 }
+
+
+rpwa::multibinBoundariesType
+rpwa::py::convertMultibinBoundariesFromPy(const boost::python::dict& pyMultibinBoundaries) {
+	rpwa::multibinBoundariesType multibinBoundaries;
+	boost::python::list keys = pyMultibinBoundaries.keys();
+	for (int i = 0; i < boost::python::len(keys); ++i) {
+		rpwa::boundaryType element;
+		if (not rpwa::py::convertBPObjectToPair<double, double>(pyMultibinBoundaries[keys[i]], element)) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid pair for multibin boundaries");
+			boost::python::throw_error_already_set();
+		}
+		boost::python::extract<std::string> getString(keys[i]);
+		if (not getString.check()) {
+			PyErr_SetString(PyExc_TypeError, "Got invalid key for multibin boundaries");
+			boost::python::throw_error_already_set();
+		}
+		multibinBoundaries[getString()] = element;
+	}
+	return multibinBoundaries;
+}
+
+
+boost::python::dict
+rpwa::py::convertMultibinBoundariesToPy(const rpwa::multibinBoundariesType& multibinBoundaries) {
+	boost::python::dict pyMultibinBoundaries;
+	for (const auto& variable_boundaries : multibinBoundaries) {
+		const boost::python::str variablePy(variable_boundaries.first);
+		pyMultibinBoundaries[variablePy] = boost::python::make_tuple(variable_boundaries.second.first, variable_boundaries.second.second);
+	}
+	return pyMultibinBoundaries;
+}

--- a/pyInterface/bindings/pyUtils/stlContainers_py.h
+++ b/pyInterface/bindings/pyUtils/stlContainers_py.h
@@ -9,6 +9,7 @@
 #include <boost/python.hpp>
 
 #include "reportingUtils.hpp"
+#include "multibinTypes.h"
 
 
 namespace rpwa {
@@ -105,8 +106,9 @@ namespace rpwa {
 			return true;
 		}
 
+		rpwa::multibinBoundariesType convertMultibinBoundariesFromPy(const boost::python::dict& pyMultibinBoundaries);
+		boost::python::dict convertMultibinBoundariesToPy(const rpwa::multibinBoundariesType& multibinBoundaries);
 	}
-
 }
 
 #endif

--- a/pyInterface/bindings/storageFormats/eventFileWriter_py.cc
+++ b/pyInterface/bindings/storageFormats/eventFileWriter_py.cc
@@ -38,23 +38,7 @@ namespace {
 			PyErr_SetString(PyExc_TypeError, "Got invalid input for finalStateParticleNames when executing rpwa::eventFileWriter::initialize()");
 			bp::throw_error_already_set();
 		}
-		rpwa::multibinBoundariesType multibinBoundaries;
-		{
-			bp::list keys = pyMultibinBoundaries.keys();
-			for(int i = 0; i < bp::len(keys); ++i) {
-				rpwa::boundaryType element;
-				if(not rpwa::py::convertBPObjectToPair<double, double>(pyMultibinBoundaries[keys[i]], element)) {
-					PyErr_SetString(PyExc_TypeError, "Got invalid pair for multibin boundaries when executing rpwa::eventFileWriter::initialize()");
-					bp::throw_error_already_set();
-				}
-				bp::extract<std::string> getString(keys[i]);
-				if(not getString.check()) {
-					PyErr_SetString(PyExc_TypeError, "Got invalid key for multibin boundaries when executing rpwa::eventFileWriter::initialize()");
-					bp::throw_error_already_set();
-				}
-				multibinBoundaries[getString()] = element;
-			}
-		}
+		rpwa::multibinBoundariesType multibinBoundaries = rpwa::py::convertMultibinBoundariesFromPy(pyMultibinBoundaries);
 		std::vector<std::string> additionalVariableLabels;
 		if(not rpwa::py::convertBPObjectToVector<std::string>(pyAdditionalVariableLabels, additionalVariableLabels))
 		{

--- a/pyInterface/bindings/storageFormats/eventMetadata_py.cc
+++ b/pyInterface/bindings/storageFormats/eventMetadata_py.cc
@@ -7,6 +7,7 @@
 
 #include "eventMetadata.h"
 #include "rootConverters_py.h"
+#include "stlContainers_py.h"
 
 namespace bp = boost::python;
 
@@ -15,14 +16,7 @@ namespace {
 
 	bp::dict eventMetadata_multibinBoundaries(const rpwa::eventMetadata& self)
 	{
-		bp::dict retval;
-		rpwa::multibinBoundariesType multibinBoundaries = self.multibinBoundaries();
-		for(rpwa::multibinBoundariesType::const_iterator it = multibinBoundaries.begin(); it != multibinBoundaries.end(); ++it)
-		{
-			bp::tuple val = bp::make_tuple<double, double>(it->second.first, it->second.second);
-			retval[it->first] = val;
-		}
-		return retval;
+		return rpwa::py::convertMultibinBoundariesToPy(self.multibinBoundaries());
 	}
 
 	bp::list eventMetadata_productionKinematicsParticleNames(const rpwa::eventMetadata& self)


### PR DESCRIPTION
Implement a converter functions between Python and C++ for the
multibinBoundariesType.
Replace the multiple implementations of this conversion by the common
converter functions.