### PR TITLE
generators: Implement 'uniformMassAndT' picker and special treatment of t' = 0

### DIFF
--- a/generators/diffractivePhaseSpace.cc
+++ b/generators/diffractivePhaseSpace.cc
@@ -120,7 +120,7 @@ diffractivePhaseSpace::calculateXSystemLab(const TLorentzVector& beamLorentzVect
                                            const double          tPrime)
 {
 
-	TRandom3* random = randomNumberGenerator::instance()->getGenerator();
+	TRandom3* const random = randomNumberGenerator::instance()->getGenerator();
 
 	// calculate t from t' in center-of-mass system of collision
 	const double sqrtS        = sqrt(s);
@@ -143,7 +143,8 @@ diffractivePhaseSpace::calculateXSystemLab(const TLorentzVector& beamLorentzVect
 	const double reggeonEnergyLab = (targetMass2 - recoilMass2 + t) / (2 * targetMass);  // breakup energy
 	const double xEnergyLab       = beamEnergy + reggeonEnergyLab;
 	const double xMomLab          = sqrt(xEnergyLab * xEnergyLab - xMass2);
-	const double xCosThetaLab     = (t - xMass2 - beamMass2 + 2 * beamEnergy * xEnergyLab) / (2 * beamMomentum * xMomLab);
+	// special treatment of t' = 0 necessary to avoid numerical problems: xCosThetaLab = 1.0 + eps -> xSinThetaLab = NAN
+	const double xCosThetaLab     = (tPrime == 0.0) ? 1.0 : ((t - xMass2 - beamMass2 + 2 * beamEnergy * xEnergyLab) / (2 * beamMomentum * xMomLab));
 	const double xSinThetaLab     = sqrt(1 - xCosThetaLab * xCosThetaLab);
 	const double xPtLab           = xMomLab * xSinThetaLab;
 	const double xPhiLab          = random->Uniform(0., TMath::TwoPi());

--- a/generators/generatorManager.cc
+++ b/generators/generatorManager.cc
@@ -273,6 +273,8 @@ bool generatorManager::readReactionFile(const string& fileName) {
 			_pickerFunction = massAndTPrimePickerPtr(new uniformMassExponentialTPicker());
 		} else if(functionName == "polynomialMassAndTPrime") {
 			_pickerFunction = massAndTPrimePickerPtr(new polynomialMassAndTPrimeSlopePicker());
+		} else if(functionName == "uniformMassAndT") {
+			_pickerFunction = massAndTPrimePickerPtr(new uniformMassAndTPicker());
 		} else {
 			printErr << "'function' name '" << functionName << "' unknown." << endl;
 			return false;

--- a/generators/generatorPickerFunctions.cc
+++ b/generators/generatorPickerFunctions.cc
@@ -471,3 +471,61 @@ ostream& polynomialMassAndTPrimeSlopePicker::print(ostream& out) const {
 	out << "    t' slopes polynomial ... " << _tPrimeSlopePolynomial.GetExpFormula() <<endl;
 	return out;
 }
+
+
+bool
+rpwa::uniformMassAndTPicker::init(const libconfig::Setting& setting)
+{
+	map<string, libconfig::Setting::Type> mandatoryArguments;
+	insert(mandatoryArguments)
+	      ("tPrimeMin", libconfig::Setting::TypeFloat)
+	      ("tPrimeMax", libconfig::Setting::TypeFloat);
+	if (not checkIfAllVariablesAreThere(&setting, mandatoryArguments)) {
+		printErr << "found invalid settings for the t' range for 'uniformMassAndTPicker'." << endl;
+		return false;
+	}
+	if(not massAndTPrimePicker::initTPrimeAndMassRanges(setting)) {
+		printErr<< "could not initialize t' or mass range settings in 'uniformMassAndTPicker'." << endl;
+		return false;
+	}
+	_initialized = true;
+	return true;
+}
+
+
+bool
+rpwa::uniformMassAndTPicker::operator()(double& invariantMass, double& tPrime)
+{
+	if (not _initialized) {
+		printErr<< "trying to use an uninitialized massAndTPrimePicker." << endl;
+		return false;
+	}
+	TRandom3* randomNumbers = randomNumberGenerator::instance()->getGenerator();
+	invariantMass = randomNumbers->Uniform(_massRange.first, _massRange.second);
+	if (not pickTPrimeForMass(invariantMass, tPrime)) {
+		printErr << "error while generating t'." << std::endl;
+		return false;
+	}
+	return true;
+}
+
+
+bool
+rpwa::uniformMassAndTPicker::pickTPrimeForMass(const double /*invariantMass*/, double& tPrime)
+{
+	TRandom3* randomNumbers = randomNumberGenerator::instance()->getGenerator();
+	tPrime = randomNumbers->Uniform(_tPrimeRange.first, _tPrimeRange.second);
+	return true;
+}
+
+
+std::ostream&
+rpwa::uniformMassAndTPicker::print(std::ostream& out) const
+{
+	out << "'uniformMassAndT' weighter parameters:" << endl;
+	out << "    minimum Mass ... " << _massRange.first << endl;
+	out << "    maximum Mass ... " << _massRange.second << endl;
+	out << "    minimum t' ..... " << _tPrimeRange.first << endl;
+	out << "    maximum t' ..... " << _tPrimeRange.second << endl;
+	return out;
+}

--- a/generators/generatorPickerFunctions.h
+++ b/generators/generatorPickerFunctions.h
@@ -87,6 +87,7 @@ namespace rpwa {
 
 	};
 
+
 	// Class to pick a m and t' slope. First the mass is picked from a polynomial,
 	// then the t' slope is determined in dependence of the mass (also a polynomial).
 	class polynomialMassAndTPrimeSlopePicker : public massAndTPrimePicker {
@@ -109,6 +110,25 @@ namespace rpwa {
 		TF1 _massPolynomial;
 		TF1 _tPrimeSlopePolynomial;
 
+	};
+
+
+	/**
+	 * Class to pick a m and t' uniformly in a given range
+	 */
+	class uniformMassAndTPicker : public massAndTPrimePicker {
+
+	  public:
+
+		uniformMassAndTPicker() { };
+		virtual ~uniformMassAndTPicker() { };
+
+		virtual bool init(const libconfig::Setting& setting);
+
+		virtual bool operator() (double& invariantMass, double& tPrime);
+		virtual bool pickTPrimeForMass(const double invariantMass, double& tPrime);
+
+		virtual std::ostream& print(std::ostream& out) const;
 	};
 
 }


### PR DESCRIPTION
Implement a picker that picks the mass and t' uniformly in the given
range. This allows, e.g. to generate events with a fixed mass and t'.